### PR TITLE
スキルパネルの各テーブルに locked_date と trace_id を追加

### DIFF
--- a/lib/bright/skill_panels/skill_class.ex
+++ b/lib/bright/skill_panels/skill_class.ex
@@ -13,6 +13,10 @@ defmodule Bright.SkillPanels.SkillClass do
   @foreign_key_type Ecto.ULID
 
   schema "skill_classes" do
+    # TODO: デフォルト値を消す
+    field :locked_date, :date, default: ~D[2023-07-01]
+    # TODO: 自動生成を消す
+    field :trace_id, Ecto.ULID, autogenerate: {Ecto.ULID, :generate, []}
     field :name, :string
     field :class, :integer
 

--- a/lib/bright/skill_panels/skill_panel.ex
+++ b/lib/bright/skill_panels/skill_panel.ex
@@ -12,7 +12,6 @@ defmodule Bright.SkillPanels.SkillPanel do
   @foreign_key_type Ecto.ULID
 
   schema "skill_panels" do
-    field :locked_date, :date
     field :name, :string
 
     has_many :skill_classes, SkillClass, preload_order: [asc: :class], on_replace: :delete
@@ -23,7 +22,7 @@ defmodule Bright.SkillPanels.SkillPanel do
   @doc false
   def changeset(skill_panel, attrs) do
     skill_panel
