### PR TITLE
教材・試験のモーダル表示内容をURLを指定したiframeに変更

### DIFF
--- a/assets/js/hooks/IframeSizeFitting.js
+++ b/assets/js/hooks/IframeSizeFitting.js
@@ -1,0 +1,12 @@
+// iFrameを現在のウインドウサイズに沿って拡大
+const IframeSizeFitting = {
+  mounted() {
+    const iframeWidth = 0.7 * document.documentElement.clientWidth
+    const iframeHeight = 0.7 * document.documentElement.clientHeight
+
+    this.el.style.width = iframeWidth + "px"
+    this.el.style.height = iframeHeight + "px"
+  }
+}
+
+export default IframeSizeFitting

--- a/assets/js/hooks/index.js
+++ b/assets/js/hooks/index.js
@@ -1,9 +1,11 @@
 import {SkillGem} from './SkillGem.js'
 import {GrowthGraph} from './GrowthGraph.js'
 import {DoughnutGraph} from './DoughnutGraph.js'
+import IframeSizeFitting from './IframeSizeFitting.js'
 
 export const Hooks = {
   SkillGem: SkillGem,
   GrowthGraph: GrowthGraph,
-  DoughnutGraph: DoughnutGraph
+  DoughnutGraph: DoughnutGraph,
+  IframeSizeFitting: IframeSizeFitting
 }

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -134,11 +134,7 @@
   <.header><%= @skill.name %></.header>
 
   <div class="mt-4">
-    <.link href={@skill_reference.url} target="_blank">
-      こちらの教材をご覧ください（外部サイトを開きます）。
-      <br />
-      <%= @skill_reference.url %>
-    </.link>
+    <iframe id="iframe-skill-reference" src={@skill_reference.url} phx-hook="IframeSizeFitting" />
   </div>
 </.bright_modal>
 
@@ -151,10 +147,6 @@
   <.header><%= @skill.name %></.header>
 
   <div class="mt-4">
-    <.link href={@skill_exam.url} target="_blank">
-      こちらから試験が行えます。
-      <br />
-      <%= @skill_exam.url %>
-    </.link>
+    <iframe id="iframe-skill-exam" src={@skill_exam.url} phx-hook="IframeSizeFitting" />
   </div>
 </.bright_modal>

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -511,8 +511,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       assert render(show_live) =~ skill_1.name
 
       assert show_live
-             |> element(~s(a[href="#{skill_reference.url}"][target="_blank"]))
-             |> has_element?()
+             |> has_element?(~s(iframe#iframe-skill-reference[src="#{skill_reference.url}"]))
     end
 
     @tag score: nil
@@ -553,8 +552,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       assert render(show_live) =~ skill_1.name
 
       assert show_live
-             |> element(~s(a[href="#{skill_exam.url}"][target="_blank"]))
-             |> has_element?()
+             |> has_element?(~s(iframe#iframe-skill-exam[src="#{skill_exam.url}"]))
     end
 
     @tag score: nil


### PR DESCRIPTION
## 対応内容

Closes #534 

- 学習モーダルで教材URL先の内容が、iframeで表示されること
- 試験モーダルで試験URL先の内容が、iframeで表示されること

## 画面

![sample14](https://github.com/bright-org/bright/assets/121112529/b6413714-1854-4cc0-bb75-3e865d08944f)

iFrameはウインドウの70%の高さと幅にしています。
