### PR TITLE
「重量な連絡」をデータマッピング対応する

### DIFF
--- a/lib/bright_web/components/contact_card_components.ex
+++ b/lib/bright_web/components/contact_card_components.ex
@@ -12,7 +12,9 @@ defmodule BrightWeb.ContactCardComponents do
       <.contact_card />
   """
   attr :datas, :list, default: []
+
   def contact_card(assigns) do
+    # ダミーデータ
     assigns =
       assigns
       |> assign(:datas, dummy())
@@ -21,38 +23,62 @@ defmodule BrightWeb.ContactCardComponents do
     <div>
       <h5>重量な連絡</h5>
       <.tab tabs={["チーム招待", "デイリー", "ウイークリー", "採用の調整", "スキルパネル更新", "運営"]}>
-        <.contact_card_body datas={@datas}/>
+        <.contact_card_body datas={@datas} />
       </.tab>
     </div>
     """
   end
 
   attr :datas, :list, default: []
-  def contact_card_body(assigns) do
 
+  def contact_card_body(assigns) do
     ~H"""
     <ul class="flex gap-y-2.5 flex-col">
       <%= for data <- assigns.datas do %>
-        <.contact_card_row data={data}/>
+        <.contact_card_row data={data} />
       <% end %>
     </ul>
     """
   end
 
   attr :data, :map, required: true
+
   def contact_card_row(assigns) do
+    style = highlight(assigns.data.highlight) <> " font-bold pl-4 inline-block"
+
+    assigns =
+      assigns
+      |> assign(:style, style)
+
     ~H"""
     <li class="text-left flex items-center text-base">
       <span class="material-icons !text-lg text-white bg-brightGreen-300 rounded-full !flex w-6 h-6 mr-2.5 !items-center !justify-center">
         <%= assigns.data.icon_type %>
       </span>
       <%= assigns.data.message %>
-      <span class="text-brightGreen-300 font-bold pl-4 inline-block">1時間前</span>
+      <span class={@style}><%= "#{assigns.data.time}時間前" %></span>
     </li>
     """
   end
 
+  defp highlight(true), do: "text-brightGreen-300"
+  defp highlight(false), do: "text-brightGray-300"
+
+  # ダミーデータ
   defp dummy do
-    [%{icon_type: "person", message: "nakoさんからの紹介 / mikaさん / Web開発（Elixir）"}]
+    [
+      %{
+        icon_type: "person",
+        message: "nakoさんからの紹介 / mikaさん / Web開発（Elixir）",
+        time: 1,
+        highlight: true
+      },
+      %{
+        icon_type: "person",
+        message: "testさんからの紹介 / hogeさん / Web開発（Elixir）",
+        time: 8,
+        highlight: false
+      }
+    ]
   end
 end


### PR DESCRIPTION
タイトルの通り

このプルリクで実施すること
・データマッピング
・仮のダミーデータ

このプルリクで実施しないこと
・マイページ上でのデータマッピング
　└DBや、他のコンポーネントに合わせてタイミングみて実装予定

![image](https://github.com/bright-org/bright/assets/13599847/b8f19c5e-7328-4c0b-91b4-5fc96979f069)
