### PR TITLE
タブ選択状態を英語化する

### DIFF
--- a/lib/bright_web/components/tab_components.ex
+++ b/lib/bright_web/components/tab_components.ex
@@ -53,7 +53,7 @@ defmodule BrightWeb.TabComponents do
     ~H"""
     <ul class="flex content-between border-b border-brightGray-200">
       <%= for {key, value} <- @tabs do %>
-        <.tab_header_item id={@id}  tab_name={key} selected={key == String.to_atom(@selected_tab)} target={@target}> <%= value %></.tab_header_item>
+        <.tab_header_item id={@id}  tab_name={key} selected={key == @selected_tab} target={@target}> <%= value %></.tab_header_item>
       <% end %>
       <%= if length(@menu_items) > 0 do %>
         <.tab_menu_button id={@id} menu_items={@menu_items}/>

--- a/lib/bright_web/live/card_live/contact_card_component.ex
+++ b/lib/bright_web/live/card_live/contact_card_component.ex
@@ -10,12 +10,12 @@ defmodule BrightWeb.CardLive.ContactCardComponent do
   alias Bright.Notifications
 
   @tabs [
-    team_invite: "チーム招待",
-    daily: "デイリー",
-    weekly: "ウイークリー",
-    recruitment_coordination: "採用の調整",
-    skill_panel_update: "スキルパネル更新",
-    operation: "運営"
+    {"team_invite", "チーム招待"},
+    {"{daily", "デイリー"},
+    {"weekly", "ウイークリー"},
+    {"recruitment_coordination", "採用の調整"},
+    {"skill_panel_update", "スキルパネル更新"},
+    {"operation", "運営"}
   ]
 
   @impl true


### PR DESCRIPTION
タイトル通り

・日本語での選択状態の維持を廃止する
・キーワードリストでタブの定義をおこなう

gettextも検討しましたが、動的な変数はgettextは使えない為gettextはやめました

このプルリクで行わないこと
・storybookの修正
　└他のプルリクで競合するので別扱いにさせてください