### PR TITLE
スキルパネル 教材エリア モーダル開閉対応

### DIFF
--- a/lib/bright/skill_references.ex
+++ b/lib/bright/skill_references.ex
@@ -38,6 +38,13 @@ defmodule Bright.SkillReferences do
   def get_skill_reference!(id), do: Repo.get!(SkillReference, id)
 
   @doc """
+  Gets a single skill_reference by condition
+  """
+  def get_skill_reference_by!(condition) do
+    Repo.get_by!(SkillReference, condition)
+  end
+
+  @doc """
   Creates a skill_reference.
 
   ## Examples

--- a/lib/bright/skill_units/skill.ex
+++ b/lib/bright/skill_units/skill.ex
@@ -19,9 +19,9 @@ defmodule Bright.SkillUnits.Skill do
 
     has_many :skill_score_items, Bright.SkillScores.SkillScoreItem
     has_many :skill_evidences, Bright.SkillEvidences.SkillEvidence
-    has_many :skill_exams, Bright.SkillExams.SkillExam
+    has_one :skill_exam, Bright.SkillExams.SkillExam
     has_many :skill_exam_results, Bright.SkillExams.SkillExamResult
-    has_many :skill_references, Bright.SkillReferences.SkillReference
+    has_one :skill_reference, Bright.SkillReferences.SkillReference
 
     timestamps()
   end

--- a/lib/bright_web/live/skill_panel_live/skill_reference_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_reference_component.ex
@@ -1,0 +1,12 @@
+defmodule BrightWeb.SkillPanelLive.SkillReferenceComponent do
+  use BrightWeb, :live_component
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id={@id}>
+      <%= @skill.name %> の教材エリア
+    </div>
+    """
+  end
+end

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -5,6 +5,7 @@ defmodule BrightWeb.SkillPanelLive.Skills do
   alias Bright.SkillUnits
   alias Bright.SkillScores
   alias Bright.SkillEvidences
+  alias Bright.SkillReferences
   alias BrightWeb.SkillPanelLive.SkillScoreItemComponent
 
   @impl true
@@ -41,6 +42,12 @@ defmodule BrightWeb.SkillPanelLive.Skills do
     |> assign_skill(params["skill_id"])
     |> assign_skill_evidence()
     |> create_skill_evidence_if_not_existing()
+  end
+
+  defp apply_action(socket, :show_reference, params) do
+    socket
+    |> assign_skill(params["skill_id"])
+    |> assign_skill_reference()
   end
 
   @impl true
@@ -99,7 +106,7 @@ defmodule BrightWeb.SkillPanelLive.Skills do
 
     skill_units =
       Ecto.assoc(socket.assigns.skill_class, :skill_units)
-      |> preload(skill_categories: [:skills])
+      |> preload(skill_categories: [skills: [:skill_reference]])
       |> SkillUnits.list_skill_units()
 
     socket
@@ -177,6 +184,13 @@ defmodule BrightWeb.SkillPanelLive.Skills do
 
     socket
     |> assign(skill_evidence: skill_evidence)
+  end
+
+  defp assign_skill_reference(socket) do
+    skill_reference = SkillReferences.get_skill_reference_by!(skill_id: socket.assigns.skill.id)
+
+    socket
+    |> assign(skill_reference: skill_reference)
   end
 
   defp create_skill_evidence_if_not_existing(%{assigns: %{skill_evidence: nil}} = socket) do

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -68,9 +68,9 @@
                 <.link class="link-evidence" patch={~p"/panels/#{@skill_panel.id}/skills/#{col3.skill.id}/evidences"}>
                   <img src="/images/common/icons/addFile.svg" />
                 </.link>
-                <button>
+                <.link :if={col3.skill.skill_reference} class="link-reference" patch={~p"/panels/#{@skill_panel.id}/skills/#{col3.skill.id}/reference"}>
                   <img src="/images/common/icons/addFile.svg" />
