### PR TITLE
storybookでMaterialIconsを読み込む

### DIFF
--- a/assets/js/storybook.js
+++ b/assets/js/storybook.js
@@ -10,6 +10,16 @@ import  * as hooks from "./hooks"
   window.storybook = hooks
 })()
 
+document.addEventListener("DOMContentLoaded", () => {
+  // storybookでMaterialIconsを読み込む
+  // linkを記述する場所がないためjsで追加する
+  const head = document.head
+  const link = document.createElement("link")
+  link.href = "https://fonts.googleapis.com/css?family=Material+Icons%7CMaterial+Icons+Outlined%7CMaterial+Icons+Round%7CMaterial+Icons+Sharp%7CMaterial+Icons+Two+Tone"
+  link.rel="stylesheet"
+  head.appendChild(link)
+})
+
 
 // If your components require alpinejs, you'll need to start
 // alpine after the DOM is loaded and pass in an onBeforeElUpdated


### PR DESCRIPTION
タイトル通りです
諸事上: storybookでlinkタグを記述する場所がありませんでした
対策: jsでlinkタグを記述する

![image](https://github.com/bright-org/bright/assets/13599847/9bae45c1-4cde-4a62-a3f1-51df403c7b33)