-    |> cast(attrs, [:locked_date, :name])
+    |> cast(attrs, [:name])
     |> cast_assoc(:skill_classes,
       with: &SkillClass.changeset/2,
       sort_param: :skill_classes_sort,

--- a/lib/bright/skill_units/skill.ex
+++ b/lib/bright/skill_units/skill.ex
@@ -13,6 +13,8 @@ defmodule Bright.SkillUnits.Skill do
   @foreign_key_type Ecto.ULID
 
   schema "skills" do
+    # TODO: 自動生成を消す
+    field :trace_id, Ecto.ULID, autogenerate: {Ecto.ULID, :generate, []}
     field :name, :string
     field :position, :integer
 

--- a/lib/bright/skill_units/skill_category.ex
+++ b/lib/bright/skill_units/skill_category.ex
@@ -13,6 +13,8 @@ defmodule Bright.SkillUnits.SkillCategory do
   @foreign_key_type Ecto.ULID
 
   schema "skill_categories" do
+    # TODO: 自動生成を消す
+    field :trace_id, Ecto.ULID, autogenerate: {Ecto.ULID, :generate, []}
     field :name, :string
     field :position, :integer
 

--- a/lib/bright/skill_units/skill_class_unit.ex
+++ b/lib/bright/skill_units/skill_class_unit.ex
@@ -13,6 +13,8 @@ defmodule Bright.SkillUnits.SkillClassUnit do
   @foreign_key_type Ecto.ULID
 
   schema "skill_class_units" do
+    # TODO: 自動生成を消す
+    field :trace_id, Ecto.ULID, autogenerate: {Ecto.ULID, :generate, []}
     field :position, :integer
 
     belongs_to :skill_class, SkillClass

--- a/lib/bright/skill_units/skill_unit.ex
+++ b/lib/bright/skill_units/skill_unit.ex
@@ -13,6 +13,10 @@ defmodule Bright.SkillUnits.SkillUnit do
   @foreign_key_type Ecto.ULID
 
   schema "skill_units" do
+    # TODO: デフォルト値を消す
+    field :locked_date, :date, default: ~D[2023-07-01]
+    # TODO: 自動生成を消す
+    field :trace_id, Ecto.ULID, autogenerate: {Ecto.ULID, :generate, []}
     field :name, :string
 
     has_many :skill_categories, SkillCategory,

--- a/lib/bright_web/live/admin/skill_panel_live/form_component.ex
+++ b/lib/bright_web/live/admin/skill_panel_live/form_component.ex
@@ -19,7 +19,6 @@ defmodule BrightWeb.Admin.SkillPanelLive.FormComponent do
         phx-change="validate"
         phx-submit="save"
       >
-        <.input field={@form[:locked_date]} type="date" label="Locked date" />
         <.input field={@form[:name]} type="text" label="Name" />
         <.label>Skill classes</.label>
         <.inputs_for :let={scf} field={@form[:skill_classes]}>

--- a/lib/bright_web/live/admin/skill_panel_live/index.html.heex
+++ b/lib/bright_web/live/admin/skill_panel_live/index.html.heex
@@ -12,7 +12,6 @@
   rows={@streams.skill_panels}
   row_click={fn {_id, skill_panel} -> JS.navigate(~p"/admin/skill_panels/#{skill_panel}") end}
 >
-  <:col :let={{_id, skill_panel}} label="Locked date"><%= skill_panel.locked_date %></:col>
   <:col :let={{_id, skill_panel}} label="Name"><%= skill_panel.name %></:col>
   <:action :let={{_id, skill_panel}}>
     <div class="sr-only">

--- a/lib/bright_web/live/admin/skill_panel_live/show.html.heex
+++ b/lib/bright_web/live/admin/skill_panel_live/show.html.heex
@@ -9,7 +9,6 @@
 </.header>
 
 <.list>
-  <:item title="Locked date"><%= @skill_panel.locked_date %></:item>
   <:item title="Name"><%= @skill_panel.name %></:item>
   <:item title="Skill classes">
     <ul>

--- a/priv/repo/migrations/20230731064403_remove_locked_date_from_skill_panels.exs
+++ b/priv/repo/migrations/20230731064403_remove_locked_date_from_skill_panels.exs
@@ -1,0 +1,9 @@
+defmodule Bright.Repo.Migrations.RemoveLockedDateFromSkillPanels do
+  use Ecto.Migration
+
+  def change do
+    alter table(:skill_panels) do
+      remove :locked_date, :date
+    end
+  end
+end

--- a/priv/repo/migrations/20230731065056_add_locked_date_and_trace_id_to_skill_classes.exs
+++ b/priv/repo/migrations/20230731065056_add_locked_date_and_trace_id_to_skill_classes.exs
@@ -1,0 +1,39 @@
+defmodule Bright.Repo.Migrations.AddLockedDateAndTraceIdToSkillClasses do
+  use Ecto.Migration
+
+  alias Bright.Repo
+  alias Bright.SkillPanels.SkillClass
+
+  def up do
+    alter table(:skill_classes) do
+      add :locked_date, :date
+      add :trace_id, :uuid
+    end
+
+    flush()
+
+    Enum.each(Repo.all(SkillClass), fn skill_class ->
+      {:ok, _} =
+        skill_class
+        |> Ecto.Changeset.cast(%{locked_date: ~D[2023-07-01], trace_id: Ecto.ULID.generate()}, [
+          :locked_date,
+          :trace_id
+        ])
+        |> Repo.update()
+    end)
+
+    flush()
+
+    alter table(:skill_classes) do
+      modify :locked_date, :date, null: false
+      modify :trace_id, :uuid, null: false
+    end
+  end
+
+  def down do
+    alter table(:skill_classes) do
+      remove :locked_date
+      remove :trace_id
+    end
+  end
+end

--- a/priv/repo/migrations/20230731085530_add_locked_date_and_trace_id_to_skill_units.exs
+++ b/priv/repo/migrations/20230731085530_add_locked_date_and_trace_id_to_skill_units.exs
@@ -1,0 +1,39 @@
+defmodule Bright.Repo.Migrations.AddLockedDateAndTraceIdToSkillUnits do
+  use Ecto.Migration
+
+  alias Bright.Repo
+  alias Bright.SkillUnits.SkillUnit
+
+  def up do
+    alter table(:skill_units) do
+      add :locked_date, :date
+      add :trace_id, :uuid
+    end
+
+    flush()
+
+    Enum.each(Repo.all(SkillUnit), fn skill_unit ->
+      {:ok, _} =
+        skill_unit
+        |> Ecto.Changeset.cast(%{locked_date: ~D[2023-07-01], trace_id: Ecto.ULID.generate()}, [
+          :locked_date,
+          :trace_id
+        ])
+        |> Repo.update()
+    end)
+
+    flush()
+
+    alter table(:skill_units) do
+      modify :locked_date, :date, null: false
+      modify :trace_id, :uuid, null: false
+    end
+  end
+
+  def down do
+    alter table(:skill_units) do
+      remove :locked_date
+      remove :trace_id
+    end
+  end
+end

--- a/priv/repo/migrations/20230731085802_add_trace_id_to_skill_categories.exs
+++ b/priv/repo/migrations/20230731085802_add_trace_id_to_skill_categories.exs
@@ -1,0 +1,33 @@
+defmodule Bright.Repo.Migrations.AddLockedDateAndTraceIdToSkillCategories do
+  use Ecto.Migration
+
+  alias Bright.Repo
+  alias Bright.SkillUnits.SkillCategory
+
+  def up do
+    alter table(:skill_categories) do
+      add :trace_id, :uuid
+    end
+
+    flush()
+
+    Enum.each(Repo.all(SkillCategory), fn skill_category ->
+      {:ok, _} =
+        skill_category
+        |> Ecto.Changeset.cast(%{trace_id: Ecto.ULID.generate()}, [:trace_id])
+        |> Repo.update()
+    end)
+
+    flush()
+
+    alter table(:skill_categories) do
+      modify :trace_id, :uuid, null: false
+    end
+  end
+
+  def down do
+    alter table(:skill_categories) do
+      remove :trace_id
+    end
+  end
+end

--- a/priv/repo/migrations/20230731085923_add_trace_id_to_skills.exs
+++ b/priv/repo/migrations/20230731085923_add_trace_id_to_skills.exs
@@ -1,0 +1,33 @@
+defmodule Bright.Repo.Migrations.AddLockedDateAndTraceIdToSkills do
+  use Ecto.Migration
+
+  alias Bright.Repo
+  alias Bright.SkillUnits.Skill
+
+  def up do
+    alter table(:skills) do
+      add :trace_id, :uuid
+    end
+
+    flush()
+
+    Enum.each(Repo.all(Skill), fn skill ->
+      {:ok, _} =
+        skill
+        |> Ecto.Changeset.cast(%{trace_id: Ecto.ULID.generate()}, [:trace_id])
+        |> Repo.update()
+    end)
+
+    flush()
+
+    alter table(:skills) do
+      modify :trace_id, :uuid, null: false
+    end
+  end
+
+  def down do
+    alter table(:skills) do
+      remove :trace_id
+    end
+  end
+end

--- a/priv/repo/migrations/20230731090127_add_trace_id_to_skill_class_units.exs
+++ b/priv/repo/migrations/20230731090127_add_trace_id_to_skill_class_units.exs
@@ -1,0 +1,33 @@
+defmodule Bright.Repo.Migrations.AddLockedDateAndTraceIdToSkillClassUnits do
+  use Ecto.Migration
+
+  alias Bright.Repo
+  alias Bright.SkillUnits.SkillClassUnit
+
+  def up do
+    alter table(:skill_class_units) do
+      add :trace_id, :uuid
+    end
+
+    flush()
+
+    Enum.each(Repo.all(SkillClassUnit), fn skill_class_unit ->
+      {:ok, _} =
+        skill_class_unit
+        |> Ecto.Changeset.cast(%{trace_id: Ecto.ULID.generate()}, [:trace_id])
+        |> Repo.update()
+    end)
+
+    flush()
+
+    alter table(:skill_class_units) do
+      modify :trace_id, :uuid, null: false
+    end
+  end
+
+  def down do
+    alter table(:skill_class_units) do
+      remove :trace_id
+    end
+  end
+end

--- a/test/bright/skill_panels_test.exs
+++ b/test/bright/skill_panels_test.exs
@@ -20,16 +20,15 @@ defmodule Bright.SkillPanelsTest do
     end
 
     test "create_skill_panel/1 with valid data creates a skill_panel" do
-      valid_attrs = params_for(:locked_skill_panel)
+      valid_attrs = params_for(:skill_panel)
 
       assert {:ok, %SkillPanel{} = skill_panel} = SkillPanels.create_skill_panel(valid_attrs)
-      assert skill_panel.locked_date == valid_attrs.locked_date
       assert skill_panel.name == valid_attrs.name
     end
 
     test "create_skill_panel/1 with skill_classes" do
       valid_attrs =
-        params_for(:locked_skill_panel)
+        params_for(:skill_panel)
         |> Map.put(:skill_classes, [
           params_for(:skill_class, class: nil),
           params_for(:skill_class, class: nil)
@@ -52,12 +51,11 @@ defmodule Bright.SkillPanelsTest do
 
     test "update_skill_panel/2 with valid data updates the skill_panel" do
       skill_panel = insert(:skill_panel)
-      update_attrs = params_for(:locked_skill_panel)
+      update_attrs = params_for(:skill_panel)
 
       assert {:ok, %SkillPanel{} = skill_panel} =
                SkillPanels.update_skill_panel(skill_panel, update_attrs)
 
-      assert skill_panel.locked_date == update_attrs.locked_date
       assert skill_panel.name == update_attrs.name
     end
 

--- a/test/bright_web/live/admin/skill_panel_live_test.exs
+++ b/test/bright_web/live/admin/skill_panel_live_test.exs
@@ -5,8 +5,8 @@ defmodule BrightWeb.Admin.SkillPanelLiveTest do
   import Bright.Factory
 
   @create_attrs params_for(:skill_panel)
-  @update_attrs params_for(:locked_skill_panel)
-  @invalid_attrs %{name: nil, locked_date: nil}
+  @update_attrs params_for(:skill_panel)
+  @invalid_attrs %{name: nil}
 
   defp create_skill_panel(_) do
     skill_panel = insert(:skill_panel, skill_classes: build_pair(:skill_class))

--- a/test/factories/skill_class_factory.ex
+++ b/test/factories/skill_class_factory.ex
@@ -7,6 +7,8 @@ defmodule Bright.SkillClassFactory do
     quote do
       def skill_class_factory do
         %Bright.SkillPanels.SkillClass{
+          locked_date: Faker.Date.backward(10),
+          trace_id: Ecto.ULID.generate(),
           name: Faker.Lorem.word(),
           class: sequence(:class, & &1, start_at: 1)
         }

--- a/test/factories/skill_panel_factory.ex
+++ b/test/factories/skill_panel_factory.ex
@@ -7,13 +7,8 @@ defmodule Bright.SkillPanelFactory do
     quote do
       def skill_panel_factory do
         %Bright.SkillPanels.SkillPanel{
-          locked_date: nil,
           name: Faker.Lorem.word()
         }
-      end
-
-      def locked_skill_panel_factory do
-        build(:skill_panel, locked_date: Faker.Date.backward(10))
       end
     end
   end


### PR DESCRIPTION
Ref #262 

[スキルパネル更新ロジック](https://github.com/bright-org/bright/blob/develop/docs/logics/update_skill_panels.md) を完全に把握するのは結構大変だと思うので、最低限テーブル定義と実際のスキーマが合っているかどうかだけチェックしてもらえればOKです

## やったこと

- スキルパネルの各テーブルに locked_date と trace_id を追加

## やってないこと

- 下書きテーブルへのデータマイグレーション
- スキルパネル更新ロジックの実装
- 管理画面で下書きテーブルに対してCRUDを行うように変更