### PR TITLE
カードコンポーネントのリスト用コンポーネントを作成

### DIFF
--- a/lib/bright_web/live/card_live/card_list_components.ex
+++ b/lib/bright_web/live/card_live/card_list_components.ex
@@ -1,6 +1,6 @@
-defmodule BrightWeb.BrightCardComponents do
+defmodule BrightWeb.CardLive.CardListComponents do
   @moduledoc """
-  Bright List Components
+  Card List Components
   """
   use Phoenix.Component
 

--- a/lib/bright_web/live/card_live/communication_card_component.ex
+++ b/lib/bright_web/live/card_live/communication_card_component.ex
@@ -5,7 +5,7 @@ defmodule BrightWeb.CardLive.CommunicationCardComponent do
   """
   use BrightWeb, :live_component
   import BrightWeb.TabComponents
-  import BrightWeb.BrightCardComponents
+  import BrightWeb.CardLive.CardListComponents
   alias Bright.Notifications
 
   @tabs ["スキルアップ", "1on1のお誘い", "推し活", "所属チーム", "気になる", "運勢公式"]

--- a/lib/bright_web/live/card_live/contact_card_component.ex
+++ b/lib/bright_web/live/card_live/contact_card_component.ex
@@ -6,7 +6,7 @@ defmodule BrightWeb.CardLive.ContactCardComponent do
 
   use BrightWeb, :live_component
   import BrightWeb.TabComponents
-  import BrightWeb.BrightCardComponents
+  import BrightWeb.CardLive.CardListComponents
   alias Bright.Notifications
 
   @tabs ["チーム招待", "デイリー", "ウイークリー", "採用の調整", "スキルパネル更新", "運営"]


### PR DESCRIPTION
このプルリクで実施すること
　・リストの中の部品のみ抽出
　　└部品を並べて比較しやすくするため
　・時間計算を共通化

このプルリクで実施しないこと
　・リストの外枠
　　└現時点では共通化できないため
　　
closes #368