### PR TITLE
ユーザーヘッダーのみデザイン更新

### DIFF
--- a/lib/bright_web/components/layout_components.ex
+++ b/lib/bright_web/components/layout_components.ex
@@ -7,7 +7,7 @@ defmodule BrightWeb.LayoutComponents do
   @doc """
   Renders a User Header
 
-  # TODO 「4211a9a3ea766724d890e7e385b9057b4ddffc52」　「feat: フォームエラー、モーダル追加」　までユーザーヘッダーのみ部品デザイン更新
+  # TODO 「4211a9a3ea766724d890e7e385b9057b4ddffc52」　「feat: フォームエラー、モーダル追加」　までユーザーヘッダーのみデザイン更新
 
   ## Examples
       <.user_header />


### PR DESCRIPTION
ログアウト検証用がメインの為作り込みはしてません

このプルリクで実施すること
　・ユーザーヘッダーの更新
　・ログアウト機能
　　・但し暫定処置
　　　└デザインが正式時に更新する

このプルリクで実施しないこと
　・各ボタンの動作
　・データマッピング

![image](https://github.com/bright-org/bright/assets/13599847/54fa0d11-328f-4c45-b794-52189fbe8a95)

[Listing-Mypages-·-Phoenix-Framework.webm](https://github.com/bright-org/bright/assets/13599847/49a0538f-fa10-4ccf-99f9-88757a386523)
