### PR TITLE
ホーム画面でフラッシュメッセージが出なくなってたので修正

### DIFF
--- a/lib/bright_web/controllers/page_html/home.html.heex
+++ b/lib/bright_web/controllers/page_html/home.html.heex
@@ -1,3 +1,4 @@
+<.flash_group flash={@flash} />
 <h1>テストページ</h1>
 <br />
 <hr />


### PR DESCRIPTION
こちらのPRの影響でホーム画面遷移したらフラッシュメッセージ出なくなってたので調整した。

- https://github.com/bright-org/bright/pull/194
- https://github.com/bright-org/bright/pull/194/files#diff-ec8dade464a5c734d6bee002943dba481e5525b119d07e1b7803d826ca8542f1L1

正式にはホーム画面は別ドメインのLPページなのでフラッシュメッセージは出ないのが正しくはあるのだが、デモの際に見栄えが悪いので修正する。
（ホーム画面に遷移しないようにする or フラッシュメッセージをなくすは別でやる想定です。大体ログイン周りだと思うので私が把握しておきます）