### PR TITLE
Delete maybe_store_return_to

### DIFF
--- a/lib/bright_web/user_auth.ex
+++ b/lib/bright_web/user_auth.ex
@@ -203,7 +203,6 @@ defmodule BrightWeb.UserAuth do
     else
       conn
       |> put_flash(:error, "You must log in to access this page.")
-      |> maybe_store_return_to()
       |> redirect(to: ~p"/users/log_in")
       |> halt()
     end
@@ -214,12 +213,6 @@ defmodule BrightWeb.UserAuth do
     |> put_session(:user_token, token)
     |> put_session(:live_socket_id, "users_sessions:#{Base.url_encode64(token)}")
   end
-
-  defp maybe_store_return_to(%{method: "GET"} = conn) do
-    put_session(conn, :user_return_to, current_path(conn))
-  end
-
-  defp maybe_store_return_to(conn), do: conn
 
   defp signed_in_path(_conn), do: ~p"/mypage"
 end

--- a/test/bright_web/user_auth_test.exs
+++ b/test/bright_web/user_auth_test.exs
@@ -236,32 +236,6 @@ defmodule BrightWeb.UserAuthTest do
                "You must log in to access this page."
     end
 
-    test "stores the path to redirect to on GET", %{conn: conn} do
-      halted_conn =
-        %{conn | path_info: ["foo"], query_string: ""}
-        |> fetch_flash()
-        |> UserAuth.require_authenticated_user([])
-
-      assert halted_conn.halted
-      assert get_session(halted_conn, :user_return_to) == "/foo"
-
-      halted_conn =
-        %{conn | path_info: ["foo"], query_string: "bar=baz"}
-        |> fetch_flash()
-        |> UserAuth.require_authenticated_user([])
-
-      assert halted_conn.halted
-      assert get_session(halted_conn, :user_return_to) == "/foo?bar=baz"
-
-      halted_conn =
-        %{conn | path_info: ["foo"], query_string: "bar", method: "POST"}
-        |> fetch_flash()
-        |> UserAuth.require_authenticated_user([])
-
-      assert halted_conn.halted
-      refute get_session(halted_conn, :user_return_to)
-    end
-
     test "does not redirect if user is authenticated", %{conn: conn, user: user} do
       conn = conn |> assign(:current_user, user) |> UserAuth.require_authenticated_user([])
       refute conn.halted


### PR DESCRIPTION
ログインしないとアクセスできないパスにアクセスした時、そのパスをセッションに保存してログイン後にリダイレクトする処理がありました。
便利機能ではありますが、本システムにおいて仕様としてないことと、ログイン後にマイページやオンボーディングに遷移しない可能性が出てきてしまうので削除しました。

return_to を使う処理も同様に不要になりそうですが、こちらについては微妙に他のロジックでも使っているので生かします。要らなくなったら消します。
https://github.com/bright-org/bright/blob/ddc3971a2682482afbf759bb71605d33e28df3b2/lib/bright_web/user_auth.ex#L30-L39