### PR TITLE
「重量な連絡」カードで「チーム招待」がデフォルトで選択されない不具合を対処

### DIFF
--- a/lib/bright_web/live/card_live/contact_card_component.ex
+++ b/lib/bright_web/live/card_live/contact_card_component.ex
@@ -48,7 +48,7 @@ defmodule BrightWeb.CardLive.ContactCardComponent do
      socket
      |> assign(assigns)
      |> assign(:tabs, @tabs)
-     |> assign(:card, create_card_param("team_invite"))
+     |> assign(:card, create_card_param("team_invitation"))
      |> assign_card()}
   end
 


### PR DESCRIPTION
タイトル通り