### PR TITLE
スキルパネル エビデンス登録エリア モーダル開閉対応

### DIFF
--- a/lib/bright/skill_evidences.ex
+++ b/lib/bright/skill_evidences.ex
@@ -38,6 +38,13 @@ defmodule Bright.SkillEvidences do
   def get_skill_evidence!(id), do: Repo.get!(SkillEvidence, id)
 
   @doc """
+  Gets a single skill_evidence by condition
+  """
+  def get_skill_evidence_by(condition) do
+    Repo.get_by(SkillEvidence, condition)
+  end
+
+  @doc """
   Creates a skill_evidence.
 
   ## Examples

--- a/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
@@ -1,0 +1,12 @@
+defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
+  use BrightWeb, :live_component
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id={@id}>
+      <%= @skill.name %> のエビデンス登録エリア
+    </div>
+    """
+  end
+end

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -55,7 +55,7 @@
       </tr>
 
       <%= for {[col1, col2, col3], row_number} <- build_table_structure(@skill_units) |> Enum.with_index(1) do %>
-        <tr>
+        <tr id={"skill-#{row_number}"}>
           <td :if={col1} rowspan={col1.size} class="align-top"><%= col1.skill_unit.name %></td>
           <td :if={col2} rowspan={col2.size} class="align-top">
             <%= col2.skill_category.name %>
@@ -65,9 +65,9 @@
               <p><%= col3.skill.name %></p>
               <!-- 未実装：デザインまま START -->
               <div class="flex justify-between items-center gap-x-2">
-                <button>
+                <.link class="link-evidence" patch={~p"/panels/#{@skill_panel.id}/skills/#{col3.skill.id}/evidences"}>
                   <img src="/images/common/icons/addFile.svg" />
-                </button>
+                </.link>
                 <button>
                   <img src="/images/common/icons/addFile.svg" />
                 </button>
@@ -96,3 +96,19 @@
     </table>
   </div>
 </div>
+
+<.modal
+  :if={:show_evidences == @live_action}
+  id="skill-evidence-modal"
+  show
+  on_cancel={JS.patch(~p"/panels/#{@skill_panel}/skills?class=#{@skill_class.class}")}>
+
+  <.live_component
+    module={BrightWeb.SkillPanelLive.SkillEvidenceComponent}
+    id={"#{@skill.id}-evidence"}
+    skill={@skill}
+    skill_evidence={@skill_evidence}
+    user={@current_user}
+    patch={~p"/panels/#{@skill_panel}/skills?class=#{@skill_class.class}"}
+  />
+</.modal>

--- a/lib/bright_web/router.ex
+++ b/lib/bright_web/router.ex
@@ -113,6 +113,11 @@ defmodule BrightWeb.Router do
       live "/onboardings/:onboarding", OnboardingLive.Index, :index
       live "/panels/:skill_panel_id/graph", SkillPanelLive.Graph, :show
       live "/panels/:skill_panel_id/skills", SkillPanelLive.Skills, :show
+
+      live "/panels/:skill_panel_id/skills/:skill_id/evidences",
+           SkillPanelLive.Skills,
+           :show_evidences
+
       live "/teams", MyTeamLive, :index
       live "/teams/new", TeamCreateLive, :new
     end

--- a/test/bright/skill_evidences_test.exs
+++ b/test/bright/skill_evidences_test.exs
@@ -35,6 +35,17 @@ defmodule Bright.SkillEvidencesTest do
       assert SkillEvidences.get_skill_evidence!(skill_evidence.id) == skill_evidence
     end
 
+    test "get_skill_evidence_by/1 returns the skill_evidence with given condition", %{
+      valid_attrs: valid_attrs
+    } do
+      skill_evidence = insert(:skill_evidence, valid_attrs)
+
+      assert SkillEvidences.get_skill_evidence_by(id: skill_evidence.id, progress: :done) ==
+               skill_evidence
+
+      assert SkillEvidences.get_skill_evidence_by(id: skill_evidence.id, progress: :wip) == nil
+    end
+
     test "create_skill_evidence/1 with valid data creates a skill_evidence", %{
       valid_attrs: valid_attrs
     } do

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -392,6 +392,26 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
     end
   end
 
+  # エビデンス登録
+  describe "Skill evidence area" do
+    setup [:register_and_log_in_user, :setup_skills]
+
+    @tag score: nil
+    test "shows modal", %{conn: conn, skill_panel: skill_panel, skill_1: skill_1} do
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+
+      show_live
+      |> element("#skill-1 .link-evidence")
+      |> render_click()
+
+      assert_patch(show_live, ~p"/panels/#{skill_panel}/skills/#{skill_1}/evidences")
+
+      assert show_live
+             |> render() =~ skill_1.name
+    end
+  end
+
+  # アクセス制御など
   describe "Security" do
     setup [:register_and_log_in_user]
 


### PR DESCRIPTION
## 対応内容

Closes #64 

スキル横のアイコンをクリックで、エビデンス登録用のモーダルが開くようにしています。

対応しないこと

- アイコンはまだHTMLに反映されていないので仮
- エビデンス登録済みのときのアイコンハイライト
- モーダル内のコンテンツ表示

## 画面

![sample5](https://github.com/bright-org/bright/assets/121112529/887730fd-604f-4528-acc1-bae67640bf03)

- 見切れていますが、クリックでモーダルを表示