### PR TITLE
サイドメニューの画像パス修正

### DIFF
--- a/lib/bright_web/components/layout_components.ex
+++ b/lib/bright_web/components/layout_components.ex
@@ -174,7 +174,7 @@ defmodule BrightWeb.LayoutComponents do
     <aside
     class="flex bg-brightGray-900 min-h-screen flex-col w-[200px] pt-3"
     >
-      <img src="./images/common/logo.svg" width="163px" class="ml-4" />
+      <img src="/images/common/logo.svg" width="163px" class="ml-4" />
       <ul class="grid pt-2">
         <%= for {title, path} <- links() do %>
           <li>


### PR DESCRIPTION
サイドメニューの画像が
/users/settings
とURLがネストすると表示されなくなるのを修正

before
![スクリーンショット 2023-07-18 13 17 44](https://github.com/bright-org/bright/assets/91950/01117b1c-5f97-45c6-b5d0-8b1adca636e1)

after
![スクリーンショット 2023-07-18 13 19 50](https://github.com/bright-org/bright/assets/91950/abc4cb56-9ad6-431f-8507-4c568ddbdcbe)