-                </button>
+                </.link>
                 <button>
                   <img src="/images/common/icons/addFile.svg" />
                 </button>
@@ -108,6 +108,22 @@
     id={"#{@skill.id}-evidence"}
     skill={@skill}
     skill_evidence={@skill_evidence}
+    user={@current_user}
+    patch={~p"/panels/#{@skill_panel}/skills?class=#{@skill_class.class}"}
+  />
+</.modal>
+
+<.modal
+  :if={:show_reference == @live_action}
+  id="skill-reference-modal"
+  show
+  on_cancel={JS.patch(~p"/panels/#{@skill_panel}/skills?class=#{@skill_class.class}")}>
+
+  <.live_component
+    module={BrightWeb.SkillPanelLive.SkillReferenceComponent}
+    id={"#{@skill.id}-reference"}
+    skill={@skill}
+    skill_reference={@skill_reference}
     user={@current_user}
     patch={~p"/panels/#{@skill_panel}/skills?class=#{@skill_class.class}"}
   />

--- a/lib/bright_web/router.ex
+++ b/lib/bright_web/router.ex
@@ -132,6 +132,10 @@ defmodule BrightWeb.Router do
            SkillPanelLive.Skills,
            :show_evidences
 
+      live "/panels/:skill_panel_id/skills/:skill_id/reference",
+           SkillPanelLive.Skills,
+           :show_reference
+
       live "/teams", MyTeamLive, :index
       live "/teams/new", TeamCreateLive, :new
     end

--- a/test/bright/skill_references_test.exs
+++ b/test/bright/skill_references_test.exs
@@ -28,6 +28,19 @@ defmodule Bright.SkillReferencesTest do
       assert SkillReferences.get_skill_reference!(skill_reference.id).id == skill_reference.id
     end
 
+    test "get_skill_reference_by!/1 returns the skill_reference with given condition", %{
+      skill: skill
+    } do
+      skill_reference = insert(:skill_reference, skill: skill)
+
+      assert SkillReferences.get_skill_reference_by!(id: skill_reference.id).id ==
+               skill_reference.id
+
+      assert_raise Ecto.NoResultsError, fn ->
+        SkillReferences.get_skill_reference_by!(id: Ecto.ULID.generate())
+      end
+    end
+
     test "create_skill_reference/1 with valid data creates a skill_reference", %{skill: skill} do
       valid_attrs = %{skill_id: skill.id}
 

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -411,6 +411,35 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
     end
   end
 
+  # 教材
+  describe "Skill reference area" do
+    setup [:register_and_log_in_user, :setup_skills]
+
+    @tag score: nil
+    test "shows modal", %{conn: conn, skill_panel: skill_panel, skill_1: skill_1} do
+      insert(:skill_reference, skill: skill_1)
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+
+      show_live
+      |> element("#skill-1 .link-reference")
+      |> render_click()
+
+      assert_patch(show_live, ~p"/panels/#{skill_panel}/skills/#{skill_1}/reference")
+
+      assert show_live
+             |> render() =~ skill_1.name
+    end
+
+    @tag score: nil
+    test "教材がないスキルのリンクが表示されないこと", %{conn: conn, skill_panel: skill_panel} do
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+
+      refute show_live
+             |> element("#skill-1 .link-reference")
+             |> has_element?()
+    end
+  end
+
   # アクセス制御など
   describe "Security" do
     setup [:register_and_log_in_user]


### PR DESCRIPTION
## 対応内容

Closes #65 

スキル横のアイコンをクリックで、教材用のモーダルが開くようにしています。

対応しないこと（別タスク）

- アイコンはまだHTMLに反映されていないので仮です
- モーダル内のコンテンツ表示
- モーダルがモーダル外のクリックで閉じる課題への対応
- 教材そのものの管理まわりの機能

![sample6](https://github.com/bright-org/bright/assets/121112529/a3e80840-ee5d-4f67-8c21-df44408525d9)
