### PR TITLE
WIP Dynamic Formのリファクタリング

### DIFF
--- a/lib/bright/skill_panels/skill_panel.ex
+++ b/lib/bright/skill_panels/skill_panel.ex
@@ -24,11 +24,7 @@ defmodule Bright.SkillPanels.SkillPanel do
   def changeset(skill_panel, attrs) do
     skill_panel
     |> cast(attrs, [:locked_date, :name])
-    |> cast_assoc(:skill_classes,
-      with: &SkillClass.changeset/2,
-      sort_param: :skill_classes_sort,
-      drop_param: :skill_classes_drop
-    )
+    |> cast_assoc(:skill_classes)
     |> validate_required([:name])
   end
 end

--- a/test/bright_web/live/admin/skill_panel_live_test.exs
+++ b/test/bright_web/live/admin/skill_panel_live_test.exs
@@ -4,7 +4,7 @@ defmodule BrightWeb.Admin.SkillPanelLiveTest do
   import Phoenix.LiveViewTest
   import Bright.Factory
 
-  @create_attrs params_for(:skill_panel)
+  @create_attrs params_for(:skill_panel) |> Map.put(:skill_classes, %{"0" => %{name: "Class 1"}})
   @update_attrs params_for(:locked_skill_panel)
   @invalid_attrs %{name: nil, locked_date: nil}
 
@@ -34,6 +34,8 @@ defmodule BrightWeb.Admin.SkillPanelLiveTest do
       assert index_live
              |> form("#skill_panel-form", skill_panel: @invalid_attrs)
              |> render_change() =~ "can&#39;t be blank"
+
+      index_live |> element("label", "add skill class") |> render_click()
 
       assert index_live
              |> form("#skill_panel-form", skill_panel: @create_attrs)


### PR DESCRIPTION
**※少し保留して、他を進めます**

現行の実装だとLiveViewTestでDynamic Formのテストができないため、 https://fullstackphoenix.com/tutorials/nested-model-forms-with-phoenix-liveview を参考に実装を変更（チェックボックスを使わなくてもいい方法を模索したい...）

- 追加は問題なくできた
- 削除は...
  - 追加した項目の削除は問題ない
  - 既存の項目を削除しようとすると、1つ目は成功するが、2つ目で以下のエラーが出る
    ```
    ** (RuntimeError) cannot replace related %Bright.SkillPanels.SkillClass{__meta__: #Ecto.Schema.Metadata<:loaded, "skill_classes">, id: "01H40DTKZDX6GKH1C6ZMV4WWKE", name: "クラス1：零細Webアプリ開発がこなせる", skill_panel_id: "01H40DTKZA2AN5XW907PFQYD8A", skill_panel: #Ecto.Association.NotLoaded<association :skill_panel is not loaded>, skill_class_units: #Ecto.Association.NotLoaded<association :skill_class_units is not loaded>, skill_units: #Ecto.Association.NotLoaded<association :skill_units is not loaded>, inserted_at: ~N[2023-06-28 07:17:31], updated_at: ~N[2023-06-29 06:23:03]}.
    This typically happens when you are calling put_assoc/put_embed with the results of a previous put_assoc/put_embed/cast_assoc/cast_embed operation, which is not supported. You must call such operations only once per embed/assoc, in order for Ecto to track changes efficiently
    ```

    https://github.com/bright-org/bright/assets/1233315/b480cd0c-ec2d-4c88-a334-a18b8c53f918



