### PR TITLE
スキルパネル 試験エリア モーダル開閉対応

### DIFF
--- a/lib/bright/skill_exams.ex
+++ b/lib/bright/skill_exams.ex
@@ -38,6 +38,13 @@ defmodule Bright.SkillExams do
   def get_skill_exam!(id), do: Repo.get!(SkillExam, id)
 
   @doc """
+  Gets a single skill_exam by condition
+  """
+  def get_skill_exam_by!(condition) do
+    Repo.get_by!(SkillExam, condition)
+  end
+
+  @doc """
   Creates a skill_exam.
 
   ## Examples

--- a/lib/bright_web/live/skill_panel_live/skill_exam_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_exam_component.ex
@@ -1,0 +1,12 @@
+defmodule BrightWeb.SkillPanelLive.SkillExamComponent do
+  use BrightWeb, :live_component
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id={@id}>
+      <%= @skill.name %> の試験エリア
+    </div>
+    """
+  end
+end

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -6,6 +6,7 @@ defmodule BrightWeb.SkillPanelLive.Skills do
   alias Bright.SkillScores
   alias Bright.SkillEvidences
   alias Bright.SkillReferences
+  alias Bright.SkillExams
   alias BrightWeb.SkillPanelLive.SkillScoreItemComponent
 
   @impl true
@@ -48,6 +49,12 @@ defmodule BrightWeb.SkillPanelLive.Skills do
     socket
     |> assign_skill(params["skill_id"])
     |> assign_skill_reference()
+  end
+
+  defp apply_action(socket, :show_exam, params) do
+    socket
+    |> assign_skill(params["skill_id"])
+    |> assign_skill_exam()
   end
 
   @impl true
@@ -106,7 +113,7 @@ defmodule BrightWeb.SkillPanelLive.Skills do
 
     skill_units =
       Ecto.assoc(socket.assigns.skill_class, :skill_units)
-      |> preload(skill_categories: [skills: [:skill_reference]])
+      |> preload(skill_categories: [skills: [:skill_reference, :skill_exam]])
       |> SkillUnits.list_skill_units()
 
     socket
@@ -191,6 +198,13 @@ defmodule BrightWeb.SkillPanelLive.Skills do
 
     socket
     |> assign(skill_reference: skill_reference)
+  end
+
+  defp assign_skill_exam(socket) do
+    skill_exam = SkillExams.get_skill_exam_by!(skill_id: socket.assigns.skill.id)
+
+    socket
+    |> assign(skill_exam: skill_exam)
   end
 
   defp create_skill_evidence_if_not_existing(%{assigns: %{skill_evidence: nil}} = socket) do

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -65,15 +65,15 @@
               <p><%= col3.skill.name %></p>
               <!-- 未実装：デザインまま START -->
               <div class="flex justify-between items-center gap-x-2">
-                <.link class="link-evidence" patch={~p"/panels/#{@skill_panel.id}/skills/#{col3.skill.id}/evidences"}>
+                <.link class="link-evidence" patch={~p"/panels/#{@skill_panel}/skills/#{col3.skill}/evidences"}>
                   <img src="/images/common/icons/addFile.svg" />
                 </.link>
-                <.link :if={col3.skill.skill_reference} class="link-reference" patch={~p"/panels/#{@skill_panel.id}/skills/#{col3.skill.id}/reference"}>
+                <.link :if={col3.skill.skill_reference} class="link-reference" patch={~p"/panels/#{@skill_panel}/skills/#{col3.skill}/reference"}>
                   <img src="/images/common/icons/addFile.svg" />
                 </.link>
-                <button>
+                <.link :if={col3.skill.skill_exam} class="link-exam" patch={~p"/panels/#{@skill_panel}/skills/#{col3.skill}/exam"}>
                   <img src="/images/common/icons/addFile.svg" />
-                </button>
+                </.link>
               </div>
               <!-- 未実装：デザインまま END -->
             </div>
@@ -124,6 +124,22 @@
     id={"#{@skill.id}-reference"}
     skill={@skill}
     skill_reference={@skill_reference}
+    user={@current_user}
+    patch={~p"/panels/#{@skill_panel}/skills?class=#{@skill_class.class}"}
+  />
+</.modal>
+
+<.modal
+  :if={:show_exam == @live_action}
+  id="skill-exam-modal"
+  show
+  on_cancel={JS.patch(~p"/panels/#{@skill_panel}/skills?class=#{@skill_class.class}")}>
+
+  <.live_component
+    module={BrightWeb.SkillPanelLive.SkillExamComponent}
+    id={"#{@skill.id}-exam"}
+    skill={@skill}
+    skill_exam={@skill_exam}
     user={@current_user}
     patch={~p"/panels/#{@skill_panel}/skills?class=#{@skill_class.class}"}
   />

--- a/lib/bright_web/router.ex
+++ b/lib/bright_web/router.ex
@@ -136,6 +136,10 @@ defmodule BrightWeb.Router do
            SkillPanelLive.Skills,
            :show_reference
 
+      live "/panels/:skill_panel_id/skills/:skill_id/exam",
+           SkillPanelLive.Skills,
+           :show_exam
+
       live "/teams", MyTeamLive, :index
       live "/teams/new", TeamCreateLive, :new
     end

--- a/test/bright/skill_exams_test.exs
+++ b/test/bright/skill_exams_test.exs
@@ -28,6 +28,18 @@ defmodule Bright.SkillExamsTest do
       assert SkillExams.get_skill_exam!(skill_exam.id).id == skill_exam.id
     end
 
+    test "get_skill_exam_by!/1 returns the skill_exam with given condition", %{
+      skill: skill
+    } do
+      skill_exam = insert(:skill_exam, skill: skill)
+
+      assert SkillExams.get_skill_exam_by!(id: skill_exam.id).id == skill_exam.id
+
+      assert_raise Ecto.NoResultsError, fn ->
+        SkillExams.get_skill_exam_by!(id: Ecto.ULID.generate())
+      end
+    end
+
     test "create_skill_exam/1 with valid data creates a skill_exam", %{skill: skill} do
       valid_attrs = %{skill_id: skill.id}
 

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -440,6 +440,35 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
     end
   end
 
+  # 試験
+  describe "Skill exam area" do
+    setup [:register_and_log_in_user, :setup_skills]
+
+    @tag score: nil
+    test "shows modal", %{conn: conn, skill_panel: skill_panel, skill_1: skill_1} do
+      insert(:skill_exam, skill: skill_1)
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+
+      show_live
+      |> element("#skill-1 .link-exam")
+      |> render_click()
+
+      assert_patch(show_live, ~p"/panels/#{skill_panel}/skills/#{skill_1}/exam")
+
+      assert show_live
+             |> render() =~ skill_1.name
+    end
+
+    @tag score: nil
+    test "試験がないスキルのリンクが表示されないこと", %{conn: conn, skill_panel: skill_panel} do
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+
+      refute show_live
+             |> element("#skill-1 .link-exam")
+             |> has_element?()
+    end
+  end
+
   # アクセス制御など
   describe "Security" do
     setup [:register_and_log_in_user]


### PR DESCRIPTION
## 対応内容

Closes #66 

スキル横のアイコンをクリックで、試験用のモーダルが開くようにしています。

対応しないこと（別タスク）

- アイコン（HTMLに反映されていないので仮）
- モーダル内のコンテンツ表示（BrightWeb.ModalComponent への統合）
- モーダルがモーダル外のクリックで閉じる課題への対応
- 試験そのものの管理まわりの機能