### PR TITLE
デフォルトブランチが変わったことで CI の github action の修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI for development
 
 # 起動タイミングは以下
 # 1. PR が open もしくは reopen した時、またはコミットなどにより head が更新された時
-# 2. main ブランチに push された時 (= main ブランチにマージされた時)
+# 2. main, develop ブランチに push された時 (= main, develop ブランチにマージされた時)
 on:
   pull_request:
     paths-ignore:
@@ -17,6 +17,7 @@ on:
   push:
     branches:
       - "main"
+      - "develop"
     paths-ignore:
       - "docs/**"
       - "docker_dev/**"


### PR DESCRIPTION
main ブランチにマージされた際に CI が回るようにしていたが、develop ブランチがデフォルトブランチになったことで、これも対象にしないといけなかった。
main ブランチはリリースブランチで、これはこれで CI 回るのはアリだと思うので残しました。