### PR TITLE
「重量な連絡」と「さまざまな人たちとの交流」のカードの高さを合わせる

### DIFF
--- a/lib/bright_web/live/card_live/communication_card_component.ex
+++ b/lib/bright_web/live/card_live/communication_card_component.ex
@@ -29,7 +29,7 @@ defmodule BrightWeb.CardLive.CommunicationCardComponent do
         total_pages={@card.total_pages}
         target={@myself}
       >
-        <div class="pt-4 px-6" style="height:216px">
+        <div class="pt-4 px-6 h-[216px]">
           <ul class="flex gap-y-2.5 flex-col">
               <%= for notification <- @card.notifications do %>
                 <.card_row type={@card.selected_tab} notification={notification} />

--- a/lib/bright_web/live/card_live/contact_card_component.ex
+++ b/lib/bright_web/live/card_live/contact_card_component.ex
@@ -30,7 +30,7 @@ defmodule BrightWeb.CardLive.ContactCardComponent do
         total_pages={@card.total_pages}
         target={@myself}
       >
-        <div class="pt-4 px-8" style="height:216px">
+        <div class="pt-4 px-8 h-[216px]">
           <ul class="flex gap-y-2.5 flex-col">
             <%= for notification <- @card.notifications do %>
               <.card_row type="contact" notification={notification} />


### PR DESCRIPTION
タイトル通り
最大５件で高さを合わせました
対象カード
　・「重量な連絡」
　・「さまざまな人たちとの交流」
　
上記以外はこのプルリクでは対応しない

■修正前
![image](https://github.com/bright-org/bright/assets/13599847/89640318-9f22-4885-8014-6d76271f8ad8)


■修正後
![image](https://github.com/bright-org/bright/assets/13599847/fd7a1d8c-eb85-495a-ae33-454f174a4243)

![image](https://github.com/bright-org/bright/assets/13599847/8abc02af-3eff-4638-89f2-7b63a829bb12)
