### PR TITLE
「保有スキル」カードのデータマッピング

### DIFF
--- a/lib/bright_web/components/skill_card_components.ex
+++ b/lib/bright_web/components/skill_card_components.ex
@@ -40,6 +40,12 @@ defmodule BrightWeb.SkillCardComponents do
           %{name: "Elixir", levels: [:skilled, :normal, :none]},
           %{name: "Python", levels: [:skilled, :none, :none]}
         ]
+      },
+      %{
+        genre_name: "PM",
+        skill_panels: [
+          %{name: "", levels: [:skilled, :normal, :none]}
+        ]
       }
     ]
 


### PR DESCRIPTION
このプルリクで行うこと
・mapで渡すと「保有スキル」カードを表示できる

このプルリクで行いこと
・DBから読み込み
・マイページからのデータの引き渡し
・リンク

![image](https://github.com/bright-org/bright/assets/13599847/f63bb8c9-2827-4629-bb74-b532f8df7a87)
