### PR TITLE
カードのボタンが無い行の高さを広げる

### DIFF
--- a/lib/bright_web/live/card_live/card_list_components.ex
+++ b/lib/bright_web/live/card_live/card_list_components.ex
@@ -29,7 +29,7 @@ defmodule BrightWeb.CardLive.CardListComponents do
 
   def card_row(%{type: "contact"} = assigns) do
     ~H"""
-    <li class="text-left flex items-center text-base">
+    <li class="py-1 text-left flex items-center text-base">
       <span class="material-icons !text-lg text-white bg-brightGreen-300 rounded-full !flex w-6 h-6 mr-2.5 !items-center !justify-center">
         <%= @notification.icon_type %>
       </span>
@@ -112,7 +112,7 @@ defmodule BrightWeb.CardLive.CardListComponents do
 
   def card_row(%{type: "your_team"} = assigns) do
     ~H"""
-    <li class="text-left flex items-center text-base hover:bg-brightGray-50 px-1">
+    <li class="py-1 text-left flex items-center text-base hover:bg-brightGray-50 px-1">
       <span class="material-icons-outlined !text-sm !text-white bg-brightGreen-300 rounded-full !flex w-6 h-6 mr-2.5 !items-center !justify-center">
         <%= @notification.icon_type %>
       </span>

--- a/lib/bright_web/live/card_live/contact_card_component.ex
+++ b/lib/bright_web/live/card_live/contact_card_component.ex
@@ -30,7 +30,7 @@ defmodule BrightWeb.CardLive.ContactCardComponent do
         total_pages={@card.total_pages}
         target={@myself}
       >
-        <div class="pt-4 pb-1 px-8">
+        <div class="pt-4 px-8">
           <ul class="flex gap-y-2.5 flex-col">
             <%= for notification <- @card.notifications do %>
               <.card_row type="contact" notification={notification} />


### PR DESCRIPTION
修正前
ボタンが無い行の高さが、ボタンありに比べて低かった
![image](https://github.com/bright-org/bright/assets/13599847/255c3e1f-6a6d-4061-af51-35947d516bc5)

修正後
![image](https://github.com/bright-org/bright/assets/13599847/71d7d8b6-f69d-42fb-b2c7-baefc6eb8f2f)

![image](https://github.com/bright-org/bright/assets/13599847/090b0ef0-8359-492b-80e1-d86c44e4db69)
