### PR TITLE
スキルパネル スキルスコアエリアのスコアに応じた表示対応

### DIFF
--- a/lib/bright/skill_scores.ex
+++ b/lib/bright/skill_scores.ex
@@ -113,8 +113,9 @@ defmodule Bright.SkillScores do
       [%SkillScoreItem{}, ...]
 
   """
-  def list_skill_score_items do
-    Repo.all(SkillScoreItem)
+  def list_skill_score_items(query \\ SkillScoreItem) do
+    query
+    |> Repo.all()
   end
 
   @doc """

--- a/lib/bright/skill_scores/skill_score.ex
+++ b/lib/bright/skill_scores/skill_score.ex
@@ -19,6 +19,8 @@ defmodule Bright.SkillScores.SkillScore do
     belongs_to(:user, Bright.Accounts.User)
     belongs_to(:skill_class, Bright.SkillPanels.SkillClass)
 
+    has_many(:skill_score_items, Bright.SkillScores.SkillScoreItem)
+
     timestamps()
   end
 

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -45,14 +45,12 @@
         <td>
           <div class="flex justify-center gap-x-2">
             <div class="min-w-[4em] flex items-center">
-              <span class="h-4 w-4 rounded-full bg-brightGreen-600 inline-block mr-1">
-                68％
-              </span>
+              <span class="h-4 w-4 rounded-full bg-brightGreen-600 inline-block mr-1" />
+              68％
             </div>
             <div class="min-w-[4em] flex items-center">
-              <span class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGreen-300 inline-block mr-1">
-                12％
-              </span>
+              <span class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGreen-300 inline-block mr-1" />
+              12％
             </div>
           </div>
         </td>
@@ -71,64 +69,26 @@
               <!-- 未実装：デザインまま START -->
               <div class="flex justify-between items-center gap-x-2">
                 <button>
-                  <img src="images/common/icons/addFile.svg" />
+                  <img src="/images/common/icons/addFile.svg" />
                 </button>
                 <button>
-                  <img src="images/common/icons/addFile.svg" />
+                  <img src="/images/common/icons/addFile.svg" />
                 </button>
                 <button>
-                  <img src="images/common/icons/addFile.svg" />
+                  <img src="/images/common/icons/addFile.svg" />
                 </button>
               </div>
               <!-- 未実装：デザインまま END -->
             </div>
           </td>
-          <!-- 未実装：デザインまま START -->
           <td>
-            <div class="flex gap-x-4 px-4">
+            <div class="flex justify-center gap-x-4 px-4">
               <div class="flex items-center">
-                <input
-                  id="radio-1"
-                  type="radio"
-                  value=""
-                  name="elixir-radio-1"
-                  class="w-2 h-2 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
-                />
-                <label
-                  for="radio-1"
-                  class="h-4 w-4 rounded-full bg-brightGreen-600 inline-block ml-1"
-                >
+                <label class={["inline_block", score_mark_class(@skill_score_items_dict[col3.skill.id])]}>
                 </label>
-              </div>
-              <div class="flex items-center">
-                <input
-                  checked
-                  id="radio-2"
-                  type="radio"
-                  value=""
-                  name="elixir-radio-1"
-                  class="w-2 h-2 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
-                />
-                <label
-                  for="radio-2"
-                  class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGreen-300 inline-block ml-1"
-                >
-                </label>
-              </div>
-              <div class="flex items-center">
-                <input
-                  checked
-                  id="radio-3"
-                  type="radio"
-                  value=""
-                  name="elixir-radio-1"
-                  class="w-2 h-2 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
-                />
-                <label for="radio-2" class="h-1 w-4 bg-brightGray-200 ml-1"></label>
               </div>
             </div>
           </td>
-          <!-- 未実装：デザインまま END -->
         </tr>
       <% end %>
     </table>


### PR DESCRIPTION
## 対応内容

#67 の一部です。
スキルパネルのスキルスコアエリアについて、
現在のスコア(skill_score_items.socre)に基づいて表示する対応を追加しました。

![image](https://github.com/bright-org/bright/assets/121112529/8a440700-026d-40a9-b553-449d0b97598e)
上記画像は全部横棒（未入力）になっています。まだ入力機能はありません。

- 本PRでは表示までです。
- スコアの入力は別PRで扱います。
