### PR TITLE
CI で fake-gcs-server を動かせるように変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,18 +32,11 @@ jobs:
     name: Build & Test & FormatCheck & Credo
     runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        # working-directory: checkoutする場所かつ、stepsのデフォルト作業位置
-        # servicesのマウントで使用する場所(github.workspace)とずらすために設定している
-        # refs: https://su-kun1899.hatenablog.com/entry/2023/01/25/090000
-        working-directory: srv
-
     container:
       image: hexpm/elixir:1.14.5-erlang-26.0-debian-bullseye-20230227-slim
       env:
         MIX_ENV: test
-        GCS_BASE_URL: https://gcs:4443
+        GCS_BASE_URL: http://gcs:4443
 
     services:
       postgres:
@@ -56,23 +49,13 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
       gcs:
-        image: fsouza/fake-gcs-server:1.45.2
+        image: ghcr.io/s12m/fake-gcs-server:1.45.2
         ports:
           - 4443:4443
-        # 起動オプションを設定するために独自チェックポイントを指定
-        volumes:
-          - ${{github.workspace}}/.github/workflows/gcs:/usr/bin/gcs
-        options: --entrypoint "/usr/bin/gcs/checkpoint.sh"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          path: srv
-
-      - name: Copy fake gcs checkpoint
-        run: |
-          cp -r .github/workflows/gcs ${{github.workspace}}/.github/workflows/gcs
 
       - name: Cache deps and _build
         uses: actions/cache@v3

--- a/.github/workflows/gcs/checkpoint.sh
+++ b/.github/workflows/gcs/checkpoint.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-/bin/fake-gcs-server -scheme http -public-host localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,10 +38,9 @@ services:
       - LIVEBOOK_TOKEN_ENABLED=false
       - LIVEBOOK_HOME=/data
   gcs:
-    image: fsouza/fake-gcs-server:1.45.2
+    image: ghcr.io/s12m/fake-gcs-server:1.45.2
     ports:
       - 4443:4443
-    command: -scheme http -public-host localhost
     volumes:
       - gcsdata:/storage/bright_storage_local
 volumes:


### PR DESCRIPTION
#169 から派生

本家の fake-gcs-server の代わりに https://github.com/s12m/docker-fake-gcs-server を使うように変更