### PR TITLE
migrationエラー回避のためデフォルト null削除

### DIFF
--- a/priv/repo/migrations/20230803013322_add_name_ja_to_career_fields.exs
+++ b/priv/repo/migrations/20230803013322_add_name_ja_to_career_fields.exs
@@ -3,7 +3,7 @@ defmodule Bright.Repo.Migrations.AddNameJaToCareerFields do
 
   def change do
     alter table(:career_fields) do
-      add :name_ja, :string, null: false
+      add :name_ja, :string
       remove :background_color, :string
       remove :button_color, :string
     end


### PR DESCRIPTION
元のnameに合わせて default: null を削除