### PR TITLE
管理機能：スキル周りのUI改善

### DIFF
--- a/lib/bright_web/live/admin/skill_panel_live/show.html.heex
+++ b/lib/bright_web/live/admin/skill_panel_live/show.html.heex
@@ -16,7 +16,7 @@
       <%= for skill_class <- @skill_panel.skill_classes do %>
         <li>
           <%= skill_class.name %>
-          <ul>
+          <ul class="pl-4 list-disc">
             <%= for skill_unit <- skill_class.skill_units do %>
               <li>
                 <.link navigate={~p"/admin/skill_units/#{skill_unit}"}>

--- a/lib/bright_web/live/admin/skill_unit_live/index.ex
+++ b/lib/bright_web/live/admin/skill_unit_live/index.ex
@@ -6,7 +6,11 @@ defmodule BrightWeb.Admin.SkillUnitLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, stream(socket, :skill_units, SkillUnits.list_skill_units())}
+    skill_units =
+      SkillUnits.list_skill_units()
+      |> Bright.Repo.preload(skill_classes: :skill_panel)
+
+    {:ok, stream(socket, :skill_units, skill_units)}
   end
 
   @impl true

--- a/lib/bright_web/live/admin/skill_unit_live/index.html.heex
+++ b/lib/bright_web/live/admin/skill_unit_live/index.html.heex
@@ -13,6 +13,13 @@
   row_click={fn {_id, skill_unit} -> JS.navigate(~p"/admin/skill_units/#{skill_unit}") end}
 >
   <:col :let={{_id, skill_unit}} label="Name"><%= skill_unit.name %></:col>
+  <:col :let={{_id, %{skill_classes: skill_classes}}} label="Skill classes">
+    <ul>
+      <%= for skill_class <- skill_classes do %>
+        <li><%= "#{skill_class.skill_panel.name} > #{skill_class.name}" %></li>
+      <% end %>
+    </ul>
+  </:col>
   <:action :let={{_id, skill_unit}}>
     <div class="sr-only">
       <.link navigate={~p"/admin/skill_units/#{skill_unit}"}>Show</.link>

--- a/lib/bright_web/live/admin/skill_unit_live/show.ex
+++ b/lib/bright_web/live/admin/skill_unit_live/show.ex
@@ -12,7 +12,7 @@ defmodule BrightWeb.Admin.SkillUnitLive.Show do
   def handle_params(%{"id" => id}, _, socket) do
     skill_unit =
       SkillUnits.get_skill_unit!(id)
-      |> Bright.Repo.preload([:skill_categories, skill_classes: :skill_panel])
+      |> Bright.Repo.preload(skill_categories: :skills, skill_classes: :skill_panel)
 
     {:noreply,
      socket

--- a/lib/bright_web/live/admin/skill_unit_live/show.html.heex
+++ b/lib/bright_web/live/admin/skill_unit_live/show.html.heex
@@ -13,7 +13,14 @@
   <:item title="Skill categories">
     <ul>
       <%= for skill_category <- @skill_unit.skill_categories do %>
-        <li><%= skill_category.name %></li>
+        <li>
+          <%= skill_category.name %>
+          <ul class="pl-4 list-disc">
+            <%= for skill <- skill_category.skills do %>
+              <li><%= skill.name %></li>
+            <% end %>
+          </ul>
+        </li>
       <% end %>
     </ul>
   </:item>


### PR DESCRIPTION
### スキルパネル詳細

- スキルユニットの箇条書きを見やすいように点を追加

![image](https://github.com/bright-org/bright/assets/1233315/8a90e621-c214-4247-9aca-4ac961c3e455)

### スキルユニット一覧

- どのスキルクラスに属するかの表示を追加

![image](https://github.com/bright-org/bright/assets/1233315/233b6019-086b-491e-b154-f29439bf3f0b)


### スキルユニット詳細

- スキルの箇条書きを見やすいように点を追加

![image](https://github.com/bright-org/bright/assets/1233315/3feb6908-50d5-4333-9bc1-32ef350183ea)
