### PR TITLE
Cloud Runサービスから外向きにリクエストできるように変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN mix release
 # the compiled release and other runtime necessities
 FROM ${RUNNER_IMAGE}
 
-RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses5 locales \
+RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 # Set the locale


### PR DESCRIPTION
Closes #509 

![image](https://github.com/bright-org/bright/assets/1233315/9948faab-625e-459f-b1fd-edd7ceb23177)

↑実際に起きていたエラーで、[Erlang/OTP的には意図した挙動](https://github.com/erlang/otp/issues/7321)。これはインフラレベルで外部への通信が拒否されていたのではなく、Dockerイメージの中にCA証明書がなかったことが原因。 `ca-certificates` をインストールすることで解決