### PR TITLE
共通モーダルが枠外クリックやESCキーで閉じないように対応

### DIFF
--- a/lib/bright_web/components/bright_modal_components.ex
+++ b/lib/bright_web/components/bright_modal_components.ex
@@ -83,9 +83,6 @@ defmodule BrightWeb.BrightModalComponents do
           <div class={@style_of_modal_flame_out}>
             <.focus_wrap
               id={"#{@id}-container"}
-              phx-window-keydown={JS.exec("data-cancel", to: "##{@id}")}
-              phx-key="escape"
-              phx-click-away={JS.exec("data-cancel", to: "##{@id}")}
               class={@style_of_modal_flame}
             >
             <%= if @enable_cancel_button do %>


### PR DESCRIPTION
表題の通りです。操作ミスによるキャンセル防止が目的になります。

話題元
https://digi-dock.slack.com/archives/C0550EENU86/p1689665777394799