### PR TITLE
ueberauth の環境変数は実行時に読む必要があったので修正

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -70,14 +70,15 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
+# ueberauth
 config :ueberauth, Ueberauth,
   providers: [
     google: {Ueberauth.Strategy.Google, [default_scope: "email profile"]}
   ]
 
 config :ueberauth, Ueberauth.Strategy.Google.OAuth,
-  client_id: System.get_env("GOOGLE_CLIENT_ID"),
-  client_secret: System.get_env("GOOGLE_CLIENT_SECRET")
+  client_id: {System, :get_env, ["GOOGLE_CLIENT_ID"]},
+  client_secret: {System, :get_env, ["GOOGLE_CLIENT_SECRET"]}
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.


### PR DESCRIPTION
タイトルの通り。dev環境の構成上、実行時にやらないとダメだった。
https://digi-dock.slack.com/archives/C0550EENU86/p1690867237645459?thread_ts=1690865772.537599&cid=C0550EENU86