### PR TITLE
livebookのバージョンを0.9.3に固定する

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     volumes:
       - dbdata:/var/lib/postgresql/data
   livebook:
-    image: ghcr.io/livebook-dev/livebook
+    image: ghcr.io/livebook-dev/livebook:0.9.3
     environment:
       - LIVEBOOK_COOKIE=bright
       - LIVEBOOK_DEFAULT_RUNTIME=attached:bright@web:bright


### PR DESCRIPTION
タイトル通り
現時点の最新版のLivebookでは下記の現象が発生して動かない為バージョン固定をする
![image](https://github.com/bright-org/bright/assets/13599847/30280f24-3007-405a-b680-3d46ac1eed1e)
