### PR TITLE
オンボーディングの仮リンクを削除

### DIFF
--- a/lib/bright_web/components/layouts/root.html.heex
+++ b/lib/bright_web/components/layouts/root.html.heex
@@ -34,11 +34,6 @@
           <li>
             <a class="!text-white text-base" href="/mypage">チームスキル分析</a>
           </li>
-          <!-- ↓TODO: テスト用の為　不要になった時は削除すること　-->
-          <li>
-            <a class="!text-white text-base" href="/onboardings">オンボーディング</a>
-          </li>
-          <!-- ↑TODO: テスト用の為　不要になった時は削除すること　-->
         </ul>
       </aside>
       <main class="bg-background flex flex-col flex-1">


### PR DESCRIPTION
確認メールにアクセスしたら確認済みになりログインできるようにする #218
の対応関連修正

メニューのオンボーディングの仮リンクを削除しました

１枚目：修正前
![1](https://github.com/bright-org/bright/assets/13599847/e4eb3da1-fa88-4c65-adaf-91eb4fd2f221)

２枚目：修正後
![2](https://github.com/bright-org/bright/assets/13599847/7cffccb0-07b6-472b-9597-b1c3be272019)
