### PR TITLE
管理機能：スキルカテゴリに紐づくスキルの更新

### DIFF
--- a/lib/bright/skill_units.ex
+++ b/lib/bright/skill_units.ex
@@ -7,6 +7,7 @@ defmodule Bright.SkillUnits do
   alias Bright.Repo
 
   alias Bright.SkillUnits.SkillUnit
+  alias Bright.SkillUnits.SkillCategory
 
   @doc """
   Returns the list of skill_units.
@@ -100,5 +101,52 @@ defmodule Bright.SkillUnits do
   """
   def change_skill_unit(%SkillUnit{} = skill_unit, attrs \\ %{}) do
     SkillUnit.changeset(skill_unit, attrs)
+  end
+
+  @doc """
+  Gets a single skill_category.
+
+  Raises `Ecto.NoResultsError` if the Skill unit does not exist.
+
+  ## Examples
+
+      iex> get_skill_category!(123)
+      %SkillCategory{}
+
+      iex> get_skill_category!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_skill_category!(id), do: Repo.get!(SkillCategory, id)
+
+  @doc """
+  Updates a skill_category.
+
+  ## Examples
+
+      iex> update_skill_category(skill_category, %{field: new_value})
+      {:ok, %SkillCategory{}}
+
+      iex> update_skill_category(skill_category, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_skill_category(%SkillCategory{} = skill_category, attrs) do
+    skill_category
+    |> SkillCategory.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking skill_category changes.
+
+  ## Examples
+
+      iex> change_skill_category(skill_category)
+      %Ecto.Changeset{data: %SkillCategory{}}
+
+  """
+  def change_skill_category(%SkillCategory{} = skill_category, attrs \\ %{}) do
+    SkillCategory.changeset(skill_category, attrs)
   end
 end

--- a/lib/bright/skill_units/skill_category.ex
+++ b/lib/bright/skill_units/skill_category.ex
@@ -26,7 +26,11 @@ defmodule Bright.SkillUnits.SkillCategory do
   def changeset(skill_category, attrs) do
     skill_category
     |> cast(attrs, [:name, :position])
-    |> cast_assoc(:skills)
+    |> cast_assoc(:skills,
+      with: &Skill.changeset/2,
+      sort_param: :skills_sort,
+      drop_param: :skills_drop
+    )
     |> validate_required([:name, :position])
   end
 end

--- a/lib/bright_web/live/admin/skill_category_live/form_component.ex
+++ b/lib/bright_web/live/admin/skill_category_live/form_component.ex
@@ -1,0 +1,103 @@
+defmodule BrightWeb.Admin.SkillCategoryLive.FormComponent do
+  use BrightWeb, :live_component
+
+  alias Bright.SkillUnits
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.header>
+        <%= @title %>
+        <:subtitle>Use this form to manage skill_category records in your database.</:subtitle>
+      </.header>
+
+      <.simple_form
+        for={@form}
+        id="skill_category-form"
+        phx-target={@myself}
+        phx-change="validate"
+        phx-submit="save"
+      >
+        <.input field={@form[:name]} type="text" label="Name" />
+        <.label>Skills</.label>
+        <.inputs_for :let={sf} field={@form[:skills]}>
+          <input type="hidden" name="skill_category[skills_sort][]" value={sf.index} />
+          <.input field={sf[:name]} type="text" label="Name" />
+          <.input field={sf[:position]} type="number" label="Position" />
+          <label class="cursor-pointer">
+            <input
+              type="checkbox"
+              name="skill_category[skills_drop][]"
+              value={sf.index}
+              class="hidden"
+            /> delete
+          </label>
+        </.inputs_for>
+        <label class="block cursor-pointer">
+          <input type="checkbox" name="skill_category[skills_sort][]" class="hidden" /> add skill
+        </label>
+        <:actions>
+          <.button phx-disable-with="Saving...">Save Skill category</.button>
+        </:actions>
+      </.simple_form>
+    </div>
+    """
+  end
+
+  @impl true
+  def update(%{skill_category: skill_category} = assigns, socket) do
+    changeset =
+      skill_category
+      |> preload_assoc()
+      |> SkillUnits.change_skill_category()
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign_form(changeset)}
+  end
+
+  @impl true
+  def handle_event("validate", %{"skill_category" => skill_category_params}, socket) do
+    changeset =
+      socket.assigns.skill_category
+      |> preload_assoc()
+      |> SkillUnits.change_skill_category(skill_category_params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign_form(socket, changeset)}
+  end
+
+  def handle_event("save", %{"skill_category" => skill_category_params}, socket) do
+    save_skill_category(socket, socket.assigns.action, skill_category_params)
+  end
+
+  defp save_skill_category(socket, :edit, skill_category_params) do
+    skill_category = preload_assoc(socket.assigns.skill_category)
+
+    case SkillUnits.update_skill_category(skill_category, skill_category_params) do
+      {:ok, skill_category} ->
+        notify_parent({:saved, preload_assoc(skill_category)})
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Skill category updated successfully")
+         |> push_navigate(to: "/admin/skill_units/#{skill_category.skill_unit_id}")}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign_form(socket, changeset)}
+    end
+  end
+
+  defp assign_form(socket, %Ecto.Changeset{} = changeset) do
+    assign(socket, :form, to_form(changeset))
+  end
+
+  defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
+
+  defp preload_assoc(skill_category) do
+    skill_category
+    |> Bright.Repo.preload(:skills)
+  end
+end

