### PR TITLE
「関わっているユーザー」内のユーザー表示をパラメータ対応する

### DIFF
--- a/lib/bright_web/components/profile_components.ex
+++ b/lib/bright_web/components/profile_components.ex
@@ -100,19 +100,25 @@ defmodule BrightWeb.ProfileComponents do
   Renders a Profile small
 
   ## Examples
-      <.profile_snall/>
+      <.profile_small
+        user_name="piacere"
+        title="リードプログラマー"
+        icon_file_path="/images/sample/sample-image.png"
+      />
   """
+  attr :user_name, :string, default: ""
+  attr :title, :string, default: ""
+  attr :detail, :string, default: ""
+  attr :icon_file_path, :string, default: ""
+
   def profile_small(assigns) do
     ~H"""
     <li class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2">
       <a class="inline-flex items-center gap-x-6">
-        <img
-          class="inline-block h-10 w-10 rounded-full"
-          src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
-        />
+        <img class="inline-block h-10 w-10 rounded-full" src={@icon_file_path} />
         <div>
-          <p>nokichi</p>
-          <p class="text-brightGray-300">アプリエンジニア</p>
+          <p><%= assigns.user_name %></p>
+          <p class="text-brightGray-300"><%= assigns.title %></p>
         </div>
       </a>
     </li>

--- a/storybook/profilecomponents/profile_small.story.exs
+++ b/storybook/profilecomponents/profile_small.story.exs
@@ -6,7 +6,12 @@ defmodule Storybook.Components.Profile do
   def variations do
     [
       %Variation{
-        id: :default
+        id: :default,
+        attributes: %{
+          user_name: "piacere",
+          title: "リードプログラマー",
+          icon_file_path: "/images/sample/sample-image.png"
+        }
       }
     ]
   end


### PR DESCRIPTION
タイトル通り

見ていただきたいこと
パラメータ化できてること
（ソースレベルでよい）

![image](https://github.com/bright-org/bright/assets/13599847/add7dbd6-994e-4120-b1c9-8cab0cb4abf6)

レビュー不要箇所
・htmlの最新化はしてないため、デザインのレビューは不要