### PR TITLE
確認メール再送信画面のドメインを修正

### DIFF
--- a/lib/bright_web/live/user_confirmation_instructions_live.ex
+++ b/lib/bright_web/live/user_confirmation_instructions_live.ex
@@ -8,7 +8,6 @@ defmodule BrightWeb.UserConfirmationInstructionsLive do
     ~H"""
     <UserAuthComponents.header>確認メールが届かなかった方へ</UserAuthComponents.header>
 
-    <%!-- TODO: ドメイン決まったら反映 --%>
     <UserAuthComponents.description>
       確認メールを再度送信します。
       <br>
@@ -18,7 +17,7 @@ defmodule BrightWeb.UserConfirmationInstructionsLive do
       <span class="text-xs">
         メールが届かない場合は、Brightからのメールが受信できるように
         <br>
-        ドメイン指定受信で「xxxxxxxx.com」を許可するように設定してください。
+        ドメイン指定受信で「bright-fun.org」を許可するように設定してください。
       </span>
     </UserAuthComponents.description>
 


### PR DESCRIPTION
LP のドメインと同じ bright-fun.org にしました。
これでいい想定ですが、スプリントレビューでも確認して間違ってたらまた修正します。