--- a/lib/bright_web/live/admin/skill_category_live/show.ex
+++ b/lib/bright_web/live/admin/skill_category_live/show.ex
@@ -1,0 +1,24 @@
+defmodule BrightWeb.Admin.SkillCategoryLive.Show do
+  use BrightWeb, :live_view
+
+  alias Bright.SkillUnits
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(%{"id" => id}, _, socket) do
+    skill_category =
+      SkillUnits.get_skill_category!(id)
+      |> Bright.Repo.preload(:skills)
+
+    {:noreply,
+     socket
+     |> assign(:page_title, page_title(socket.assigns.live_action))
+     |> assign(:skill_category, skill_category)}
+  end
+
+  defp page_title(:edit), do: "Edit Skill category"
+end

--- a/lib/bright_web/live/admin/skill_category_live/show.html.heex
+++ b/lib/bright_web/live/admin/skill_category_live/show.html.heex
@@ -1,0 +1,43 @@
+<.header>
+  Skill category <%= @skill_category.id %>
+  <:subtitle>This is a skill_category record from your database.</:subtitle>
+  <:actions>
+    <.link
+      patch={~p"/admin/skill_categories/#{@skill_category}/show/edit"}
+      phx-click={JS.push_focus()}
+    >
+      <.button>Edit skill_category</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.list>
+  <:item title="Name"><%= @skill_category.name %></:item>
+  <:item title="Skills">
+    <ul>
+      <%= for skill <- @skill_category.skills do %>
+        <li><%= skill.name %></li>
+      <% end %>
+    </ul>
+  </:item>
+</.list>
+
+<.back navigate={~p"/admin/skill_units/#{@skill_category.skill_unit_id}"}>
+  Back to skill_unit
+</.back>
+
+<.modal
+  :if={@live_action == :edit}
+  id="skill_category-modal"
+  show
+  on_cancel={JS.navigate(~p"/admin/skill_units/#{@skill_category.skill_unit_id}")}
+>
+  <.live_component
+    module={BrightWeb.Admin.SkillCategoryLive.FormComponent}
+    id={@skill_category.id}
+    title={@page_title}
+    action={@live_action}
+    skill_category={@skill_category}
+    navigate={~p"/admin/skill_units/#{@skill_category.skill_unit_id}"}
+  />
+</.modal>

--- a/lib/bright_web/live/admin/skill_unit_live/show.html.heex
+++ b/lib/bright_web/live/admin/skill_unit_live/show.html.heex
@@ -20,6 +20,9 @@
               <li><%= skill.name %></li>
             <% end %>
           </ul>
