### PR TITLE
skill_classes.rankをclassというカラム名に変更

### DIFF
--- a/lib/bright/skill_panels/skill_class.ex
+++ b/lib/bright/skill_panels/skill_class.ex
@@ -14,7 +14,7 @@ defmodule Bright.SkillPanels.SkillClass do
 
   schema "skill_classes" do
     field :name, :string
-    field :rank, :integer
+    field :class, :integer
 
     belongs_to :skill_panel, SkillPanel
 

--- a/lib/bright/skill_panels/skill_panel.ex
+++ b/lib/bright/skill_panels/skill_panel.ex
@@ -15,7 +15,7 @@ defmodule Bright.SkillPanels.SkillPanel do
     field :locked_date, :date
     field :name, :string
 
-    has_many :skill_classes, SkillClass, preload_order: [asc: :rank], on_replace: :delete
+    has_many :skill_classes, SkillClass, preload_order: [asc: :class], on_replace: :delete
 
     timestamps()
   end
@@ -29,13 +29,13 @@ defmodule Bright.SkillPanels.SkillPanel do
       sort_param: :skill_classes_sort,
       drop_param: :skill_classes_drop
     )
-    |> change_skill_classes_rank()
+    |> change_skill_classes_class()
     |> validate_required([:name])
   end
 
-  # 紐づくスキルクラスのrankを順に設定したchangesetを返す。
+  # 紐づくスキルクラスのclassを順に設定したchangesetを返す。
   # - attrsは様々な形(atomキー, DynamicForm由来,...)があるためchangesetの状態で設定している。
-  defp change_skill_classes_rank(
+  defp change_skill_classes_class(
          %{
            changes: %{skill_classes: skill_classes}
          } = changeset
@@ -43,13 +43,13 @@ defmodule Bright.SkillPanels.SkillPanel do
     skill_classes_changeset =
       skill_classes
       |> Enum.with_index(1)
-      |> Enum.map(fn {skill_class_changeset, rank} ->
-        Map.update!(skill_class_changeset, :changes, &Map.put(&1, :rank, rank))
+      |> Enum.map(fn {skill_class_changeset, class} ->
+        Map.update!(skill_class_changeset, :changes, &Map.put(&1, :class, class))
       end)
 
     changeset
     |> Map.update!(:changes, &Map.put(&1, :skill_classes, skill_classes_changeset))
   end
 
-  defp change_skill_classes_rank(changeset), do: changeset
+  defp change_skill_classes_class(changeset), do: changeset
 end

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -25,9 +25,9 @@ defmodule BrightWeb.SkillPanelLive.Skills do
 
   defp assign_skill_class(socket, nil), do: assign_skill_class(socket, "1")
 
-  defp assign_skill_class(socket, rank) do
-    rank = String.to_integer(rank)
-    skill_class = socket.assigns.skill_panel.skill_classes |> Enum.find(&(&1.rank == rank))
+  defp assign_skill_class(socket, class) do
+    class = String.to_integer(class)
+    skill_class = socket.assigns.skill_panel.skill_classes |> Enum.find(&(&1.class == class))
 
     socket
     |> assign(:skill_class, skill_class)

--- a/priv/repo/migrations/20230709231152_rename_skill_classes_rank.exs
+++ b/priv/repo/migrations/20230709231152_rename_skill_classes_rank.exs
@@ -1,0 +1,10 @@
+defmodule Bright.Repo.Migrations.RenameSkillClassesRank do
+  use Ecto.Migration
+
+  def change do
+    rename table("skill_classes"), :rank, to: :class
+
+    rename index(:skill_classes, [:skill_panel_id, :rank]),
+      to: "skill_classes_skill_panel_id_class_index"
+  end
+end

--- a/test/bright/skill_panels_test.exs
+++ b/test/bright/skill_panels_test.exs
@@ -31,8 +31,8 @@ defmodule Bright.SkillPanelsTest do
       valid_attrs =
         params_for(:locked_skill_panel)
         |> Map.put(:skill_classes, [
-          params_for(:skill_class, rank: nil),
-          params_for(:skill_class, rank: nil)
+          params_for(:skill_class, class: nil),
+          params_for(:skill_class, class: nil)
         ])
 
       {:ok, %SkillPanel{} = skill_panel} = SkillPanels.create_skill_panel(valid_attrs)
@@ -41,9 +41,9 @@ defmodule Bright.SkillPanelsTest do
       [valid_attrs_1, valid_attrs_2] = valid_attrs.skill_classes
 
       assert skill_class_1.name == valid_attrs_1.name
-      assert skill_class_1.rank == 1
+      assert skill_class_1.class == 1
       assert skill_class_2.name == valid_attrs_2.name
-      assert skill_class_2.rank == 2
+      assert skill_class_2.class == 2
     end
 
     test "create_skill_panel/1 with invalid data returns error changeset" do

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -28,7 +28,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
 
     setup do
       skill_panel = insert(:skill_panel)
-      skill_class = insert(:skill_class, skill_panel: skill_panel, rank: 1)
+      skill_class = insert(:skill_class, skill_panel: skill_panel, class: 1)
 
       %{skill_panel: skill_panel, skill_class: skill_class}
     end
@@ -94,7 +94,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       conn: conn,
       skill_panel: skill_panel
     } do
-      skill_class_2 = insert(:skill_class, skill_panel: skill_panel, rank: 2)
+      skill_class_2 = insert(:skill_class, skill_panel: skill_panel, class: 2)
       {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=2")
 
       assert show_live

--- a/test/factories/skill_class_factory.ex
+++ b/test/factories/skill_class_factory.ex
@@ -8,7 +8,7 @@ defmodule Bright.SkillClassFactory do
       def skill_class_factory do
         %Bright.SkillPanels.SkillClass{
           name: Faker.Lorem.word(),
-          rank: sequence(:rank, & &1, start_at: 1)
+          class: sequence(:class, & &1, start_at: 1)
         }
       end
     end


### PR DESCRIPTION
## 対応内容

skill_classesテーブルについて、rankカラムがスキルクラスのクラス(class)そのものを表すカラムで、また「ランク」という呼称自体も現在使用されておらず、紛らわしいため、リネームしています。

Slack上でのやりとり：
https://digi-dock.slack.com/archives/C0550EENU86/p1688890144041269?thread_ts=1688565237.872609&cid=C0550EENU86

#223 の修正