### PR TITLE
マイページからチームへ仮リンク

### DIFF
--- a/lib/bright_web/live/mypage_live/index.html.heex
+++ b/lib/bright_web/live/mypage_live/index.html.heex
@@ -573,10 +573,10 @@
             <ul class="flex gap-y-1.5 flex-col">
               <a href="/teams">
                 <li class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded">
-                    <span class="text-base !text-white bg-lapislazuli-900 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center">
-                      E
-                    </span>
-                    Elixir Fukuoka
+                  <span class="text-base !text-white bg-lapislazuli-900 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center">
+                    E
+                  </span>
+                  Elixir Fukuoka
                 </li>
               </a>
               <li class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded">


### PR DESCRIPTION
赤い枠の部分にリンクはりました

![image](https://github.com/bright-org/bright/assets/13599847/a9908769-02e1-4962-b362-6b89f2536d17)

![image](https://github.com/bright-org/bright/assets/13599847/2325c6e1-b962-4f37-a22c-156ebcddcdcf)