+          <.link navigate={~p"/admin/skill_categories/#{skill_category}/show/edit"}>
+            <.button>Edit skill_category</.button>
+          </.link>
         </li>
       <% end %>
     </ul>

--- a/lib/bright_web/router.ex
+++ b/lib/bright_web/router.ex
@@ -48,6 +48,7 @@ defmodule BrightWeb.Router do
     live "/skill_units/:id/edit", SkillUnitLive.Index, :edit
     live "/skill_units/:id", SkillUnitLive.Show, :show
     live "/skill_units/:id/show/edit", SkillUnitLive.Show, :edit
+    live "/skill_categories/:id/show/edit", SkillCategoryLive.Show, :edit
   end
 
   # Other scopes may use custom stacks.

--- a/test/bright/skill_units_test.exs
+++ b/test/bright/skill_units_test.exs
@@ -60,4 +60,39 @@ defmodule Bright.SkillUnitsTest do
       assert %Ecto.Changeset{} = SkillUnits.change_skill_unit(skill_unit)
     end
   end
+
+  describe "skill_categories" do
+    alias Bright.SkillUnits.SkillCategory
+
+    @invalid_attrs params_for(:skill_category) |> Map.put(:name, nil)
+
+    test "get_skill_category!/1 returns the skill_category with given id" do
+      skill_category = insert(:skill_category, skill_unit_id: insert(:skill_unit).id)
+      assert SkillUnits.get_skill_category!(skill_category.id) == skill_category
+    end
+
+    test "update_skill_category/2 with valid data updates the skill_category" do
+      skill_category = insert(:skill_category, skill_unit_id: insert(:skill_unit).id)
+      update_attrs = params_for(:skill_category)
+
+      assert {:ok, %SkillCategory{} = skill_category} =
+               SkillUnits.update_skill_category(skill_category, update_attrs)
+
+      assert skill_category.name == update_attrs.name
+    end
+
+    test "update_skill_category/2 with invalid data returns error changeset" do
+      skill_category = insert(:skill_category, skill_unit_id: insert(:skill_unit).id)
+
+      assert {:error, %Ecto.Changeset{}} =
+               SkillUnits.update_skill_category(skill_category, @invalid_attrs)
+
+      assert skill_category == SkillUnits.get_skill_category!(skill_category.id)
+    end
+
+    test "change_skill_category/1 returns a skill_category changeset" do
+      skill_category = insert(:skill_category, skill_unit_id: insert(:skill_unit).id)
+      assert %Ecto.Changeset{} = SkillUnits.change_skill_category(skill_category)
+    end
+  end
 end

--- a/test/factories/skill_category_factory.ex
+++ b/test/factories/skill_category_factory.ex
@@ -7,7 +7,8 @@ defmodule Bright.SkillCategoryFactory do
     quote do
       def skill_category_factory do
         %Bright.SkillUnits.SkillCategory{
-          name: Faker.Lorem.word()
+          name: Faker.Lorem.word(),
+          position: sequence(:position, & &1)
         }
       end
     end


### PR DESCRIPTION
Closes #139 

## やったこと

- スキルユニット詳細画面にて、スキルカテゴリに紐づくスキルを更新するモーダルを追加
  - 当初は `SkillUnitLive.SkillCategoryFormComponent` のようなモジュールを追加する想定だったんですが、同じ画面に複数のモーダルがあるとうまく制御できなかったので、`SkillCategoryLive.Show` と `SkillCategoryLive.FormComponent` を追加しています（スキルカテゴリ詳細画面へのルーティングはありません）

### スキルユニット詳細画面
![image](https://github.com/bright-org/bright/assets/1233315/d7032744-8463-45ea-bbef-fc1526983d83)

### スキル更新モーダル
![image](https://github.com/bright-org/bright/assets/1233315/fa90802d-14af-42a5-acf9-2de0f2f88e72)


## やってないこと

- LiveViewTestの追加
  - #19 と一緒に対応予定