### PR TITLE
「保有スキル」のスキルジャンルの概念の削除とタブアクティブ表示を追加

### DIFF
--- a/lib/bright_web/live/card_live/skill_card_component.ex
+++ b/lib/bright_web/live/card_live/skill_card_component.ex
@@ -67,12 +67,12 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
         %{"id" => "skill_card", "tab_name" => tab_name},
         socket
       ) do
-    assigns =
+    socket =
       socket
       |> assign(:selected_tab, tab_name)
 
     # TODO 処理は未実装
-    {:noreply, assigns}
+    {:noreply, socket}
   end
 
   def handle_event(


### PR DESCRIPTION
このプルリクで実施すること
　・スキルジャンルの概念を削除
　・タブアクティブ表示を追加（緑に選択される）

このプルリクで実施しないこと
　・DB処理
　・デザインの適用
　　　└デザインがまだのため