### PR TITLE
frontend更新

### DIFF
--- a/frontend/dist/growth_graph.html
+++ b/frontend/dist/growth_graph.html
@@ -129,7 +129,7 @@
               data-dropdown-toggle="dropdownOffset"
               data-dropdown-offset-skidding="320"
               data-dropdown-placement="bottom"
-              class="text-white bg-brightGreen-300 rounded-sm pl-3 flex items-center font-bold h-[35px]"
+              class="text-white bg-brightGreen-300 rounded pl-3 flex items-center font-bold h-[35px]"
               type="button"
             >
               <span class="min-w-[6em]">スキルパネル</span>
@@ -433,7 +433,7 @@
               data-dropdown-toggle="dropdown"
               data-dropdown-offset-skidding="20"
               data-dropdown-placement="bottom"
-              class="text-white bg-brightGreen-300 rounded-sm h-[35px] pl-3 flex items-center font-bold"
+              class="text-white bg-brightGreen-300 rounded h-[35px] pl-3 flex items-center font-bold"
               type="button"
             >
               スキルセット
@@ -485,7 +485,7 @@
               data-dropdown-toggle="dropdown2"
               data-dropdown-offset-skidding="302"
               data-dropdown-placement="bottom"
-              class="text-white bg-brightGreen-300 rounded-sm py-1.5 pl-3 flex items-center font-bold"
+              class="text-white bg-brightGreen-300 rounded py-1.5 pl-3 flex items-center font-bold"
               type="button"
             >
               <span class="min-w-[6em]">個人</span>
@@ -654,7 +654,7 @@
               data-dropdown-toggle="dropdown3"
               data-dropdown-offset-skidding="307"
               data-dropdown-placement="bottom"
-              class="text-white bg-brightGreen-300 rounded-sm py-1.5 pl-3 flex items-center font-bold"
+              class="text-white bg-brightGreen-300 rounded py-1.5 pl-3 flex items-center font-bold"
               type="button"
             >
               <span class="min-w-[6em]">チーム</span>
@@ -1116,13 +1116,15 @@
                       <button
                         id="addCompareDropdownButton"
                         data-dropdown-toggle="addCompareDropdown"
+                        data-dropdown-offset-skidding="300"
+                        data-dropdown-placement="top"
                         class="border border-brightGray-200 rounded-md py-1.5 pl-3 flex items-center"
                         type="button"
                       >
-                        <span class="min-w-[6em]">他社と比較</span>
+                        <span class="min-w-[6em]">他者と比較</span>
                         <span
                           class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-7px] before:bg-brightGray-200 before:w-[1px] before:h-[38px]"
-                          >expand_more</span
+                          >expand_less</span
                         >
                       </button>
                       <!-- 個人 menu -->
@@ -1158,35 +1160,88 @@
                                   >採用候補者</a
                                 >
                               </li>
+                              <li class="flex items-center">
+                                <button
+                                  type="button"
+                                  id="dropmenu04"
+                                  data-dropdown-offset-skidding="-130"
+                                  data-dropdown-placement="bottom"
+                                  data-dropdown-toggle="menu04"
+                                  class="text-black rounded-full w-10 h-10 inline-flex items-center justify-center"
+                                >
+                                  <span
+                                    class="material-icons text-xs text-brightGreen-900"
+                                    >more_vert</span
+                                  >
+                                </button>
+                                <!-- 関わっているユーザー Dropdown menu -->
+                                <div
+                                  id="menu04"
+                                  class="z-10 hidden bg-white rounded-lg shadow-md min-w-[286px] border border-brightGray-50"
+                                >
+                                  <ul
+                                    class="p-2 text-left text-base"
+                                    aria-labelledby="dropmenu04"
+                                  >
+                                    <li>
+                                      <a
+                                        data-modal-target="defaultModal"
+                                        data-modal-toggle="defaultModal"
+                                        href="#"
+                                        class="block px-4 py-3 hover:bg-brightGray-50 text-base hover:cursor-pointer"
+                                        >カスタムグループの編集</a
+                                      >
+                                    </li>
+                                  </ul>
+                                </div>
+                              </li>
                             </ul>
-                            <div class="overflow-hidden">
-                              <ul
-                                class="flex border-b border-brightGray-50 text-base !text-sm w-[800px]"
+                            <div
+                              class="flex border-b border-brightGray-50 min-h-[36px]"
+                            >
+                              <div class="overflow-hidden">
+                                <ul
+                                  class="overflow-hidden flex text-base !text-sm w-[800px]"
+                                >
+                                  <li
+                                    class="py-2 w-[200px] border-r border-brightGray-50"
+                                  >
+                                    キャリアの参考になる方々
+                                  </li>
+                                  <li
+                                    class="py-2 w-[200px] border-r border-brightGray-50 bg-brightGreen-50"
+                                  >
+                                    優秀なエンジニアの方々
+                                  </li>
+                                  <li
+                                    class="py-2 w-[200px] border-r border-brightGray-50"
+                                  >
+                                    カスタムグループ３
+                                  </li>
+                                  <li
+                                    class="py-2 w-[200px] border-r border-brightGray-50"
+                                  >
+                                    カスタムグループ４
+                                  </li>
+                                </ul>
+                              </div>
+                              <button
+                                class="px-1 border-l border-brightGray-50"
                               >
-                                <li
-                                  class="py-2 w-[200px] border-r border-brightGray-50"
-                                >
-                                  キャリアの参考になる方々
-                                </li>
-                                <li
-                                  class="py-2 w-[200px] border-r border-brightGray-50 bg-brightGreen-50"
-                                >
-                                  優秀なエンジニアの方々
-                                </li>
-                                <li
-                                  class="py-2 w-[200px] border-r border-brightGray-50"
-                                >
-                                  カスタムグループ３
-                                </li>
-                                <li
-                                  class="py-2 w-[200px] border-r border-brightGray-50"
-                                >
-                                  カスタムグループ４
-                                </li>
-                              </ul>
+                                <span
+                                  class="w-0 h-0 border-solid border-l-0 border-r-[10px] border-r-brightGray-300 border-t-[6px] border-t-transparent border-b-[6px] border-b-transparent inline-block"
+                                ></span>
+                              </button>
+                              <button
+                                class="px-1 border-l border-brightGray-50"
+                              >
+                                <span
+                                  class="w-0 h-0 border-solid border-r-0 border-l-[10px] border-l-brightGray-300 border-t-[6px] border-t-transparent border-b-[6px] border-b-transparent inline-block"
+                                ></span>
+                              </button>
                             </div>
 
-                            <div class="pt-3 pb-1 px-6">
+                            <div class="pt-3 pb-1 px-6 min-h-[192px]">
                               <ul class="flex flex-wrap gap-y-1">
                                 <li
                                   class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"

--- a/frontend/dist/my_team.html
+++ b/frontend/dist/my_team.html
@@ -109,7 +109,7 @@
                 data-dropdown-toggle="dropdownOffset"
                 data-dropdown-offset-skidding="320"
                 data-dropdown-placement="bottom"
-                class="text-white bg-brightGreen-300 rounded-sm pl-3 flex items-center font-bold h-[35px]"
+                class="text-white bg-brightGreen-300 rounded pl-3 flex items-center font-bold h-[35px]"
                 type="button"
               >
                 <span class="min-w-[6em]">スキルパネル</span>
@@ -413,7 +413,7 @@
                 data-dropdown-toggle="dropdown"
                 data-dropdown-offset-skidding="20"
                 data-dropdown-placement="bottom"
-                class="text-white bg-brightGreen-300 rounded-sm h-[35px] pl-3 flex items-center font-bold"
+                class="text-white bg-brightGreen-300 rounded h-[35px] pl-3 flex items-center font-bold"
                 type="button"
               >
                 スキルセット
@@ -460,197 +460,13 @@
               </div>
 
               <p class="leading-tight ml-4">対象者の<br />切り替え</p>
-              <button
-                id="dropdownDefaultButton"
-                data-dropdown-toggle="dropdown2"
-                data-dropdown-offset-skidding="302"
-                data-dropdown-placement="bottom"
-                class="text-white bg-brightGreen-300 rounded-sm py-1.5 pl-3 flex items-center font-bold"
-                type="button"
-              >
-                <span class="min-w-[6em]">個人</span>
-                <span
-                  class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-8px] before:bg-brightGray-50 before:w-[1px] before:h-[42px]"
-                  >expand_more</span
-                >
-              </button>
-              <!-- 個人 menu -->
-              <div
-                id="dropdown2"
-                class="z-10 hidden bg-whiterounded-lg shadow w-[750px]"
-              >
-                <div class="bg-white rounded-md mt-1">
-                  <div
-                    class="text-sm font-medium text-center text-brightGray-500"
-                  >
-                    <ul
-                      class="flex content-between border-b border-brightGray-200"
-                    >
-                      <li class="w-full">
-                        <a
-                          href="#"
-                          class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
-                          >気になる人</a
-                        >
-                      </li>
-                      <li class="w-full">
-                        <a
-                          href="#"
-                          class="py-3.5 w-full items-center justify-center inline-block"
-                          >チーム</a
-                        >
-                      </li>
-                      <li class="w-full">
-                        <a
-                          href="#"
-                          class="py-3.5 w-full items-center justify-center inline-block"
-                          >採用候補者</a
-                        >
-                      </li>
-                    </ul>
-                    <div class="overflow-hidden">
-                      <ul
-                        class="flex border-b border-brightGray-50 text-base !text-sm w-[800px]"
-                      >
-                        <li
-                          class="py-2 w-[200px] border-r border-brightGray-50"
-                        >
-                          キャリアの参考になる方々
-                        </li>
-                        <li
-                          class="py-2 w-[200px] border-r border-brightGray-50 bg-brightGreen-50"
-                        >
-                          優秀なエンジニアの方々
-                        </li>
-                        <li
-                          class="py-2 w-[200px] border-r border-brightGray-50"
-                        >
-                          カスタムグループ３
-                        </li>
-                        <li
-                          class="py-2 w-[200px] border-r border-brightGray-50"
-                        >
-                          カスタムグループ４
-                        </li>
-                      </ul>
-                    </div>
-
-                    <div class="pt-3 pb-1 px-6">
-                      <ul class="flex flex-wrap gap-y-1">
-                        <li
-                          class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
-                        >
-                          <a class="inline-flex items-center gap-x-6">
-                            <img
-                              class="inline-block h-10 w-10 rounded-full"
-                              src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
-                            />
-                            <div>
-                              <p>nokichi</p>
-                              <p class="text-brightGray-300">
-                                アプリエンジニア
-                              </p>
-                            </div>
-                          </a>
-                        </li>
-                        <li
-                          class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
-                        >
-                          <a class="inline-flex items-center gap-x-6">
-                            <img
-                              class="inline-block h-10 w-10 rounded-full"
-                              src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
-                            />
-                            <div>
-                              <p>nokichi</p>
-                              <p class="text-brightGray-300">
-                                アプリエンジニア
-                              </p>
-                            </div>
-                          </a>
-                        </li>
-                        <li
-                          class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
-                        >
-                          <a class="inline-flex items-center gap-x-6">
-                            <img
-                              class="inline-block h-10 w-10 rounded-full"
-                              src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
-                            />
-                            <div>
-                              <p>nokichi</p>
-                              <p class="text-brightGray-300">
-                                アプリエンジニア
-                              </p>
-                            </div>
-                          </a>
-                        </li>
-                        <li
-                          class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
-                        >
-                          <a class="inline-flex items-center gap-x-6">
-                            <img
-                              class="inline-block h-10 w-10 rounded-full"
-                              src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
-                            />
-                            <div>
-                              <p>nokichi</p>
-                              <p class="text-brightGray-300">
-                                アプリエンジニア
-                              </p>
-                            </div>
-                          </a>
-                        </li>
-                        <li
-                          class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
-                        >
-                          <a class="inline-flex items-center gap-x-6">
-                            <img
-                              class="inline-block h-10 w-10 rounded-full"
-                              src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
-                            />
-                            <div>
-                              <p>nokichi</p>
-                              <p class="text-brightGray-300">
-                                アプリエンジニア
-                              </p>
-                            </div>
-                          </a>
-                        </li>
-                      </ul>
-                    </div>
-                    <div class="flex justify-center gap-x-14 pb-3">
-                      <button
-                        type="button"
-                        class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
-                      >
-                        <span
-                          class="material-icons md-18 mr-2 text-brightGray-200"
-                          >chevron_left</span
-                        >
-                        前
-                      </button>
-                      <button
-                        type="button"
-                        class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
-                      >
-                        次
-                        <span
-                          class="material-icons md-18 ml-2 text-brightGray-900"
-                          >chevron_right</span
-                        >
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
 
               <button
                 id="dropdownDefaultButton"
                 data-dropdown-toggle="dropdown3"
                 data-dropdown-offset-skidding="307"
                 data-dropdown-placement="bottom"
-                class="text-white bg-brightGreen-300 rounded-sm py-1.5 pl-3 flex items-center font-bold"
+                class="text-white bg-brightGreen-300 rounded py-1.5 pl-3 flex items-center font-bold"
                 type="button"
               >
                 <span class="min-w-[6em]">チーム</span>
@@ -768,483 +584,21 @@
                   </div>
                 </div>
               </div>
-
-              <button
-                data-modal-target="defaultModal"
-                data-modal-toggle="defaultModal"
-                class="text-brightGreen-300 border bg-white border-brightGreen-300 rounded px-3 font-bold ml-auto"
-              >
-                チームを作る
-              </button>
-            </div>
-
-            <!-- チーム作成モーダル
-           -->
-            <!-- Main modal -->
-            <div
-              id="defaultModal"
-              tabindex="-1"
-              aria-hidden="true"
-              class="bg-brightGray-900 bg-opacity-70 fixed top-0 left-0 right-0 z-50 hidden w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-full max-h-full"
-            >
-              <div class="relative w-[1500px] max-h-full">
-                <!-- Modal content -->
-                <div class="relative bg-white rounded-sm shadow px-16 py-8">
-                  <!-- Modal header -->
-                  <h3>チームを作る</h3>
-                  <!-- Modal body -->
-                  <div class="flex pt-5">
-                    <!-- modal left -->
-                    <div
-                      class="w-[790px] pr-10 border-r border-r-brightGray-200 border-dashed"
-                    >
-                      <p class="text-base">
-                        <span class="font-bold">気になる</span
-                        >からメンバーとして追加
-                      </p>
-                      <div
-                        class="bg-white rounded border border-brightGray-100 mt-2 mb-8"
-                      >
-                        <div
-                          class="text-sm font-medium text-center text-brightGray-200"
-                        >
-                          <ul
-                            class="flex content-between border-b border-brightGray-100"
-                          >
-                            <li class="w-full">
-                              <a
-                                href="#"
-                                class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
-                                >参考になる人</a
-                              >
-                            </li>
-                            <li class="w-full">
-                              <a
-                                href="#"
-                                class="py-3.5 w-full items-center justify-center inline-block"
-                                >採用</a
-                              >
-                            </li>
-                            <li class="w-full">
-                              <a
-                                href="#"
-                                class="py-3.5 w-full items-center justify-center inline-block"
-                                >離任者</a
-                              >
-                            </li>
-                            <li class="w-full">
-                              <a
-                                href="#"
-                                class="py-3.5 w-full items-center justify-center inline-block"
-                                >スキルパネル</a
-                              >
-                            </li>
-                            <li class="w-full">
-                              <a
-                                href="#"
-                                class="py-3.5 w-full items-center justify-center inline-block"
-                                >ジョブ</a
-                              >
-                            </li>
-                          </ul>
-                          <div class="pt-3 pb-1 px-6">
-                            <ul class="flex flex-wrap gap-y-1">
-                              <li
-                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
-                              >
-                                <a class="inline-flex items-center gap-x-6">
-                                  <img
-                                    class="inline-block h-10 w-10 rounded-full"
-                                    src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
-                                  />
-                                  <div>
-                                    <p>nokichi</p>
-                                    <p class="text-brightGray-300">
-                                      アプリエンジニア
-                                    </p>
-                                  </div>
-                                </a>
-                              </li>
-                              <li
-                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
-                              >
-                                <a class="inline-flex items-center gap-x-6">
-                                  <img
-                                    class="inline-block h-10 w-10 rounded-full"
-                                    src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
-                                  />
-                                  <div>
-                                    <p>nokichi</p>
-                                    <p class="text-brightGray-300">
-                                      アプリエンジニア
-                                    </p>
-                                  </div>
-                                </a>
-                              </li>
-                              <li
-                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
-                              >
-                                <a class="inline-flex items-center gap-x-6">
-                                  <img
-                                    class="inline-block h-10 w-10 rounded-full"
-                                    src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
-                                  />
-                                  <div>
-                                    <p>nokichi</p>
-                                    <p class="text-brightGray-300">
-                                      アプリエンジニア
-                                    </p>
-                                  </div>
-                                </a>
-                              </li>
-                              <li
-                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
-                              >
-                                <a class="inline-flex items-center gap-x-6">
-                                  <img
-                                    class="inline-block h-10 w-10 rounded-full"
-                                    src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
-                                  />
-                                  <div>
-                                    <p>nokichi</p>
-                                    <p class="text-brightGray-300">
-                                      アプリエンジニア
-                                    </p>
-                                  </div>
-                                </a>
-                              </li>
-                              <li
-                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
-                              >
-                                <a class="inline-flex items-center gap-x-6">
-                                  <img
-                                    class="inline-block h-10 w-10 rounded-full"
-                                    src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
-                                  />
-                                  <div>
-                                    <p>nokichi</p>
-                                    <p class="text-brightGray-300">
-                                      アプリエンジニア
-                                    </p>
-                                  </div>
-                                </a>
-                              </li>
-                            </ul>
-                          </div>
-                          <div class="flex justify-center gap-x-14 pb-3">
-                            <button
-                              type="button"
-                              class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
-                            >
-                              <span
-                                class="material-icons md-18 mr-2 text-brightGray-200"
-                                >chevron_left</span
-                              >
-                              前
-                            </button>
-                            <button
-                              type="button"
-                              class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
-                            >
-                              次
-                              <span
-                                class="material-icons md-18 ml-2 text-brightGray-900"
-                                >chevron_right</span
-                              >
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                      <p class="text-base">
-                        <span class="font-bold">関わっているチーム</span
-                        >からサブチームとして追加
-                      </p>
-                      <div
-                        class="bg-white rounded mt-2 mb-6 border border-brightGray-100"
-                      >
-                        <div
-                          class="text-sm font-medium text-center text-brightGray-200"
-                        >
-                          <ul
-                            class="flex content-between border-b border-brightGray-100"
-                          >
-                            <li class="w-full">
-                              <a
-                                href="#"
-                                class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
-                                >所属チーム</a
-                              >
-                            </li>
-                            <li class="w-full">
-                              <a
-                                href="#"
-                                class="py-3.5 w-full items-center justify-center inline-block"
-                                >管轄チーム</a
-                              >
-                            </li>
-                          </ul>
-                          <div class="pt-4 pb-1 px-6">
-                            <ul class="flex gap-y-1.5 flex-col">
-                              <li
-                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
-                              >
-                                <span
-                                  class="text-base !text-white bg-lapislazuli-900 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
-                                  >E</span
-                                >
-                                Elixir Fukuoka
-                              </li>
-
-                              <li
-                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
-                              >
-                                <span
-                                  class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
-                                  >圧</span
-                                >
-                                圧倒的開発スピード
-                              </li>
-
-                              <li
-                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
-                              >
-                                <span
-                                  class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
-                                  >S</span
-                                >
-                                S社案件開発
-                              </li>
-                              <li
-                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
-                              >
-                                <span
-                                  class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
-                                  >D</span
-                                >
-                                D社スマホアプリプロジェクト
-                              </li>
-                              <li
-                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
-                              >
-                                <span
-                                  class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
-                                  >A</span
-                                >
-                                A社スマホアプリプロジェクト
-                              </li>
-                            </ul>
-                          </div>
-                          <div class="flex justify-center gap-x-14 pb-3">
-                            <button
-                              type="button"
-                              class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
-                            >
-                              <span
-                                class="material-icons md-18 mr-2 text-brightGray-200"
-                                >chevron_left</span
-                              >
-                              前
-                            </button>
-                            <button
-                              type="button"
-                              class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
-                            >
-                              次
-                              <span
-                                class="material-icons md-18 ml-2 text-brightGray-900"
-                                >chevron_right</span
-                              >
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                      <div>
-                        <p class="pb-2 text-base">
-                          <span class="font-bold">ハンドル名</span>または<span
-                            class="font-bold"
-                            >メールアドレス</span
-                          >からメンバーとして追加
-                        </p>
-
-                        <input
-                          type="autocomplete"
-                          placeholder="ハンドル名またはメールアドレスを入力してください"
-                          class="px-5 py-2 border border-brightGray-100 rounded-sm flex-1 w-[390px]"
-                        />
-
-                        <button
-                          class="text-sm font-bold px-5 py-2 rounded border border-base ml-2.5"
-                        >
-                          追加
-                        </button>
-                      </div>
-                    </div>
-                    <!-- modal-right -->
-                    <div class="w-[580px] pl-10 flex flex-col justify-between">
-                      <div>
-                        <h5 class="text-[20px]">新しいチーム</h5>
-
-                        <div class="bg-brightGray-10 rounded-sm px-10 py-6">
-                          <dl class="flex flex-wrap w-full">
-                            <dt
-                              class="font-bold w-[100px] flex items-center mb-10 text-base"
-                            >
-                              チーム名
-                            </dt>
-                            <dd class="w-[340px] mb-10">
-                              <input
-                                type="text"
-                                placeholder="新しいチーム名を入力してください"
-                                class="px-5 py-2 border border-brightGray-100 rounded-sm flex-1 w-full"
-                              />
-                            </dd>
-                            <dt class="font-bold w-[100px] mb-10 text-base">
-                              メンバー
-                            </dt>
-                            <dd class="w-[340px] mb-10">
-                              <ul class="flex flex-wrap gap-y-1">
-                                <li
-                                  class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
-                                >
-                                  <a
-                                    class="inline-flex items-center gap-x-6 w-full"
-                                  >
-                                    <img
-                                      class="inline-block h-10 w-10 rounded-full"
-                                      src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
-                                    />
-                                    <div class="flex-auto">
-                                      <p>nokichi</p>
-                                      <p class="text-brightGray-300">
-                                        アプリエンジニア
-                                      </p>
-                                    </div>
-                                    <button class="mx-4">
-                                      <span
-                                        class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
-                                        >close</span
-                                      >
-                                    </button>
-                                  </a>
-                                </li>
-                                <li
-                                  class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
-                                >
-                                  <a
-                                    class="inline-flex items-center gap-x-6 w-full"
-                                  >
-                                    <img
-                                      class="inline-block h-10 w-10 rounded-full"
-                                      src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
-                                    />
-                                    <div class="flex-auto">
-                                      <p>nokichi</p>
-                                      <p class="text-brightGray-300">
-                                        アプリエンジニア
-                                      </p>
-                                    </div>
-                                    <button class="mx-4">
-                                      <span
-                                        class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
-                                        >close</span
-                                      >
-                                    </button>
-                                  </a>
-                                </li>
-                                <li
-                                  class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
-                                >
-                                  <a
-                                    class="inline-flex items-center gap-x-6 w-full"
-                                  >
-                                    <img
-                                      class="inline-block h-10 w-10 rounded-full"
-                                      src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
-                                    />
-                                    <div class="flex-auto">
-                                      <p>nokichi</p>
-                                      <p class="text-brightGray-300">
-                                        アプリエンジニア
-                                      </p>
-                                    </div>
-                                    <button class="mx-4">
-                                      <span
-                                        class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
-                                        >close</span
-                                      >
-                                    </button>
-                                  </a>
-                                </li>
-                              </ul>
-                            </dd>
-                            <dt class="font-bold w-[100px] mb-10 text-base">
-                              サブチーム
-                            </dt>
-                            <dd class="w-[340px]">
-                              <ul class="flex gap-y-1.5 flex-col">
-                                <li
-                                  class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded justify-between"
-                                >
-                                  <span
-                                    class="text-base !text-white bg-lapislazuli-900 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
-                                    >E</span
-                                  >
-                                  <p class="flex-1">Elixir Fukuoka</p>
-                                  <button class="mx-4">
-                                    <span
-                                      class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
-                                      >close</span
-                                    >
-                                  </button>
-                                </li>
-
-                                <li
-                                  class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded justify-between"
-                                >
-                                  <span
-                                    class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
-                                    >圧</span
-                                  >
-                                  <p class="flex-1">圧倒的開発スピード</p>
-                                  <button class="mx-4">
-                                    <span
-                                      class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
-                                      >close</span
-                                    >
-                                  </button>
-                                </li>
-
-                                <li
-                                  class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded justify-between"
-                                >
-                                  <span
-                                    class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
-                                    >S</span
-                                  >
-                                  <p class="flex-1">S社案件開発</p>
-                                  <button class="mx-4">
-                                    <span
-                                      class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
-                                      >close</span
-                                    >
-                                  </button>
-                                </li>
-                              </ul>
-                            </dd>
-                          </dl>
-                        </div>
-                      </div>
-
-                      <div class="flex justify-end gap-x-4">
-                        <button
-                          class="text-base font-bold px-4 py-3 rounded text-white bg-base"
-                        >
-                          チームを作成し、上記メンバーに招待を送る
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
+              <div class="flex ml-auto gap-x-4">
+                <button
+                  data-modal-target="defaultModal"
+                  data-modal-toggle="defaultModal"
+                  class="text-brightGray-900 border bg-white border-brightGray-900 rounded px-3 font-bold ml-auto"
+                >
+                  人材チームを作る
+                </button>
+                <button
+                  data-modal-target="defaultModal"
+                  data-modal-toggle="defaultModal"
+                  class="text-white border bg-brightGray-900 rounded px-3 font-bold"
+                >
+                  チームを作る
+                </button>
               </div>
             </div>
 
@@ -1384,17 +738,34 @@
           <!-- card -->
           <div class="ml-24 p-6">
             <!-- チームタイトル -->
-            <div class="flex items-center">
+            <div class="flex gap-x-4">
               <h3>
                 <span
                   class="material-icons !text-xl text-white bg-brightGreen-300 rounded-full !inline-flex w-8 h-8 mr-2.5 !items-center !justify-center"
                   >group</span
                 >DMC Ph3
               </h3>
-              <label
-                class="text-white bg-lapislazuli-300 ml-8 rounded-md font-bold px-3 inline-flex items-center h-7"
-                >プライマリ</label
+              <button
+                class="bg-white border border-brightGreen-300 rounded px-1 h-8 flex items-center mt-auto mb-1"
               >
+                <span class="material-icons text-brightGreen-300">star</span>
+              </button>
+              <div class="flex ml-auto gap-x-4">
+                <button
+                  data-modal-target="teamUpdateModal"
+                  data-modal-toggle="teamUpdateModal"
+                  class="text-brightGray-900 border bg-white border-brightGray-900 rounded px-3 font-bold ml-auto"
+                >
+                  編集
+                </button>
+                <button
+                  data-modal-target="backupModal"
+                  data-modal-toggle="backupModal"
+                  class="text-white border bg-brightGray-900 rounded px-3 font-bold"
+                >
+                  人材チームにバックアップしてもらう
+                </button>
+              </div>
             </div>
             <!-- チームメンバー -->
             <div class="flex gap-8 pt-4 flex-wrap">
@@ -1673,184 +1044,994 @@
                 </div>
               </div>
             </div>
-            <!-- チームタイトル -->
-            <div class="flex pt-20 items-center">
-              <h3>
-                <span
-                  class="material-icons !text-xl text-white bg-brightGreen-300 rounded-full !inline-flex w-8 h-8 mr-2.5 !items-center !justify-center"
-                  >group</span
-                >DMC Ph2 インフラ
-              </h3>
-              <button
-                class="text-lapislazuli-300 border border-lapislazuli-300 ml-8 rounded-md font-bold px-3 h-7 inline-flex items-center"
-              >
-                プライマリに設定
-              </button>
+          </div>
+
+          <!-- チーム作成モーダル-->
+          <div
+            id="defaultModal"
+            tabindex="-1"
+            aria-hidden="true"
+            class="bg-brightGray-900 bg-opacity-70 fixed top-0 left-0 right-0 z-50 hidden w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-full max-h-full"
+          >
+            <div class="relative w-[1500px] max-h-full">
+              <!-- Modal content -->
+              <div class="relative bg-white rounded-sm shadow px-16 py-8">
+                <!-- Modal header -->
+                <h3>チームを作る</h3>
+                <!-- Modal body -->
+                <div class="flex pt-5">
+                  <!-- modal left -->
+                  <div
+                    class="w-[790px] pr-10 border-r border-r-brightGray-200 border-dashed"
+                  >
+                    <p class="text-base">
+                      <span class="font-bold">気になる</span
+                      >からメンバーとして追加
+                    </p>
+                    <div
+                      class="bg-white rounded border border-brightGray-100 mt-2 mb-8"
+                    >
+                      <div
+                        class="text-sm font-medium text-center text-brightGray-200"
+                      >
+                        <ul
+                          class="flex content-between border-b border-brightGray-100"
+                        >
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
+                              >参考になる人</a
+                            >
+                          </li>
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block"
+                              >採用</a
+                            >
+                          </li>
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block"
+                              >離任者</a
+                            >
+                          </li>
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block"
+                              >スキルパネル</a
+                            >
+                          </li>
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block"
+                              >ジョブ</a
+                            >
+                          </li>
+                        </ul>
+                        <div class="pt-3 pb-1 px-6">
+                          <ul class="flex flex-wrap gap-y-1">
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
+                            >
+                              <a class="inline-flex items-center gap-x-6">
+                                <img
+                                  class="inline-block h-10 w-10 rounded-full"
+                                  src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                />
+                                <div>
+                                  <p>nokichi</p>
+                                  <p class="text-brightGray-300">
+                                    アプリエンジニア
+                                  </p>
+                                </div>
+                              </a>
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
+                            >
+                              <a class="inline-flex items-center gap-x-6">
+                                <img
+                                  class="inline-block h-10 w-10 rounded-full"
+                                  src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                />
+                                <div>
+                                  <p>nokichi</p>
+                                  <p class="text-brightGray-300">
+                                    アプリエンジニア
+                                  </p>
+                                </div>
+                              </a>
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
+                            >
+                              <a class="inline-flex items-center gap-x-6">
+                                <img
+                                  class="inline-block h-10 w-10 rounded-full"
+                                  src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                />
+                                <div>
+                                  <p>nokichi</p>
+                                  <p class="text-brightGray-300">
+                                    アプリエンジニア
+                                  </p>
+                                </div>
+                              </a>
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
+                            >
+                              <a class="inline-flex items-center gap-x-6">
+                                <img
+                                  class="inline-block h-10 w-10 rounded-full"
+                                  src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                />
+                                <div>
+                                  <p>nokichi</p>
+                                  <p class="text-brightGray-300">
+                                    アプリエンジニア
+                                  </p>
+                                </div>
+                              </a>
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
+                            >
+                              <a class="inline-flex items-center gap-x-6">
+                                <img
+                                  class="inline-block h-10 w-10 rounded-full"
+                                  src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                />
+                                <div>
+                                  <p>nokichi</p>
+                                  <p class="text-brightGray-300">
+                                    アプリエンジニア
+                                  </p>
+                                </div>
+                              </a>
+                            </li>
+                          </ul>
+                        </div>
+                        <div class="flex justify-center gap-x-14 pb-3">
+                          <button
+                            type="button"
+                            class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                          >
+                            <span
+                              class="material-icons md-18 mr-2 text-brightGray-200"
+                              >chevron_left</span
+                            >
+                            前
+                          </button>
+                          <button
+                            type="button"
+                            class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                          >
+                            次
+                            <span
+                              class="material-icons md-18 ml-2 text-brightGray-900"
+                              >chevron_right</span
+                            >
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <p class="text-base">
+                      <span class="font-bold">関わっているチーム</span
+                      >からサブチームとして追加
+                    </p>
+                    <div
+                      class="bg-white rounded mt-2 mb-6 border border-brightGray-100"
+                    >
+                      <div
+                        class="text-sm font-medium text-center text-brightGray-200"
+                      >
+                        <ul
+                          class="flex content-between border-b border-brightGray-100"
+                        >
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
+                              >所属チーム</a
+                            >
+                          </li>
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block"
+                              >管轄チーム</a
+                            >
+                          </li>
+                        </ul>
+                        <div class="pt-4 pb-1 px-6">
+                          <ul class="flex gap-y-1.5 flex-col">
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                            >
+                              <span
+                                class="text-base !text-white bg-lapislazuli-900 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                >E</span
+                              >
+                              Elixir Fukuoka
+                            </li>
+
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                            >
+                              <span
+                                class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                >圧</span
+                              >
+                              圧倒的開発スピード
+                            </li>
+
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                            >
+                              <span
+                                class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                >S</span
+                              >
+                              S社案件開発
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                            >
+                              <span
+                                class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                >D</span
+                              >
+                              D社スマホアプリプロジェクト
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                            >
+                              <span
+                                class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                >A</span
+                              >
+                              A社スマホアプリプロジェクト
+                            </li>
+                          </ul>
+                        </div>
+                        <div class="flex justify-center gap-x-14 pb-3">
+                          <button
+                            type="button"
+                            class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                          >
+                            <span
+                              class="material-icons md-18 mr-2 text-brightGray-200"
+                              >chevron_left</span
+                            >
+                            前
+                          </button>
+                          <button
+                            type="button"
+                            class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                          >
+                            次
+                            <span
+                              class="material-icons md-18 ml-2 text-brightGray-900"
+                              >chevron_right</span
+                            >
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <div>
+                      <p class="pb-2 text-base">
+                        <span class="font-bold">ハンドル名</span>または<span
+                          class="font-bold"
+                          >メールアドレス</span
+                        >からメンバーとして追加
+                      </p>
+
+                      <input
+                        type="autocomplete"
+                        placeholder="ハンドル名またはメールアドレスを入力してください"
+                        class="px-5 py-2 border border-brightGray-100 rounded-sm flex-1 w-[390px]"
+                      />
+
+                      <button
+                        class="text-sm font-bold px-5 py-2 rounded border border-base ml-2.5"
+                      >
+                        追加
+                      </button>
+                    </div>
+                  </div>
+                  <!-- modal-right -->
+                  <div class="w-[580px] pl-10 flex flex-col justify-between">
+                    <div>
+                      <h5 class="text-[20px]">新しいチーム</h5>
+
+                      <div class="bg-brightGray-10 rounded-sm px-10 py-6">
+                        <dl class="flex flex-wrap w-full">
+                          <dt
+                            class="font-bold w-[100px] flex items-center mb-10 text-base"
+                          >
+                            チーム名
+                          </dt>
+                          <dd class="w-[340px] mb-6">
+                            <input
+                              type="text"
+                              placeholder="新しいチーム名を入力してください"
+                              class="px-5 py-2 border border-brightGray-100 rounded-sm flex-1 w-full"
+                            />
+                          </dd>
+                          <dt class="font-bold w-[100px] mb-10 text-base">
+                            メンバー
+                          </dt>
+                          <dd class="w-[340px] mb-6">
+                            <ul class="flex flex-wrap gap-y-1">
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
+                              >
+                                <a
+                                  class="inline-flex items-center gap-x-6 w-full"
+                                >
+                                  <img
+                                    class="inline-block h-10 w-10 rounded-full"
+                                    src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                  />
+                                  <div class="flex-auto">
+                                    <p>nokichi</p>
+                                    <p class="text-brightGray-300">
+                                      アプリエンジニア
+                                    </p>
+                                  </div>
+                                  <button class="mx-4">
+                                    <span
+                                      class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                      >close</span
+                                    >
+                                  </button>
+                                </a>
+                              </li>
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
+                              >
+                                <a
+                                  class="inline-flex items-center gap-x-6 w-full"
+                                >
+                                  <img
+                                    class="inline-block h-10 w-10 rounded-full"
+                                    src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                  />
+                                  <div class="flex-auto">
+                                    <p>nokichi</p>
+                                    <p class="text-brightGray-300">
+                                      アプリエンジニア
+                                    </p>
+                                  </div>
+                                  <button class="mx-4">
+                                    <span
+                                      class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                      >close</span
+                                    >
+                                  </button>
+                                </a>
+                              </li>
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
+                              >
+                                <a
+                                  class="inline-flex items-center gap-x-6 w-full"
+                                >
+                                  <img
+                                    class="inline-block h-10 w-10 rounded-full"
+                                    src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                  />
+                                  <div class="flex-auto">
+                                    <p>nokichi</p>
+                                    <p class="text-brightGray-300">
+                                      アプリエンジニア
+                                    </p>
+                                  </div>
+                                  <button class="mx-4">
+                                    <span
+                                      class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                      >close</span
+                                    >
+                                  </button>
+                                </a>
+                              </li>
+                            </ul>
+                          </dd>
+                          <dt class="font-bold w-[100px] mb-10 text-base">
+                            サブチーム
+                          </dt>
+                          <dd class="w-[340px] mb-6">
+                            <ul class="flex gap-y-1.5 flex-col">
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded justify-between"
+                              >
+                                <span
+                                  class="text-base !text-white bg-lapislazuli-900 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                  >E</span
+                                >
+                                <p class="flex-1">Elixir Fukuoka</p>
+                                <button class="mx-4">
+                                  <span
+                                    class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                    >close</span
+                                  >
+                                </button>
+                              </li>
+
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded justify-between"
+                              >
+                                <span
+                                  class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                  >圧</span
+                                >
+                                <p class="flex-1">圧倒的開発スピード</p>
+                                <button class="mx-4">
+                                  <span
+                                    class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                    >close</span
+                                  >
+                                </button>
+                              </li>
+
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded justify-between"
+                              >
+                                <span
+                                  class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                  >S</span
+                                >
+                                <p class="flex-1">S社案件開発</p>
+                                <button class="mx-4">
+                                  <span
+                                    class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                    >close</span
+                                  >
+                                </button>
+                              </li>
+                            </ul>
+                          </dd>
+                          <dt class="font-bold w-[100px] mb-10 text-base">
+                            人材チーム
+                          </dt>
+                          <dd class="w-[340px]">
+                            <input
+                              type="checkbox"
+                              value=""
+                              class="coustom-checkbox w-4 h-4 ml-1"
+                            />
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+
+                    <div class="flex justify-end gap-x-4">
+                      <button
+                        class="text-base font-bold px-4 py-3 rounded text-white bg-base"
+                      >
+                        チームを作成し、上記メンバーに招待を送る
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
-            <!-- チームメンバー -->
-            <div class="flex gap-8 pt-4 flex-wrap">
-              <!-- 　メンバーデータ -->
-              <div class="flex w-[474px] shadow flex-col bg-white">
-                <ul
-                  class="flex text-md font-bold text-brightGray-500 bg-skillGem-50 content-between w-full"
-                >
-                  <li class="bg-white text-base w-full">
-                    <a
-                      href="#"
-                      class="w-full py-3 text-center inline-block"
-                      aria-current="page"
-                      >レベル1 <span class="text-xl ml-4">52</span>％</a
-                    >
-                  </li>
-                  <li class="w-full">
-                    <a href="#" class="w-full py-3 text-center inline-block"
-                      >レベル2 <span class="text-xl ml-4">52</span>％</a
-                    >
-                  </li>
-                  <li class="w-full">
-                    <a href="#" class="w-full py-3 text-center inline-block"
-                      >レベル3 <span class="text-xl ml-4">52</span>％</a
-                    >
-                  </li>
-                </ul>
-                <div class="flex justify-between px-6 pt-1 items-center">
-                  <div class="text-2xl font-bold">piacere</div>
+          </div>
+
+          <!-- チーム編集 modal -->
+          <div
+            id="teamUpdateModal"
+            tabindex="-1"
+            aria-hidden="true"
+            class="bg-brightGray-900 bg-opacity-70 fixed top-0 left-0 right-0 z-50 hidden w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-full max-h-full"
+          >
+            <div class="relative w-[1500px] max-h-full">
+              <!-- Modal content -->
+              <div class="relative bg-white rounded-sm shadow px-16 py-8">
+                <!-- Modal header -->
+                <h3>管理しているチームの編集</h3>
+                <!-- Modal body -->
+                <div class="flex pt-5">
+                  <!-- modal left -->
                   <div
-                    class="bg-test bg-contain h-20 w-20 mt-4"
-                    style="
-                      background-image: url('./images/sample/sample-image.png');
-                    "
-                  ></div>
-                </div>
-                <div class="w-[400px] flex justify-center mx-auto">
-                  <canvas id="radarChart6" width="300" height="300"></canvas>
-                </div>
-                <div class="p-6 pt-0 flex justify-between">
-                  <button
-                    class="text-sm font-bold px-5 py-3 rounded text-white bg-base"
+                    class="w-[790px] pr-10 border-r border-r-brightGray-200 border-dashed"
                   >
-                    1on1に誘う
-                  </button>
-                  <button
-                    class="text-sm font-bold px-5 py-3 rounded border border-base"
-                  >
-                    この人と比較
-                  </button>
-                  <button
-                    class="text-sm font-bold px-5 py-3 rounded border border-base"
-                  >
-                    スキルアップ確認
-                  </button>
+                    <p class="text-base">
+                      <span class="font-bold">気になる</span
+                      >からメンバーとして追加
+                    </p>
+                    <div
+                      class="bg-white rounded border border-brightGray-100 mt-2 mb-8"
+                    >
+                      <div
+                        class="text-sm font-medium text-center text-brightGray-200"
+                      >
+                        <ul
+                          class="flex content-between border-b border-brightGray-100"
+                        >
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
+                              >参考になる人</a
+                            >
+                          </li>
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block"
+                              >採用</a
+                            >
+                          </li>
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block"
+                              >離任者</a
+                            >
+                          </li>
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block"
+                              >スキルパネル</a
+                            >
+                          </li>
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block"
+                              >ジョブ</a
+                            >
+                          </li>
+                        </ul>
+                        <div class="pt-3 pb-1 px-6">
+                          <ul class="flex flex-wrap gap-y-1">
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
+                            >
+                              <a class="inline-flex items-center gap-x-6">
+                                <img
+                                  class="inline-block h-10 w-10 rounded-full"
+                                  src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                />
+                                <div>
+                                  <p>nokichi</p>
+                                  <p class="text-brightGray-300">
+                                    アプリエンジニア
+                                  </p>
+                                </div>
+                              </a>
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
+                            >
+                              <a class="inline-flex items-center gap-x-6">
+                                <img
+                                  class="inline-block h-10 w-10 rounded-full"
+                                  src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                />
+                                <div>
+                                  <p>nokichi</p>
+                                  <p class="text-brightGray-300">
+                                    アプリエンジニア
+                                  </p>
+                                </div>
+                              </a>
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
+                            >
+                              <a class="inline-flex items-center gap-x-6">
+                                <img
+                                  class="inline-block h-10 w-10 rounded-full"
+                                  src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                />
+                                <div>
+                                  <p>nokichi</p>
+                                  <p class="text-brightGray-300">
+                                    アプリエンジニア
+                                  </p>
+                                </div>
+                              </a>
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
+                            >
+                              <a class="inline-flex items-center gap-x-6">
+                                <img
+                                  class="inline-block h-10 w-10 rounded-full"
+                                  src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                />
+                                <div>
+                                  <p>nokichi</p>
+                                  <p class="text-brightGray-300">
+                                    アプリエンジニア
+                                  </p>
+                                </div>
+                              </a>
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
+                            >
+                              <a class="inline-flex items-center gap-x-6">
+                                <img
+                                  class="inline-block h-10 w-10 rounded-full"
+                                  src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                />
+                                <div>
+                                  <p>nokichi</p>
+                                  <p class="text-brightGray-300">
+                                    アプリエンジニア
+                                  </p>
+                                </div>
+                              </a>
+                            </li>
+                          </ul>
+                        </div>
+                        <div class="flex justify-center gap-x-14 pb-3">
+                          <button
+                            type="button"
+                            class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                          >
+                            <span
+                              class="material-icons md-18 mr-2 text-brightGray-200"
+                              >chevron_left</span
+                            >
+                            前
+                          </button>
+                          <button
+                            type="button"
+                            class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                          >
+                            次
+                            <span
+                              class="material-icons md-18 ml-2 text-brightGray-900"
+                              >chevron_right</span
+                            >
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <p class="text-base">
+                      <span class="font-bold">関わっているチーム</span
+                      >からサブチームとして追加
+                    </p>
+                    <div
+                      class="bg-white rounded mt-2 mb-6 border border-brightGray-100"
+                    >
+                      <div
+                        class="text-sm font-medium text-center text-brightGray-200"
+                      >
+                        <ul
+                          class="flex content-between border-b border-brightGray-100"
+                        >
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
+                              >所属チーム</a
+                            >
+                          </li>
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block"
+                              >管轄チーム</a
+                            >
+                          </li>
+                        </ul>
+                        <div class="pt-4 pb-1 px-6">
+                          <ul class="flex gap-y-1.5 flex-col">
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                            >
+                              <span
+                                class="text-base !text-white bg-lapislazuli-900 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                >E</span
+                              >
+                              Elixir Fukuoka
+                            </li>
+
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                            >
+                              <span
+                                class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                >圧</span
+                              >
+                              圧倒的開発スピード
+                            </li>
+
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                            >
+                              <span
+                                class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                >S</span
+                              >
+                              S社案件開発
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                            >
+                              <span
+                                class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                >D</span
+                              >
+                              D社スマホアプリプロジェクト
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                            >
+                              <span
+                                class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                >A</span
+                              >
+                              A社スマホアプリプロジェクト
+                            </li>
+                          </ul>
+                        </div>
+                        <div class="flex justify-center gap-x-14 pb-3">
+                          <button
+                            type="button"
+                            class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                          >
+                            <span
+                              class="material-icons md-18 mr-2 text-brightGray-200"
+                              >chevron_left</span
+                            >
+                            前
+                          </button>
+                          <button
+                            type="button"
+                            class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                          >
+                            次
+                            <span
+                              class="material-icons md-18 ml-2 text-brightGray-900"
+                              >chevron_right</span
+                            >
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <div>
+                      <p class="pb-2 text-base">
+                        <span class="font-bold">ハンドル名</span>または<span
+                          class="font-bold"
+                          >メールアドレス</span
+                        >からメンバーとして追加
+                      </p>
+
+                      <input
+                        type="autocomplete"
+                        placeholder="ハンドル名またはメールアドレスを入力してください"
+                        class="px-5 py-2 border border-brightGray-100 rounded-sm flex-1 w-[390px]"
+                      />
+
+                      <button
+                        class="text-sm font-bold px-5 py-2 rounded border border-base ml-2.5"
+                      >
+                        追加
+                      </button>
+                    </div>
+                  </div>
+                  <!-- modal-right -->
+                  <div class="w-[580px] pl-10 flex flex-col justify-between">
+                    <div>
+                      <div class="flex justify-between pb-2">
+                        <h5 class="text-[20px]">編集後のチーム</h5>
+                        <button
+                          class="text-brightGray-900 border bg-white border-brightGray-900 rounded px-3 py-2 font-bold ml-auto"
+                        >
+                          チームを削除する
+                        </button>
+                      </div>
+
+                      <div class="bg-brightGray-10 rounded-sm px-10 py-6">
+                        <dl class="flex flex-wrap w-full">
+                          <dt
+                            class="font-bold w-[100px] flex items-center mb-10 text-base"
+                          >
+                            チーム名
+                          </dt>
+                          <dd class="w-[340px] mb-6">
+                            <input
+                              type="text"
+                              placeholder="新しいチーム名を入力してください"
+                              class="px-5 py-2 border border-brightGray-100 rounded-sm flex-1 w-full"
+                            />
+                          </dd>
+                          <dt class="font-bold w-[100px] mb-10 text-base">
+                            メンバー
+                          </dt>
+                          <dd class="w-[340px] mb-6">
+                            <ul class="flex flex-wrap gap-y-1">
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
+                              >
+                                <a
+                                  class="inline-flex items-center gap-x-6 w-full"
+                                >
+                                  <img
+                                    class="inline-block h-10 w-10 rounded-full"
+                                    src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                  />
+                                  <div class="flex-auto">
+                                    <p>nokichi</p>
+                                    <p class="text-brightGray-300">
+                                      アプリエンジニア
+                                    </p>
+                                  </div>
+                                  <button class="mx-4">
+                                    <span
+                                      class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                      >close</span
+                                    >
+                                  </button>
+                                </a>
+                              </li>
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
+                              >
+                                <a
+                                  class="inline-flex items-center gap-x-6 w-full"
+                                >
+                                  <img
+                                    class="inline-block h-10 w-10 rounded-full"
+                                    src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                  />
+                                  <div class="flex-auto">
+                                    <p>nokichi</p>
+                                    <p class="text-brightGray-300">
+                                      アプリエンジニア
+                                    </p>
+                                  </div>
+                                  <button class="mx-4">
+                                    <span
+                                      class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                      >close</span
+                                    >
+                                  </button>
+                                </a>
+                              </li>
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
+                              >
+                                <a
+                                  class="inline-flex items-center gap-x-6 w-full"
+                                >
+                                  <img
+                                    class="inline-block h-10 w-10 rounded-full"
+                                    src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                  />
+                                  <div class="flex-auto">
+                                    <p>nokichi</p>
+                                    <p class="text-brightGray-300">
+                                      アプリエンジニア
+                                    </p>
+                                  </div>
+                                  <button class="mx-4">
+                                    <span
+                                      class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                      >close</span
+                                    >
+                                  </button>
+                                </a>
+                              </li>
+                            </ul>
+                          </dd>
+                          <dt class="font-bold w-[100px] mb-10 text-base">
+                            サブチーム
+                          </dt>
+                          <dd class="w-[340px] mb-6">
+                            <ul class="flex gap-y-1.5 flex-col">
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded justify-between"
+                              >
+                                <span
+                                  class="text-base !text-white bg-lapislazuli-900 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                  >E</span
+                                >
+                                <p class="flex-1">Elixir Fukuoka</p>
+                                <button class="mx-4">
+                                  <span
+                                    class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                    >close</span
+                                  >
+                                </button>
+                              </li>
+
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded justify-between"
+                              >
+                                <span
+                                  class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                  >圧</span
+                                >
+                                <p class="flex-1">圧倒的開発スピード</p>
+                                <button class="mx-4">
+                                  <span
+                                    class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                    >close</span
+                                  >
+                                </button>
+                              </li>
+
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded justify-between"
+                              >
+                                <span
+                                  class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                  >S</span
+                                >
+                                <p class="flex-1">S社案件開発</p>
+                                <button class="mx-4">
+                                  <span
+                                    class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                    >close</span
+                                  >
+                                </button>
+                              </li>
+                            </ul>
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+
+                    <div class="flex justify-end gap-x-4">
+                      <button
+                        class="text-base font-bold px-4 py-3 rounded text-white bg-base"
+                      >
+                        チームを編集し、上記メンバーに招待を送る
+                      </button>
+                    </div>
+                  </div>
                 </div>
               </div>
+            </div>
+          </div>
 
-              <!-- 　メンバーデータ -->
-              <div class="flex w-[474px] shadow flex-col bg-white">
-                <ul
-                  class="flex text-md font-bold text-brightGray-500 bg-skillGem-50 content-between w-full"
+          <!-- バックアップしてもらうModal -->
+          <div
+            id="backupModal"
+            tabindex="-1"
+            aria-hidden="true"
+            class="bg-brightGray-900 bg-opacity-70 fixed top-0 left-0 right-0 z-50 hidden w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-full max-h-full"
+          >
+            <div class="relative">
+              <!-- close button -->
+              <button class="absolute right-3 top-3 z-10">
+                <span class="material-icons !text-xl text-brightGray-900"
+                  >close</span
                 >
-                  <li class="bg-white text-base w-full">
-                    <a
-                      href="#"
-                      class="w-full py-3 text-center inline-block"
-                      aria-current="page"
-                      >レベル1 <span class="text-xl ml-4">52</span>％</a
-                    >
-                  </li>
-                  <li class="w-full">
-                    <a href="#" class="w-full py-3 text-center inline-block"
-                      >レベル2 <span class="text-xl ml-4">52</span>％</a
-                    >
-                  </li>
-                  <li class="w-full">
-                    <a href="#" class="w-full py-3 text-center inline-block"
-                      >レベル3 <span class="text-xl ml-4">52</span>％</a
-                    >
-                  </li>
-                </ul>
-                <div class="flex justify-between px-6 pt-1 items-center">
-                  <div class="text-2xl font-bold">piacere</div>
-                  <div
-                    class="bg-test bg-contain h-20 w-20 mt-4"
-                    style="
-                      background-image: url('./images/sample/sample-image.png');
-                    "
-                  ></div>
-                </div>
-                <div class="w-[400px] flex justify-center mx-auto">
-                  <canvas id="radarChart7" width="300" height="300"></canvas>
-                </div>
-                <div class="p-6 pt-0 flex justify-between">
-                  <button
-                    class="text-sm font-bold px-5 py-3 rounded text-white bg-base"
-                  >
-                    1on1に誘う
-                  </button>
-                  <button
-                    class="text-sm font-bold px-5 py-3 rounded border border-base"
-                  >
-                    この人と比較
-                  </button>
-                  <button
-                    class="text-sm font-bold px-5 py-3 rounded border border-base"
-                  >
-                    スキルアップ確認
-                  </button>
-                </div>
-              </div>
+              </button>
 
-              <!-- 　メンバーデータ -->
-              <div class="flex w-[474px] shadow flex-col bg-white">
-                <ul
-                  class="flex text-md font-bold text-brightGray-500 bg-skillGem-50 content-between w-full"
-                >
-                  <li class="bg-white text-base w-full">
-                    <a
-                      href="#"
-                      class="w-full py-3 text-center inline-block"
-                      aria-current="page"
-                      >レベル1 <span class="text-xl ml-4">52</span>％</a
+              <div class="relative bg-white rounded-sm shadow-md p-8">
+                <div>
+                  <p class="pb-2 text-base font-bold">
+                    人材チームにバックアップしてもらう
+                  </p>
+                  <p class="pb-2">人材チームID</p>
+                  <input
+                    type="autocomplete"
+                    placeholder="人材チームIDを入力"
+                    class="px-2 py-2 mb-4 border border-brightGray-100 rounded-sm flex-1 w-[420px]"
+                  />
+                  <div class="flex justify-end">
+                    <button
+                      class="text-sm font-bold px-5 py-2 rounded border bg-base text-white"
                     >
-                  </li>
-                  <li class="w-full">
-                    <a href="#" class="w-full py-3 text-center inline-block"
-                      >レベル2 <span class="text-xl ml-4">52</span>％</a
-                    >
-                  </li>
-                  <li class="w-full">
-                    <a href="#" class="w-full py-3 text-center inline-block"
-                      >レベル3 <span class="text-xl ml-4">52</span>％</a
-                    >
-                  </li>
-                </ul>
-                <div class="flex justify-between px-6 pt-1 items-center">
-                  <div class="text-2xl font-bold">piacere</div>
-                  <div
-                    class="bg-test bg-contain h-20 w-20 mt-4"
-                    style="
-                      background-image: url('./images/sample/sample-image.png');
-                    "
-                  ></div>
-                </div>
-                <div class="w-[400px] flex justify-center mx-auto">
-                  <canvas id="radarChart8" width="300" height="300"></canvas>
-                </div>
-                <div class="p-6 pt-0 flex justify-between">
-                  <button
-                    class="text-sm font-bold px-5 py-3 rounded text-white bg-base"
-                  >
-                    1on1に誘う
-                  </button>
-                  <button
-                    class="text-sm font-bold px-5 py-3 rounded border border-base"
-                  >
-                    この人と比較
-                  </button>
-                  <button
-                    class="text-sm font-bold px-5 py-3 rounded border border-base"
-                  >
-                    スキルアップ確認
-                  </button>
+                      バックアップしてもらう
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/dist/my_team_not_belong.html
+++ b/frontend/dist/my_team_not_belong.html
@@ -1,0 +1,1334 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="./output.css" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Round|Material+Icons+Sharp|Material+Icons+Two+Tone"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <link />
+  </head>
+  <body>
+    <div class="flex w-[1920px]">
+      <aside
+        class="flex bg-brightGray-900 min-h-screen flex-col w-[200px] pt-3"
+      >
+        <img src="./images/common/logo.svg" width="163px" class="ml-4" />
+        <ul class="grid pt-2">
+          <li>
+            <a
+              class="!text-white text-base py-4 inline-block pl-4 w-full mb-1"
+              href="/mypage"
+              >マイページ</a
+            >
+          </li>
+          <li>
+            <a
+              class="!text-white text-base py-4 inline-block pl-4 w-full mb-1"
+              href="/mypage"
+              >キャリアパス</a
+            >
+          </li>
+          <li>
+            <a
+              class="!text-white text-base py-4 inline-block pl-4 w-full mb-1"
+              href="/mypage"
+              >スキルアップ</a
+            >
+          </li>
+          <li>
+            <a
+              class="!text-white text-base py-4 inline-block pl-4 w-full mb-1 bg-opacity-30 bg-white"
+              href="/mypage"
+              >チームスキル分析</a
+            >
+          </li>
+        </ul>
+      </aside>
+      <main
+        class="bg-background flex flex-col flex-1 border-brightGray-100 border-r"
+      >
+        <!-- ヘッダー -->
+        <div
+          class="w-full flex justify-between py-2.5 px-10 border-brightGray-100 border-b bg-white"
+        >
+          <h4>チームスキル分析</h4>
+          <div class="flex gap-x-5">
+            <button
+              type="button"
+              class="text-white bg-brightGreen-300 px-4 inline-flex rounded-md text-sm items-center font-bold h-9 hover:opacity-70"
+            >
+              <span
+                class="bg-white material-icons mr-1 !text-base !text-brightGreen-300 rounded-full h-6 w-6 !font-bold material-icons-outlined"
+                >sms</span
+              >
+              カスタマーサクセスに連絡
+            </button>
+
+            <button
+              type="button"
+              class="text-white bg-brightGreen-300 px-4 inline-flex rounded-md text-sm items-center font-bold h-9 hover:opacity-70"
+            >
+              <span
+                class="bg-white material-icons mr-1 !text-base !text-brightGreen-300 rounded-full h-6 w-6 !font-bold"
+                >search</span
+              >
+              スキル保有者を検索
+            </button>
+
+            <button
+              type="button"
+              class="text-black bg-brightGray-50 hover:bg-brightGray-100 rounded-full w-10 h-10 inline-flex items-center justify-center relative"
+            >
+              <span class="material-icons text-xs">notifications_none</span>
+              <div
+                class="absolute inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-attention-600 rounded-full -top-0 -right-2"
+              >
+                1
+              </div>
+            </button>
+            <button class="hover:opacity-70">
+              <img
+                class="inline-block h-10 w-10 rounded-full"
+                src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+              />
+            </button>
+          </div>
+        </div>
+        <!-- スイッチ -->
+        <div class="px-10 pt-4 pb-8 bg-white">
+          <!-- スキルと対象の切り替え -->
+          <div class="flex gap-x-4">
+            <p class="leading-tight">対象スキルの<br />切り替え</p>
+            <button
+              id="dropdownOffsetButton"
+              data-dropdown-toggle="dropdownOffset"
+              data-dropdown-offset-skidding="320"
+              data-dropdown-placement="bottom"
+              class="text-white bg-brightGreen-300 rounded pl-3 flex items-center font-bold h-[35px]"
+              type="button"
+            >
+              <span class="min-w-[6em]">スキルパネル</span>
+              <span
+                class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-8px] before:bg-brightGray-50 before:w-[1px] before:h-[42px]"
+                >expand_more</span
+              >
+            </button>
+            <!-- スキルパネル menu -->
+            <div
+              id="dropdownOffset"
+              class="z-10 hidden bg-white rounded-sm shadow"
+            >
+              <div class="bg-white rounded-md mt-1">
+                <div
+                  class="text-sm font-medium text-center text-brightGray-500"
+                >
+                  <ul
+                    class="flex content-between border-b border-brightGray-200"
+                  >
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
+                        >エンジニア</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >インフラ</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >デザイナー</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >マーケッター</a
+                      >
+                    </li>
+                  </ul>
+
+                  <div class="py-4 px-7 flex gap-y-2 flex-col">
+                    <div
+                      class="bg-brightGray-10 rounded-md text-base flex px-5 py-4 content-between"
+                    >
+                      <p class="font-bold w-[150px] text-left text-sm">
+                        Webアプリ開発
+                      </p>
+                      <table class="table-fixed skill-table -mt-2">
+                        <thead>
+                          <tr>
+                            <td></td>
+                            <th class="pl-8">クラス1</th>
+                            <th class="pl-8">クラス2</th>
+                            <th class="pl-8">クラス3</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>Elixir</td>
+                            <td>
+                              <p
+                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                              >
+                                <img
+                                  src="./images/common/icons/jemHigh.svg"
+                                  class="mr-1"
+                                />ベテラン
+                              </p>
+                            </td>
+                            <td>
+                              <p
+                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                              >
+                                <img
+                                  src="./images/common/icons/jemMiddle.svg"
+                                  class="mr-1"
+                                />平均
+                              </p>
+                            </td>
+                            <td>
+                              <p
+                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                              >
+                                <img
+                                  src="./images/common/icons/jemLow.svg"
+                                  class="mr-1"
+                                />見習い
+                              </p>
+                            </td>
+                          </tr>
+                          <tr>
+                            <td>PHP</td>
+                            <td>
+                              <p
+                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                              >
+                                <img
+                                  src="./images/common/icons/jemHigh.svg"
+                                  class="mr-1"
+                                />ベテラン
+                              </p>
+                            </td>
+                            <td>
+                              <p
+                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                              >
+                                <img
+                                  src="./images/common/icons/jemMiddle.svg"
+                                  class="mr-1"
+                                />平均
+                              </p>
+                            </td>
+                            <td></td>
+                          </tr>
+                          <tr>
+                            <td>Ruby</td>
+                            <td>
+                              <p
+                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                              >
+                                <img
+                                  src="./images/common/icons/jemLow.svg"
+                                  class="mr-1"
+                                />見習い
+                              </p>
+                            </td>
+                            <td></td>
+                            <td></td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+
+                    <div
+                      class="bg-brightGray-10 rounded-md text-base flex px-5 py-4 content-between"
+                    >
+                      <p class="font-bold w-[150px] text-left text-sm">
+                        Webアプリ開発
+                      </p>
+                      <table class="table-fixed skill-table -mt-2">
+                        <thead>
+                          <tr>
+                            <td></td>
+                            <th class="pl-8">クラス1</th>
+                            <th class="pl-8">クラス2</th>
+                            <th class="pl-8">クラス3</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>Elixir</td>
+                            <td>
+                              <p
+                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                              >
+                                <img
+                                  src="./images/common/icons/jemHigh.svg"
+                                  class="mr-1"
+                                />ベテラン
+                              </p>
+                            </td>
+                            <td>
+                              <p
+                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                              >
+                                <img
+                                  src="./images/common/icons/jemMiddle.svg"
+                                  class="mr-1"
+                                />平均
+                              </p>
+                            </td>
+                            <td>
+                              <p
+                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                              >
+                                <img
+                                  src="./images/common/icons/jemLow.svg"
+                                  class="mr-1"
+                                />見習い
+                              </p>
+                            </td>
+                          </tr>
+                          <tr>
+                            <td>PHP</td>
+                            <td>
+                              <p
+                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                              >
+                                <img
+                                  src="./images/common/icons/jemHigh.svg"
+                                  class="mr-1"
+                                />ベテラン
+                              </p>
+                            </td>
+                            <td>
+                              <p
+                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                              >
+                                <img
+                                  src="./images/common/icons/jemMiddle.svg"
+                                  class="mr-1"
+                                />平均
+                              </p>
+                            </td>
+                            <td></td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+
+                    <div
+                      class="bg-brightGray-10 rounded-md text-base flex px-5 py-4 content-between"
+                    >
+                      <p class="font-bold w-[150px] text-left text-sm">PM</p>
+                      <table class="table-fixed skill-table">
+                        <thead>
+                          <tr>
+                            <td></td>
+                            <th class="pl-8">クラス1</th>
+                            <th class="pl-8">クラス2</th>
+                            <th class="pl-8">クラス3</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td></td>
+                            <td>
+                              <p
+                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                              >
+                                <img
+                                  src="./images/common/icons/jemHigh.svg"
+                                  class="mr-1"
+                                />ベテラン
+                              </p>
+                            </td>
+                            <td>
+                              <p
+                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                              >
+                                <img
+                                  src="./images/common/icons/jemMiddle.svg"
+                                  class="mr-1"
+                                />平均
+                              </p>
+                            </td>
+                            <td>
+                              <p
+                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                              >
+                                <img
+                                  src="./images/common/icons/jemLow.svg"
+                                  class="mr-1"
+                                />見習い
+                              </p>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+
+                  <div class="flex justify-center gap-x-14 pb-3">
+                    <button
+                      type="button"
+                      class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                    >
+                      <span
+                        class="material-icons md-18 mr-2 text-brightGray-200"
+                        >chevron_left</span
+                      >
+                      前
+                    </button>
+                    <button
+                      type="button"
+                      class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                    >
+                      次
+                      <span
+                        class="material-icons md-18 ml-2 text-brightGray-900"
+                        >chevron_right</span
+                      >
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <button
+              id="dropdownDefaultButton"
+              data-dropdown-toggle="dropdown"
+              data-dropdown-offset-skidding="20"
+              data-dropdown-placement="bottom"
+              class="text-white bg-brightGreen-300 rounded h-[35px] pl-3 flex items-center font-bold"
+              type="button"
+            >
+              スキルセット
+              <span
+                class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-8px] before:bg-brightGray-50 before:w-[1px] before:h-[42px]"
+                >expand_more</span
+              >
+            </button>
+            <!-- スキルセット menu -->
+            <div
+              id="dropdown"
+              class="z-10 hidden bg-white divide-y divide-gray-100 rounded-lg shadow w-44 dark:bg-gray-700"
+            >
+              <ul
+                class="py-2 text-sm text-gray-700 dark:text-gray-200"
+                aria-labelledby="dropdownDefaultButton"
+              >
+                <li>
+                  <a href="#" class="block px-4 py-3 hover:bg-brightGray-50"
+                    >全スキルセット</a
+                  >
+                </li>
+                <li>
+                  <a href="#" class="block px-4 py-3 hover:bg-brightGray-50"
+                    >エンジニア</a
+                  >
+                </li>
+                <li>
+                  <a href="#" class="block px-4 py-3 hover:bg-brightGray-50"
+                    >インフラ</a
+                  >
+                </li>
+                <li>
+                  <a href="#" class="block px-4 py-3 hover:bg-brightGray-50"
+                    >デザイナー</a
+                  >
+                </li>
+                <li>
+                  <a href="#" class="block px-4 py-3 hover:bg-brightGray-50"
+                    >マーケッター</a
+                  >
+                </li>
+              </ul>
+            </div>
+
+            <p class="leading-tight ml-4">対象者の<br />切り替え</p>
+
+            <button
+              id="dropdownDefaultButton"
+              data-dropdown-toggle="dropdown3"
+              data-dropdown-offset-skidding="307"
+              data-dropdown-placement="bottom"
+              class="text-white bg-brightGreen-300 rounded py-1.5 pl-3 flex items-center font-bold"
+              type="button"
+            >
+              <span class="min-w-[6em]">チーム</span>
+              <span
+                class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-8px] before:bg-brightGray-50 before:w-[1px] before:h-[42px]"
+                >expand_more</span
+              >
+            </button>
+            <!-- チーム menu -->
+            <div
+              id="dropdown3"
+              class="z-10 hidden bg-white rounded-lg shadow w-[750px]"
+            >
+              <div class="bg-white rounded-md mt-1">
+                <div
+                  class="text-sm font-medium text-center text-brightGray-500"
+                >
+                  <ul
+                    class="flex content-between border-b border-brightGray-200"
+                  >
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
+                        >所属チーム</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >管轄チーム</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >カスタムグループ</a
+                      >
+                    </li>
+                  </ul>
+                  <div class="pt-4 pb-1 px-6">
+                    <ul class="flex gap-y-1.5 flex-col">
+                      <li
+                        class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                      >
+                        <img
+                          src="./images/common/icons/team.svg"
+                          class="mr-2"
+                        />Elixir Fukuoka
+                      </li>
+
+                      <li
+                        class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                      >
+                        <img
+                          src="./images/common/icons/other_team.svg"
+                          class="mr-2"
+                        />
+                        圧倒的開発スピード
+                      </li>
+
+                      <li
+                        class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                      >
+                        <img
+                          src="./images/common/icons/management_team.svg"
+                          class="mr-2"
+                        />
+                        S社案件開発
+                      </li>
+                      <li
+                        class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                      >
+                        <img
+                          src="./images/common/icons/coustom_group.svg"
+                          class="mr-2"
+                        />
+                        D社スマホアプリプロジェクト
+                      </li>
+                      <li
+                        class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                      >
+                        <img
+                          src="./images/common/icons/other_team.svg"
+                          class="mr-2"
+                        />
+                        D社スマホアプリプロジェクト
+                      </li>
+                    </ul>
+                  </div>
+                  <div class="flex justify-center gap-x-14 pb-3">
+                    <button
+                      type="button"
+                      class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                    >
+                      <span
+                        class="material-icons md-18 mr-2 text-brightGray-200"
+                        >chevron_left</span
+                      >
+                      前
+                    </button>
+                    <button
+                      type="button"
+                      class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                    >
+                      次
+                      <span
+                        class="material-icons md-18 ml-2 text-brightGray-900"
+                        >chevron_right</span
+                      >
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="flex ml-auto gap-x-4">
+              <button
+                data-modal-target="defaultModal"
+                data-modal-toggle="defaultModal"
+                class="text-brightGray-900 border bg-white border-brightGray-900 rounded px-3 font-bold ml-auto"
+              >
+                人材チームを作る
+              </button>
+              <button
+                data-modal-target="defaultModal"
+                data-modal-toggle="defaultModal"
+                class="text-white border bg-brightGray-900 rounded px-3 font-bold"
+              >
+                チームを作る
+              </button>
+            </div>
+          </div>
+
+          <!-- チーム作成モーダル
+           -->
+          <!-- Main modal -->
+          <div
+            id="defaultModal"
+            tabindex="-1"
+            aria-hidden="true"
+            class="bg-brightGray-900 bg-opacity-70 fixed top-0 left-0 right-0 z-50 hidden w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-full max-h-full"
+          >
+            <div class="relative w-[1500px] max-h-full">
+              <!-- Modal content -->
+              <div class="relative bg-white rounded-sm shadow px-16 py-8">
+                <!-- Modal header -->
+                <h3>チームを作る</h3>
+                <!-- Modal body -->
+                <div class="flex pt-5">
+                  <!-- modal left -->
+                  <div
+                    class="w-[790px] pr-10 border-r border-r-brightGray-200 border-dashed"
+                  >
+                    <p class="text-base">
+                      <span class="font-bold">気になる</span
+                      >からメンバーとして追加
+                    </p>
+                    <div
+                      class="bg-white rounded border border-brightGray-100 mt-2 mb-8"
+                    >
+                      <div
+                        class="text-sm font-medium text-center text-brightGray-200"
+                      >
+                        <ul
+                          class="flex content-between border-b border-brightGray-100"
+                        >
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
+                              >参考になる人</a
+                            >
+                          </li>
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block"
+                              >採用</a
+                            >
+                          </li>
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block"
+                              >離任者</a
+                            >
+                          </li>
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block"
+                              >スキルパネル</a
+                            >
+                          </li>
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block"
+                              >ジョブ</a
+                            >
+                          </li>
+                        </ul>
+                        <div class="pt-3 pb-1 px-6">
+                          <ul class="flex flex-wrap gap-y-1">
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
+                            >
+                              <a class="inline-flex items-center gap-x-6">
+                                <img
+                                  class="inline-block h-10 w-10 rounded-full"
+                                  src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                />
+                                <div>
+                                  <p>nokichi</p>
+                                  <p class="text-brightGray-300">
+                                    アプリエンジニア
+                                  </p>
+                                </div>
+                              </a>
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
+                            >
+                              <a class="inline-flex items-center gap-x-6">
+                                <img
+                                  class="inline-block h-10 w-10 rounded-full"
+                                  src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                />
+                                <div>
+                                  <p>nokichi</p>
+                                  <p class="text-brightGray-300">
+                                    アプリエンジニア
+                                  </p>
+                                </div>
+                              </a>
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
+                            >
+                              <a class="inline-flex items-center gap-x-6">
+                                <img
+                                  class="inline-block h-10 w-10 rounded-full"
+                                  src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                />
+                                <div>
+                                  <p>nokichi</p>
+                                  <p class="text-brightGray-300">
+                                    アプリエンジニア
+                                  </p>
+                                </div>
+                              </a>
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
+                            >
+                              <a class="inline-flex items-center gap-x-6">
+                                <img
+                                  class="inline-block h-10 w-10 rounded-full"
+                                  src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                />
+                                <div>
+                                  <p>nokichi</p>
+                                  <p class="text-brightGray-300">
+                                    アプリエンジニア
+                                  </p>
+                                </div>
+                              </a>
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
+                            >
+                              <a class="inline-flex items-center gap-x-6">
+                                <img
+                                  class="inline-block h-10 w-10 rounded-full"
+                                  src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                />
+                                <div>
+                                  <p>nokichi</p>
+                                  <p class="text-brightGray-300">
+                                    アプリエンジニア
+                                  </p>
+                                </div>
+                              </a>
+                            </li>
+                          </ul>
+                        </div>
+                        <div class="flex justify-center gap-x-14 pb-3">
+                          <button
+                            type="button"
+                            class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                          >
+                            <span
+                              class="material-icons md-18 mr-2 text-brightGray-200"
+                              >chevron_left</span
+                            >
+                            前
+                          </button>
+                          <button
+                            type="button"
+                            class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                          >
+                            次
+                            <span
+                              class="material-icons md-18 ml-2 text-brightGray-900"
+                              >chevron_right</span
+                            >
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <p class="text-base">
+                      <span class="font-bold">関わっているチーム</span
+                      >からサブチームとして追加
+                    </p>
+                    <div
+                      class="bg-white rounded mt-2 mb-6 border border-brightGray-100"
+                    >
+                      <div
+                        class="text-sm font-medium text-center text-brightGray-200"
+                      >
+                        <ul
+                          class="flex content-between border-b border-brightGray-100"
+                        >
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
+                              >所属チーム</a
+                            >
+                          </li>
+                          <li class="w-full">
+                            <a
+                              href="#"
+                              class="py-3.5 w-full items-center justify-center inline-block"
+                              >管轄チーム</a
+                            >
+                          </li>
+                        </ul>
+                        <div class="pt-4 pb-1 px-6">
+                          <ul class="flex gap-y-1.5 flex-col">
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                            >
+                              <span
+                                class="text-base !text-white bg-lapislazuli-900 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                >E</span
+                              >
+                              Elixir Fukuoka
+                            </li>
+
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                            >
+                              <span
+                                class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                >圧</span
+                              >
+                              圧倒的開発スピード
+                            </li>
+
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                            >
+                              <span
+                                class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                >S</span
+                              >
+                              S社案件開発
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                            >
+                              <span
+                                class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                >D</span
+                              >
+                              D社スマホアプリプロジェクト
+                            </li>
+                            <li
+                              class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
+                            >
+                              <span
+                                class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                >A</span
+                              >
+                              A社スマホアプリプロジェクト
+                            </li>
+                          </ul>
+                        </div>
+                        <div class="flex justify-center gap-x-14 pb-3">
+                          <button
+                            type="button"
+                            class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                          >
+                            <span
+                              class="material-icons md-18 mr-2 text-brightGray-200"
+                              >chevron_left</span
+                            >
+                            前
+                          </button>
+                          <button
+                            type="button"
+                            class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                          >
+                            次
+                            <span
+                              class="material-icons md-18 ml-2 text-brightGray-900"
+                              >chevron_right</span
+                            >
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <div>
+                      <p class="pb-2 text-base">
+                        <span class="font-bold">ハンドル名</span>または<span
+                          class="font-bold"
+                          >メールアドレス</span
+                        >からメンバーとして追加
+                      </p>
+
+                      <input
+                        type="autocomplete"
+                        placeholder="ハンドル名またはメールアドレスを入力してください"
+                        class="px-5 py-2 border border-brightGray-100 rounded-sm flex-1 w-[390px]"
+                      />
+
+                      <button
+                        class="text-sm font-bold px-5 py-2 rounded border border-base ml-2.5"
+                      >
+                        追加
+                      </button>
+                    </div>
+                  </div>
+                  <!-- modal-right -->
+                  <div class="w-[580px] pl-10 flex flex-col justify-between">
+                    <div>
+                      <h5 class="text-[20px]">新しいチーム</h5>
+
+                      <div class="bg-brightGray-10 rounded-sm px-10 py-6">
+                        <dl class="flex flex-wrap w-full">
+                          <dt
+                            class="font-bold w-[100px] flex items-center mb-10 text-base"
+                          >
+                            チーム名
+                          </dt>
+                          <dd class="w-[340px] mb-10">
+                            <input
+                              type="text"
+                              placeholder="新しいチーム名を入力してください"
+                              class="px-5 py-2 border border-brightGray-100 rounded-sm flex-1 w-full"
+                            />
+                          </dd>
+                          <dt class="font-bold w-[100px] mb-10 text-base">
+                            メンバー
+                          </dt>
+                          <dd class="w-[340px] mb-10">
+                            <ul class="flex flex-wrap gap-y-1">
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
+                              >
+                                <a
+                                  class="inline-flex items-center gap-x-6 w-full"
+                                >
+                                  <img
+                                    class="inline-block h-10 w-10 rounded-full"
+                                    src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                  />
+                                  <div class="flex-auto">
+                                    <p>nokichi</p>
+                                    <p class="text-brightGray-300">
+                                      アプリエンジニア
+                                    </p>
+                                  </div>
+                                  <button class="mx-4">
+                                    <span
+                                      class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                      >close</span
+                                    >
+                                  </button>
+                                </a>
+                              </li>
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
+                              >
+                                <a
+                                  class="inline-flex items-center gap-x-6 w-full"
+                                >
+                                  <img
+                                    class="inline-block h-10 w-10 rounded-full"
+                                    src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                  />
+                                  <div class="flex-auto">
+                                    <p>nokichi</p>
+                                    <p class="text-brightGray-300">
+                                      アプリエンジニア
+                                    </p>
+                                  </div>
+                                  <button class="mx-4">
+                                    <span
+                                      class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                      >close</span
+                                    >
+                                  </button>
+                                </a>
+                              </li>
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
+                              >
+                                <a
+                                  class="inline-flex items-center gap-x-6 w-full"
+                                >
+                                  <img
+                                    class="inline-block h-10 w-10 rounded-full"
+                                    src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                  />
+                                  <div class="flex-auto">
+                                    <p>nokichi</p>
+                                    <p class="text-brightGray-300">
+                                      アプリエンジニア
+                                    </p>
+                                  </div>
+                                  <button class="mx-4">
+                                    <span
+                                      class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                      >close</span
+                                    >
+                                  </button>
+                                </a>
+                              </li>
+                            </ul>
+                          </dd>
+                          <dt class="font-bold w-[100px] mb-10 text-base">
+                            サブチーム
+                          </dt>
+                          <dd class="w-[340px]">
+                            <ul class="flex gap-y-1.5 flex-col">
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded justify-between"
+                              >
+                                <span
+                                  class="text-base !text-white bg-lapislazuli-900 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                  >E</span
+                                >
+                                <p class="flex-1">Elixir Fukuoka</p>
+                                <button class="mx-4">
+                                  <span
+                                    class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                    >close</span
+                                  >
+                                </button>
+                              </li>
+
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded justify-between"
+                              >
+                                <span
+                                  class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                  >圧</span
+                                >
+                                <p class="flex-1">圧倒的開発スピード</p>
+                                <button class="mx-4">
+                                  <span
+                                    class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                    >close</span
+                                  >
+                                </button>
+                              </li>
+
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded justify-between"
+                              >
+                                <span
+                                  class="text-base !text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center"
+                                  >S</span
+                                >
+                                <p class="flex-1">S社案件開発</p>
+                                <button class="mx-4">
+                                  <span
+                                    class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                    >close</span
+                                  >
+                                </button>
+                              </li>
+                            </ul>
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+
+                    <div class="flex justify-end gap-x-4">
+                      <button
+                        class="text-base font-bold px-4 py-3 rounded text-white bg-base"
+                      >
+                        チームを作成し、上記メンバーに招待を送る
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- プロフィール -->
+          <div class="w-[850px] pt-6">
+            <div class="flex">
+              <div
+                class="bg-test bg-contain h-20 w-20 mr-5"
+                style="
+                  background-image: url('/dist/images/sample/sample-image.png');
+                "
+              ></div>
+              <div class="flex-1">
+                <div class="flex justify-between pb-2 items-end">
+                  <div class="text-2xl font-bold">piacere</div>
+                  <div class="flex gap-x-3">
+                    <button
+                      type="button"
+                      class="text-gray-900 bg-white px-2 py-1 inline-flex font-medium rounded-md text-sm items-center border border-brightGreen-300"
+                    >
+                      <span
+                        class="material-icons md-18 mr-1 text-brightGreen-300"
+                        >share</span
+                      >
+                      優秀な人として紹介
+                    </button>
+
+                    <button
+                      type="button"
+                      id="dropcheckmenu"
+                      data-dropdown-toggle="checkmenu"
+                      class="text-gray-900 bg-white px-2 py-1 inline-flex font-medium rounded-md text-sm items-center border border-brightGray-200"
+                    >
+                      <span
+                        class="material-icons md-18 mr-1 text-brightGray-200"
+                        >star</span
+                      >
+                      気になる
+                    </button>
+                    <!-- 気になるDropdown menu -->
+                    <div
+                      id="checkmenu"
+                      class="z-10 hidden bg-white rounded-lg shadow min-w-[286px]"
+                    >
+                      <ul
+                        class="p-2 text-left text-base"
+                        aria-labelledby="dropcheckmenu"
+                      >
+                        <li>
+                          <a
+                            href="#"
+                            class="block px-4 py-3 hover:bg-brightGray-50 text-base"
+                            >気になるリスト</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="#"
+                            class="block px-4 py-3 hover:bg-brightGray-50 text-base"
+                            >メンバー候補</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="#"
+                            class="block px-4 py-3 hover:bg-brightGray-50 text-base"
+                            >java開発者リスト</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="#"
+                            class="block px-4 py-3 hover:bg-brightGray-50 text-base"
+                            >Python開発者リスト</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="#"
+                            class="block px-4 py-3 hover:bg-brightGray-50 text-base"
+                            >ジュニアエンジニア</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="#"
+                            class="block px-4 py-3 hover:bg-brightGray-50 text-base"
+                            >シニアエンジニア</a
+                          >
+                        </li>
+                        <li
+                          class="px-4 py-3 hover:bg-brightGray-50 flex justify-center gap-x-2"
+                        >
+                          <input
+                            type="text"
+                            placeholder="リスト名を入力"
+                            class="px-2 py-1 border border-brightGray-900 rounded-sm flex-1 w-full text-base w-[220px]"
+                          />
+                          <button
+                            class="text-sm font-bold px-4 py-1 rounded text-white bg-base"
+                          >
+                            新規作成
+                          </button>
+                        </li>
+                      </ul>
+                    </div>
+
+                    <button
+                      type="button"
+                      class="text-brightGreen-300 bg-white px-2 py-1 inline-flex rounded-md text-sm items-center border border-brightGreen-300 font-bold"
+                    >
+                      自分に戻す
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="flex justify-between pt-3 border-brightGray-100 border-t"
+                >
+                  <div class="text-2xl">リードプログラマー</div>
+                  <div class="flex gap-x-6 mr-2">
+                    <button type="button">
+                      <img src="./images/common/twitter.svg" width="26px" />
+                    </button>
+                    <button type="button">
+                      <img src="./images/common/github.svg" width="26px" />
+                    </button>
+                    <button type="button">
+                      <img src="./images/common/facebook.svg" width="26px" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- card -->
+        <div
+          class="m-10 bg-white shadow flex justify-center items-center flex-1 h-full"
+        >
+          <div class="flex flex-col items-center text-center">
+            <p class="font-bold">管理／所属しているチームはありません</p>
+          </div>
+        </div>
+      </main>
+    </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.5/flowbite.min.js"></script>
+
+    <script>
+      const radar = document.getElementById("radarChart");
+      const radar2 = document.getElementById("radarChart2");
+      const radar3 = document.getElementById("radarChart3");
+      const radar4 = document.getElementById("radarChart4");
+      const radar5 = document.getElementById("radarChart5");
+      const radar6 = document.getElementById("radarChart6");
+      const radar7 = document.getElementById("radarChart7");
+      const radar8 = document.getElementById("radarChart8");
+
+      const radarData = {
+        labels: [
+          "Elixir本来",
+          "ライブラリ",
+          "環境構築",
+          "関連スキル",
+          "デバッグ",
+          "テスト",
+        ],
+        datasets: [
+          {
+            data: [80, 63, 50, 67, 40, 78],
+            fill: true,
+            backgroundColor: "rgba(82, 204, 181,0.6)",
+            borderWidth: 1,
+            pointRadius: 0,
+          },
+        ],
+      };
+
+      const radarOptions = {
+        plugins: {
+          legend: {
+            display: false,
+          },
+        },
+        scales: {
+          r: {
+            //グラフの最小値・最大値
+            min: 0,
+            max: 100,
+            //背景色
+            backgroundColor: "#EBFEFC",
+            ticks: {
+              min: 0, // 最小値
+              max: 100, // 最大値
+              stepSize: 10, // 目盛の間隔
+              display: false,
+            },
+            // グリッドライン
+            grid: {
+              color: "#ffffff",
+              lineWidth: 2,
+            },
+            // アングルライン
+            angleLines: {
+              color: "#ffffff",
+            },
+            pointLabels: {
+              font: {
+                size: 14,
+              },
+            },
+          },
+        },
+      };
+      new Chart(radar, {
+        type: "radar",
+        data: radarData,
+        options: radarOptions,
+      });
+
+      new Chart(radar2, {
+        type: "radar",
+        data: radarData,
+        options: radarOptions,
+      });
+
+      new Chart(radar3, {
+        type: "radar",
+        data: radarData,
+        options: radarOptions,
+      });
+
+      new Chart(radar4, {
+        type: "radar",
+        data: radarData,
+        options: radarOptions,
+      });
+
+      new Chart(radar5, {
+        type: "radar",
+        data: radarData,
+        options: radarOptions,
+      });
+
+      new Chart(radar6, {
+        type: "radar",
+        data: radarData,
+        options: radarOptions,
+      });
+
+      new Chart(radar7, {
+        type: "radar",
+        data: radarData,
+        options: radarOptions,
+      });
+
+      new Chart(radar8, {
+        type: "radar",
+        data: radarData,
+        options: radarOptions,
+      });
+    </script>
+  </body>
+</html>

--- a/frontend/dist/mypage.html
+++ b/frontend/dist/mypage.html
@@ -80,6 +80,16 @@
           <div class="flex gap-x-5">
             <button
               type="button"
+              class="text-white bg-[#f57f3e] px-4 inline-flex rounded-md text-sm items-center font-bold h-9 hover:opacity-70"
+            >
+              <span
+                class="bg-white material-icons mr-1 !text-base !text-[#f57f3e] rounded-full h-6 w-6 !font-bold material-icons-outlined"
+                >upgrade</span
+              >
+              プランのアップグレード
+            </button>
+            <button
+              type="button"
               class="text-white bg-brightGreen-300 px-4 inline-flex rounded-md text-sm items-center font-bold h-9 hover:opacity-70"
             >
               <span
@@ -100,22 +110,17 @@
               スキル保有者を検索
             </button>
 
-            <button
-              type="button"
-              class="text-black bg-brightGray-50 hover:bg-brightGray-100 rounded-full w-10 h-10 inline-flex items-center justify-center relative"
-            >
-              <span class="material-icons">notifications_none</span>
-              <div
-                class="absolute inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-attention-600 rounded-full -top-0 -right-2"
-              >
-                1
-              </div>
-            </button>
             <button class="hover:opacity-70">
               <img
                 class="inline-block h-10 w-10 rounded-full"
                 src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
               />
+            </button>
+
+            <button
+              class="rounded-full border border-brightGray-600 h-10 w-10 flex items-center justify-center"
+            >
+              <span class="material-icons text-brightGray-600">logout</span>
             </button>
           </div>
         </div>
@@ -377,7 +382,7 @@
             <!-- 重要な連絡 -->
             <div>
               <h5>重要な連絡</h5>
-              <div class="bg-white rounded-md mt-1 shadow-md">
+              <div class="bg-white rounded-md mt-1">
                 <div
                   class="text-sm font-medium text-center text-brightGray-500"
                 >
@@ -427,62 +432,87 @@
                       >
                     </li>
                   </ul>
-                  <div class="pt-4 pb-1 px-8">
+                  <div class="pt-4 px-6 min-h-[216px]">
                     <ul class="flex gap-y-2.5 flex-col">
-                      <li class="text-left flex items-center text-base">
-                        <span
-                          class="material-icons !text-lg text-white bg-brightGreen-300 rounded-full !flex w-6 h-6 mr-2.5 !items-center !justify-center"
-                          >person</span
+                      <li
+                        class="flex"
+                        data-modal-target="teamSupportModal"
+                        data-modal-toggle="teamSupportModal"
+                      >
+                        <div
+                          class="text-left flex items-center text-base px-1 py-1 hover:bg-brightGray-50 flex-1 mr-2"
                         >
-                        nakoさんからの紹介 / mikaさん / Web開発（Elixir）
-                        <span
-                          class="text-brightGreen-300 font-bold pl-4 inline-block"
-                          >1時間前</span
-                        >
+                          <span
+                            class="material-icons !text-lg text-white bg-brightGreen-300 rounded-full !flex w-6 h-6 mr-2.5 !items-center !justify-center"
+                            >person</span
+                          >
+                          nakoさんからの紹介 / mikaさん / Web開発（Elixir）
+                          <span
+                            class="text-brightGreen-300 font-bold pl-4 inline-block"
+                            >1時間前</span
+                          >
+                        </div>
                       </li>
-                      <li class="text-left flex items-center text-base">
-                        <span
-                          class="material-icons !text-lg text-white bg-brightGreen-300 rounded-full !flex w-6 h-6 mr-2.5 !items-center !justify-center"
-                          >person</span
+
+                      <li class="flex">
+                        <div
+                          class="text-left flex items-center text-base px-1 py-1 hover:bg-brightGray-50 flex-1 mr-2"
                         >
-                        nakoさんからの紹介 / mikaさん / Web開発（Elixir）
-                        <span
-                          class="text-brightGreen-300 font-bold pl-4 inline-block"
-                          >1時間前</span
-                        >
+                          <span
+                            class="material-icons !text-lg text-white bg-brightGreen-300 rounded-full !flex w-6 h-6 mr-2.5 !items-center !justify-center"
+                            >person</span
+                          >
+                          nakoさんからの紹介 / mikaさん / Web開発（Elixir）
+                          <span
+                            class="text-brightGreen-300 font-bold pl-4 inline-block"
+                            >1時間前</span
+                          >
+                        </div>
                       </li>
-                      <li class="text-left flex items-center text-base">
-                        <span
-                          class="material-icons !text-lg text-white bg-brightGreen-300 rounded-full !flex w-6 h-6 mr-2.5 !items-center !justify-center"
-                          >person</span
+                      <li class="flex">
+                        <div
+                          class="text-left flex items-center text-base px-1 py-1 hover:bg-brightGray-50 flex-1 mr-2"
                         >
-                        nakoさんからの紹介 / mikaさん / Web開発（Elixir）
-                        <span
-                          class="text-brightGreen-300 font-bold pl-4 inline-block"
-                          >1時間前</span
-                        >
+                          <span
+                            class="material-icons !text-lg text-white bg-brightGreen-300 rounded-full !flex w-6 h-6 mr-2.5 !items-center !justify-center"
+                            >person</span
+                          >
+                          nakoさんからの紹介 / mikaさん / Web開発（Elixir）
+                          <span
+                            class="text-brightGreen-300 font-bold pl-4 inline-block"
+                            >1時間前</span
+                          >
+                        </div>
                       </li>
-                      <li class="text-left flex items-center text-base">
-                        <span
-                          class="material-icons !text-lg text-white bg-brightGreen-300 rounded-full !flex w-6 h-6 mr-2.5 !items-center !justify-center"
-                          >person</span
+                      <li class="flex">
+                        <div
+                          class="text-left flex items-center text-base px-1 py-1 hover:bg-brightGray-50 flex-1 mr-2"
                         >
-                        nakoさんからの紹介 / mikaさん / Web開発（Elixir）
-                        <span
-                          class="text-brightGray-200 font-bold pl-4 inline-block"
-                          >8時間前</span
-                        >
+                          <span
+                            class="material-icons !text-lg text-white bg-brightGreen-300 rounded-full !flex w-6 h-6 mr-2.5 !items-center !justify-center"
+                            >person</span
+                          >
+                          nakoさんからの紹介 / mikaさん / Web開発（Elixir）
+                          <span
+                            class="text-brightGreen-300 font-bold pl-4 inline-block"
+                            >1時間前</span
+                          >
+                        </div>
                       </li>
-                      <li class="text-left flex items-center text-base">
-                        <span
-                          class="material-icons !text-lg text-white bg-brightGreen-300 rounded-full !flex w-6 h-6 mr-2.5 !items-center !justify-center"
-                          >person</span
+                      <li class="flex">
+                        <div
+                          class="text-left flex items-center text-base px-1 py-1 hover:bg-brightGray-50 flex-1 mr-2"
                         >
-                        nakoさんからの紹介 / mikaさん / Web開発（Elixir）
-                        <span
-                          class="text-brightGray-200 font-bold pl-4 inline-block"
-                          >1日前</span
-                        >
+                          <span
+                            class="material-icons !text-lg text-white bg-brightGreen-300 rounded-full !flex w-6 h-6 mr-2.5 !items-center !justify-center"
+                            >person</span
+                          >
+                          nakoさんからの紹介 / mikaさん / Web開発（Elixir）
+                          <span
+                            class="text-brightGreen-300 font-bold pl-4 inline-block"
+                            >1時間前</span
+                          >
+                        </div>
                       </li>
                     </ul>
                   </div>
@@ -516,7 +546,7 @@
               <h5>保有スキル（ジェムをクリックすると成長グラフが見れます）</h5>
               <div class="bg-white rounded-md mt-1">
                 <div
-                  class="text-sm font-medium text-center text-brightGray-500"
+                  class="text-sm font-medium text-center text-brightGray-900"
                 >
                   <ul
                     class="flex content-between border-b border-brightGray-200"
@@ -551,225 +581,290 @@
                     </li>
                   </ul>
 
-                  <div class="py-4 px-7 flex gap-y-2 flex-col">
-                    <div
-                      class="bg-brightGray-10 rounded-md text-base flex px-5 py-4 content-between"
-                    >
-                      <p class="font-bold w-[150px] text-left text-sm">
-                        Webアプリ開発
-                      </p>
-                      <table class="table-fixed skill-table -mt-2">
-                        <thead>
-                          <tr>
-                            <td></td>
-                            <th class="pl-8">クラス1</th>
-                            <th class="pl-8">クラス2</th>
-                            <th class="pl-8">クラス3</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <td>Elixir</td>
-                            <td>
-                              <p
-                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
-                              >
-                                <img
-                                  src="./images/common/icons/jemHigh.svg"
-                                  class="mr-1"
-                                />ベテラン
-                              </p>
-                            </td>
-                            <td>
-                              <p
-                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
-                              >
-                                <img
-                                  src="./images/common/icons/jemMiddle.svg"
-                                  class="mr-1"
-                                />平均
-                              </p>
-                            </td>
-                            <td>
-                              <p
-                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
-                              >
-                                <img
-                                  src="./images/common/icons/jemLow.svg"
-                                  class="mr-1"
-                                />見習い
-                              </p>
-                            </td>
-                          </tr>
-                          <tr>
-                            <td>PHP</td>
-                            <td>
-                              <p
-                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
-                              >
-                                <img
-                                  src="./images/common/icons/jemHigh.svg"
-                                  class="mr-1"
-                                />ベテラン
-                              </p>
-                            </td>
-                            <td>
-                              <p
-                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
-                              >
-                                <img
-                                  src="./images/common/icons/jemMiddle.svg"
-                                  class="mr-1"
-                                />平均
-                              </p>
-                            </td>
-                            <td></td>
-                          </tr>
-                          <tr>
-                            <td>Ruby</td>
-                            <td>
-                              <p
-                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
-                              >
-                                <img
-                                  src="./images/common/icons/jemLow.svg"
-                                  class="mr-1"
-                                />見習い
-                              </p>
-                            </td>
-                            <td></td>
-                            <td></td>
-                          </tr>
-                        </tbody>
-                      </table>
+                  <div class="py-6 px-7 flex gap-y-4 flex-col min-h-[464px]">
+                    <div class="flex">
+                      <div class="flex-1 text-left font-bold"></div>
+                      <div class="w-36 font-bold">クラス1</div>
+                      <div class="w-36 font-bold">クラス2</div>
+                      <div class="w-36 font-bold">クラス3</div>
                     </div>
-
-                    <div
-                      class="bg-brightGray-10 rounded-md text-base flex px-5 py-4 content-between"
-                    >
-                      <p class="font-bold w-[150px] text-left text-sm">
-                        Webアプリ開発
-                      </p>
-                      <table class="table-fixed skill-table -mt-2">
-                        <thead>
-                          <tr>
-                            <td></td>
-                            <th class="pl-8">クラス1</th>
-                            <th class="pl-8">クラス2</th>
-                            <th class="pl-8">クラス3</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <td>Elixir</td>
-                            <td>
-                              <p
-                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
-                              >
-                                <img
-                                  src="./images/common/icons/jemHigh.svg"
-                                  class="mr-1"
-                                />ベテラン
-                              </p>
-                            </td>
-                            <td>
-                              <p
-                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
-                              >
-                                <img
-                                  src="./images/common/icons/jemMiddle.svg"
-                                  class="mr-1"
-                                />平均
-                              </p>
-                            </td>
-                            <td>
-                              <p
-                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
-                              >
-                                <img
-                                  src="./images/common/icons/jemLow.svg"
-                                  class="mr-1"
-                                />見習い
-                              </p>
-                            </td>
-                          </tr>
-                          <tr>
-                            <td>PHP</td>
-                            <td>
-                              <p
-                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
-                              >
-                                <img
-                                  src="./images/common/icons/jemHigh.svg"
-                                  class="mr-1"
-                                />ベテラン
-                              </p>
-                            </td>
-                            <td>
-                              <p
-                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
-                              >
-                                <img
-                                  src="./images/common/icons/jemMiddle.svg"
-                                  class="mr-1"
-                                />平均
-                              </p>
-                            </td>
-                            <td></td>
-                          </tr>
-                        </tbody>
-                      </table>
+                    <div class="flex">
+                      <div class="flex-1 text-left font-bold">
+                        Webアプリ開発Java
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemHigh.svg"
+                            class="mr-1"
+                          />ベテラン
+                        </p>
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemMiddle.svg"
+                            class="mr-1"
+                          />平均
+                        </p>
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemLow.svg"
+                            class="mr-1"
+                          />見習い
+                        </p>
+                      </div>
                     </div>
-
-                    <div
-                      class="bg-brightGray-10 rounded-md text-base flex px-5 py-4 content-between"
-                    >
-                      <p class="font-bold w-[150px] text-left text-sm">PM</p>
-                      <table class="table-fixed skill-table">
-                        <thead>
-                          <tr>
-                            <td></td>
-                            <th class="pl-8">クラス1</th>
-                            <th class="pl-8">クラス2</th>
-                            <th class="pl-8">クラス3</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <td></td>
-                            <td>
-                              <p
-                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
-                              >
-                                <img
-                                  src="./images/common/icons/jemHigh.svg"
-                                  class="mr-1"
-                                />ベテラン
-                              </p>
-                            </td>
-                            <td>
-                              <p
-                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
-                              >
-                                <img
-                                  src="./images/common/icons/jemMiddle.svg"
-                                  class="mr-1"
-                                />平均
-                              </p>
-                            </td>
-                            <td>
-                              <p
-                                class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
-                              >
-                                <img
-                                  src="./images/common/icons/jemLow.svg"
-                                  class="mr-1"
-                                />見習い
-                              </p>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
+                    <div class="flex">
+                      <div class="flex-1 text-left font-bold">
+                        Webアプリ開発 PHP
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemHigh.svg"
+                            class="mr-1"
+                          />ベテラン
+                        </p>
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemMiddle.svg"
+                            class="mr-1"
+                          />平均
+                        </p>
+                      </div>
+                      <div class="w-36"></div>
+                    </div>
+                    <div class="flex">
+                      <div class="flex-1 text-left font-bold">
+                        Webアプリ開発 Elixir
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemHigh.svg"
+                            class="mr-1"
+                          />ベテラン
+                        </p>
+                      </div>
+                      <div class="w-36"></div>
+                      <div class="w-36"></div>
+                    </div>
+                    <div class="flex">
+                      <div class="flex-1 text-left font-bold">
+                        データサイエンティスト Excel
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemHigh.svg"
+                            class="mr-1"
+                          />ベテラン
+                        </p>
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemMiddle.svg"
+                            class="mr-1"
+                          />平均
+                        </p>
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemLow.svg"
+                            class="mr-1"
+                          />見習い
+                        </p>
+                      </div>
+                    </div>
+                    <div class="flex">
+                      <div class="flex-1 text-left font-bold">
+                        データサイエンティスト Python
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemHigh.svg"
+                            class="mr-1"
+                          />ベテラン
+                        </p>
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemMiddle.svg"
+                            class="mr-1"
+                          />平均
+                        </p>
+                      </div>
+                      <div class="w-36"></div>
+                    </div>
+                    <div class="flex">
+                      <div class="flex-1 text-left font-bold">
+                        データサイエンティスト Elixir
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemHigh.svg"
+                            class="mr-1"
+                          />ベテラン
+                        </p>
+                      </div>
+                      <div class="w-36"></div>
+                      <div class="w-36"></div>
+                    </div>
+                    <div class="flex">
+                      <div class="flex-1 text-left font-bold">
+                        デスクトップアプリ開発者 C#
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemHigh.svg"
+                            class="mr-1"
+                          />ベテラン
+                        </p>
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemMiddle.svg"
+                            class="mr-1"
+                          />平均
+                        </p>
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemLow.svg"
+                            class="mr-1"
+                          />見習い
+                        </p>
+                      </div>
+                    </div>
+                    <div class="flex">
+                      <div class="flex-1 text-left font-bold">
+                        Google Cloud　ファンダメンタルズ
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemHigh.svg"
+                            class="mr-1"
+                          />ベテラン
+                        </p>
+                      </div>
+                      <div class="w-36"></div>
+                      <div class="w-36"></div>
+                    </div>
+                    <div class="flex">
+                      <div class="flex-1 text-left font-bold">
+                        コミュニティマネージャー
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemHigh.svg"
+                            class="mr-1"
+                          />ベテラン
+                        </p>
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemMiddle.svg"
+                            class="mr-1"
+                          />平均
+                        </p>
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemLow.svg"
+                            class="mr-1"
+                          />見習い
+                        </p>
+                      </div>
+                    </div>
+                    <div class="flex">
+                      <div class="flex-1 text-left font-bold">
+                        スマホアプリ開発者 Kotlin
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemHigh.svg"
+                            class="mr-1"
+                          />ベテラン
+                        </p>
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemMiddle.svg"
+                            class="mr-1"
+                          />平均
+                        </p>
+                      </div>
+                      <div class="w-36">
+                        <p
+                          class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1"
+                        >
+                          <img
+                            src="./images/common/icons/jemLow.svg"
+                            class="mr-1"
+                          />見習い
+                        </p>
+                      </div>
                     </div>
                   </div>
 
@@ -846,7 +941,7 @@
                       >
                     </li>
                   </ul>
-                  <div class="pt-4 px-6">
+                  <div class="pt-4 px-6 min-h-[216px]">
                     <ul class="flex gap-y-2.5 flex-col">
                       <li class="flex">
                         <div
@@ -1095,141 +1190,79 @@
                         >カスタムグループ</a
                       >
                     </li>
-                    <li class="flex items-center">
-                      <button
-                        type="button"
-                        id="dropmenu03"
-                        data-dropdown-toggle="menu03"
-                        data-dropdown-offset-skidding="-130"
-                        data-dropdown-placement="bottom"
-                        class="text-black rounded-full w-10 h-10 inline-flex items-center justify-center"
-                      >
-                        <span class="material-icons text-brightGreen-900"
-                          >more_vert</span
-                        >
-                      </button>
-                      <!-- Dropdown menu -->
-                      <div
-                        id="menu03"
-                        class="z-10 hidden bg-white rounded-lg shadow-md min-w-[286px]"
-                      >
-                        <ul
-                          class="p-2 text-left text-base"
-                          aria-labelledby="dropmenu04"
-                        >
-                          <li>
-                            <a
-                              href="#"
-                              class="block px-4 py-3 hover:bg-brightGray-50 text-base"
-                              >チームを作る</a
-                            >
-                          </li>
-                          <li>
-                            <a
-                              data-modal-target="addTeamModal"
-                              data-modal-toggle="addTeamModal"
-                              class="block px-4 py-3 hover:bg-brightGray-50 text-base"
-                              >人材チームへのチーム登録依頼</a
-                            >
-                          </li>
-                          <li>
-                            <a
-                              href="#"
-                              class="block px-4 py-3 hover:bg-brightGray-50 text-base"
-                              >管理チームの編集</a
-                            >
-                          </li>
-                          <li>
-                            <a
-                              href="#"
-                              class="block px-4 py-3 hover:bg-brightGray-50 text-base"
-                              >管理チームの削除</a
-                            >
-                          </li>
-                        </ul>
-                      </div>
-                    </li>
                   </ul>
-                  <div class="pt-4 pb-1 px-6">
-                    <ul class="flex gap-y-1.5 flex-col">
-                      <li
-                        class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
-                      >
-                        <input
-                          type="checkbox"
-                          value=""
-                          class="coustom-checkbox w-4 h-4 mr-3"
-                        />
-                        <img
-                          src="./images/common/icons/team.svg"
-                          class="mr-2"
-                        />Elixir Fukuoka
-                      </li>
-
-                      <li
-                        class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
-                      >
-                        <input
-                          type="checkbox"
-                          value=""
-                          class="coustom-checkbox w-4 h-4 mr-3"
-                        />
-                        <img
-                          src="./images/common/icons/other_team.svg"
-                          class="mr-2"
-                        />
-                        圧倒的開発スピード
-                      </li>
-
-                      <li
-                        class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
-                      >
-                        <input
-                          type="checkbox"
-                          value=""
-                          class="coustom-checkbox w-4 h-4 mr-3"
-                        />
-                        <img
-                          src="./images/common/icons/management_team.svg"
-                          class="mr-2"
-                        />
-                        S社案件開発
-                      </li>
-                      <li
-                        class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
-                      >
-                        <input
-                          type="checkbox"
-                          value=""
-                          class="coustom-checkbox w-4 h-4 mr-3"
-                        />
-                        <img
-                          src="./images/common/icons/coustom_group.svg"
-                          class="mr-2"
-                        />
-                        D社スマホアプリプロジェクト
-                      </li>
-                      <li
-                        class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded"
-                      >
-                        <input
-                          checked
-                          type="checkbox"
-                          value=""
-                          class="coustom-checkbox w-4 h-4 mr-3"
-                        />
-                        <img
-                          src="./images/common/icons/other_team.svg"
-                          class="mr-2"
-                        />
-                        D社スマホアプリプロジェクト
-                      </li>
-                      <li class="text-left py-2">
-                        <button
-                          class="text-base !text-sm font-bold px-3 py-1 rounded border border-brightGray-900"
+                  <div class="pt-4 px-6 min-h-[216px]">
+                    <ul class="flex gap-y-2.5 flex-col">
+                      <li class="flex">
+                        <div
+                          class="text-left flex items-center text-base px-1 py-1 hover:bg-brightGray-50 flex-1 mr-2"
                         >
-                          削除
-                        </button>
+                          <img
+                            src="./images/common/icons/team.svg"
+                            class="mr-2"
+                          />
+                          Elixir Fukuoka
+                          <span
+                            class="text-white text-sm font-bold ml-4 px-2 py-1 inline-block bg-lapislazuli-300 rounded"
+                            >管理者</span
+                          >
+                        </div>
+                      </li>
+
+                      <li class="flex">
+                        <div
+                          class="text-left flex items-center text-base px-1 py-1 hover:bg-brightGray-50 flex-1 mr-2"
+                        >
+                          <img
+                            src="./images/common/icons/other_team.svg"
+                            class="mr-2"
+                          />
+                          圧倒的開発スピード
+                          <span
+                            class="text-white text-sm font-bold ml-4 px-2 py-1 inline-block bg-lapislazuli-300 rounded"
+                            >管理者</span
+                          >
+                        </div>
+                      </li>
+
+                      <li class="flex">
+                        <div
+                          class="text-left flex items-center text-base px-1 py-1 hover:bg-brightGray-50 flex-1 mr-2"
+                        >
+                          <img
+                            src="./images/common/icons/management_team.svg"
+                            class="mr-2"
+                          />
+                          S社案件開発
+                          <span
+                            class="text-white text-sm font-bold ml-4 px-2 py-1 inline-block bg-lapislazuli-300 rounded"
+                            >管理者</span
+                          >
+                        </div>
+                      </li>
+
+                      <li class="flex">
+                        <div
+                          class="text-left flex items-center text-base px-1 py-1 hover:bg-brightGray-50 flex-1 mr-2"
+                        >
+                          <img
+                            src="./images/common/icons/coustom_group.svg"
+                            class="mr-2"
+                          />
+                          D社スマホアプリプロジェクト
+                        </div>
+                      </li>
+
+                      <li class="flex">
+                        <div
+                          class="text-left flex items-center text-base px-1 py-1 hover:bg-brightGray-50 flex-1 mr-2"
+                        >
+                          <img
+                            src="./images/common/icons/other_team.svg"
+                            class="mr-2"
+                          />
+                          D社スマホアプリプロジェクト
+                        </div>
                       </li>
                     </ul>
                   </div>
@@ -1316,30 +1349,16 @@
                             <a
                               data-modal-target="defaultModal"
                               data-modal-toggle="defaultModal"
-                              class="block px-4 py-3 hover:bg-brightGray-50 text-base hover:cursor-pointer"
-                            >
-                              カスタムグループを作る
-                            </a>
-                          </li>
-                          <li>
-                            <a
                               href="#"
                               class="block px-4 py-3 hover:bg-brightGray-50 text-base hover:cursor-pointer"
                               >カスタムグループの編集</a
-                            >
-                          </li>
-                          <li>
-                            <a
-                              href="#"
-                              class="block px-4 py-3 hover:bg-brightGray-50 text-base hover:cursor-pointer"
-                              >カスタムグループの削除</a
                             >
                           </li>
                         </ul>
                       </div>
                     </li>
                   </ul>
-                  <div class="flex border-b border-brightGray-50">
+                  <div class="flex border-b border-brightGray-50 min-h-[36px]">
                     <div class="overflow-hidden">
                       <ul
                         class="overflow-hidden flex text-base !text-sm w-[800px]"
@@ -1378,7 +1397,7 @@
                     </button>
                   </div>
 
-                  <div class="pt-3 pb-1 px-6">
+                  <div class="pt-3 pb-1 px-6 min-h-[192px]">
                     <ul class="flex flex-wrap gap-y-1">
                       <li
                         class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
@@ -1496,7 +1515,7 @@
                 <!-- Modal content -->
                 <div class="relative bg-white rounded-sm shadow-md p-16 pt-14">
                   <!-- Modal header -->
-                  <h3 class="text-[28px] mb-4">カスタムグループを作る</h3>
+                  <h3 class="text-[28px] mb-4">カスタムグループの編集</h3>
                   <!-- Modal body -->
                   <div class="flex">
                     <!-- modal left -->
@@ -1504,100 +1523,82 @@
                       class="w-[790px] pr-10 border-r border-r-brightGray-200 border-dashed"
                     >
                       <p class="text-base">
-                        <span class="font-bold">気になる</span
+                        <span class="font-bold">関わっているユーザー</span
                         >からメンバーとして追加
                       </p>
                       <div
-                        class="bg-white rounded-md border border-brightGray-100 mt-2 mb-4"
+                        class="bg-white rounded-md mt-1 border border-brightGray-200"
                       >
                         <div
-                          class="text-sm font-medium text-center text-brightGray-200"
+                          class="text-sm font-medium text-center text-brightGray-500"
                         >
                           <ul
-                            class="flex content-between border-b border-brightGray-100"
+                            class="flex content-between border-b border-brightGray-200"
                           >
                             <li class="w-full">
                               <a
                                 href="#"
                                 class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
-                                >参考になる人</a
+                                >気になる人</a
                               >
                             </li>
                             <li class="w-full">
                               <a
                                 href="#"
                                 class="py-3.5 w-full items-center justify-center inline-block"
-                                >採用</a
+                                >チーム</a
                               >
                             </li>
                             <li class="w-full">
                               <a
                                 href="#"
                                 class="py-3.5 w-full items-center justify-center inline-block"
-                                >離任者</a
+                                >採用候補者</a
                               >
-                            </li>
-                            <li class="w-full">
-                              <a
-                                href="#"
-                                class="py-3.5 w-full items-center justify-center inline-block"
-                                >スキルパネル</a
-                              >
-                            </li>
-                            <li class="w-full">
-                              <a
-                                href="#"
-                                class="py-3.5 w-full items-center justify-center inline-block"
-                                >ジョブ</a
-                              >
-                            </li>
-                            <li class="flex items-center">
-                              <button
-                                type="button"
-                                id="dropmenu04"
-                                data-dropdown-toggle="menu04"
-                                class="text-black rounded-full w-10 h-10 inline-flex items-center justify-center"
-                              >
-                                <span
-                                  class="material-icons text-xs text-brightGreen-900"
-                                  >more_vert</span
-                                >
-                              </button>
-                              <!-- Dropdown menu -->
-                              <div
-                                id="menu04"
-                                class="z-10 hidden bg-white divide-y divide-gray-100 rounded-lg shadow-md w-44 dark:bg-gray-700"
-                              >
-                                <ul
-                                  class="py-2 text-sm text-gray-700 dark:text-gray-200"
-                                  aria-labelledby="dropmenu04"
-                                >
-                                  <li>
-                                    <a
-                                      href="#"
-                                      class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
-                                      >menu4-1</a
-                                    >
-                                  </li>
-                                  <li>
-                                    <a
-                                      href="#"
-                                      class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
-                                      >menu4-2</a
-                                    >
-                                  </li>
-                                  <li>
-                                    <a
-                                      href="#"
-                                      class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
-                                      >menu4-3</a
-                                    >
-                                  </li>
-                                </ul>
-                              </div>
                             </li>
                           </ul>
-                          <div class="pt-3 pb-1 px-6">
+                          <div
+                            class="flex border-b border-brightGray-50 min-h-[36px]"
+                          >
+                            <div class="overflow-hidden">
+                              <ul
+                                class="overflow-hidden flex text-base !text-sm w-[800px]"
+                              >
+                                <li
+                                  class="py-2 w-[200px] border-r border-brightGray-50"
+                                >
+                                  キャリアの参考になる方々
+                                </li>
+                                <li
+                                  class="py-2 w-[200px] border-r border-brightGray-50 bg-brightGreen-50"
+                                >
+                                  優秀なエンジニアの方々
+                                </li>
+                                <li
+                                  class="py-2 w-[200px] border-r border-brightGray-50"
+                                >
+                                  カスタムグループ３
+                                </li>
+                                <li
+                                  class="py-2 w-[200px] border-r border-brightGray-50"
+                                >
+                                  カスタムグループ４
+                                </li>
+                              </ul>
+                            </div>
+                            <button class="px-1 border-l border-brightGray-50">
+                              <span
+                                class="w-0 h-0 border-solid border-l-0 border-r-[10px] border-r-brightGray-300 border-t-[6px] border-t-transparent border-b-[6px] border-b-transparent inline-block"
+                              ></span>
+                            </button>
+                            <button class="px-1 border-l border-brightGray-50">
+                              <span
+                                class="w-0 h-0 border-solid border-r-0 border-l-[10px] border-l-brightGray-300 border-t-[6px] border-t-transparent border-b-[6px] border-b-transparent inline-block"
+                              ></span>
+                            </button>
+                          </div>
+
+                          <div class="pt-3 pb-1 px-6 min-h-[192px]">
                             <ul class="flex flex-wrap gap-y-1">
                               <li
                                 class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
@@ -1706,7 +1707,7 @@
                         </div>
                       </div>
 
-                      <div>
+                      <div class="pt-6">
                         <p class="pb-2 text-base">
                           <span class="font-bold">ハンドル名</span>または<span
                             class="font-bold"
@@ -1730,18 +1731,26 @@
                     <!-- modal-right -->
                     <div class="w-[580px] pl-10 flex flex-col justify-between">
                       <div>
-                        <h5 class="text-[20px]">新しいグループ</h5>
+                        <div class="flex justify-between items-end">
+                          <h5 class="text-[20px]">編集後のグループ</h5>
+                          <button
+                            class="font-bold text-sm px-5 py-3 rounded border border-base mb-2"
+                          >
+                            グループを削除する
+                          </button>
+                        </div>
+
                         <div class="bg-brightGray-10 rounded-sm px-10 py-6">
                           <dl class="flex flex-wrap w-full">
                             <dt
                               class="font-bold w-[100px] flex items-center mb-10"
                             >
-                              チーム名
+                              グループ名
                             </dt>
                             <dd class="w-[340px] mb-10">
                               <input
                                 type="text"
-                                placeholder="新しいチーム名を入力してください"
+                                placeholder="優秀なエンジニアの方々"
                                 class="px-5 py-2 border border-brightGray-100 rounded-sm flex-1 w-full"
                               />
                             </dd>
@@ -1766,7 +1775,7 @@
                                     </div>
                                     <button class="mx-4">
                                       <span
-                                        class="material-icons text-white !text-sm bg-base rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                        class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
                                         >close</span
                                       >
                                     </button>
@@ -1790,7 +1799,7 @@
                                     </div>
                                     <button class="mx-4">
                                       <span
-                                        class="material-icons text-white !text-sm bg-base rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                        class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
                                         >close</span
                                       >
                                     </button>
@@ -1814,7 +1823,7 @@
                                     </div>
                                     <button class="mx-4">
                                       <span
-                                        class="material-icons text-white !text-sm bg-base rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                        class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
                                         >close</span
                                       >
                                     </button>
@@ -1826,16 +1835,11 @@
                         </div>
                       </div>
 
-                      <div class="flex justify-center gap-x-4">
+                      <div class="flex justify-end gap-x-4">
                         <button
                           class="text-sm font-bold px-5 py-3 rounded text-white bg-base"
                         >
-                          チームを作成し、上記メンバーに招待を送る
-                        </button>
-                        <button
-                          class="text-sm font-bold px-5 py-3 rounded border border-base"
-                        >
-                          キャンセル
+                          グループを編集し、上記メンバーに招待を送る
                         </button>
                       </div>
                     </div>
@@ -1875,6 +1879,105 @@
                         class="text-sm font-bold px-5 py-2 rounded border bg-base text-white"
                       >
                         登録を依頼する
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div
+              id="teamSupportModal"
+              tabindex="-1"
+              aria-hidden="true"
+              class="bg-brightGray-900 bg-opacity-70 fixed top-0 left-0 right-0 z-50 hidden w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-full max-h-full"
+            >
+              <div class="relative">
+                <!-- close button -->
+                <button class="absolute right-3 top-3 z-10">
+                  <span class="material-icons !text-xl text-brightGray-900"
+                    >close</span
+                  >
+                </button>
+
+                <div class="relative bg-white rounded-sm shadow-md p-8">
+                  <div class="flex flex-col w-[440px]">
+                    <h4 class="!text-left mb-8 w-full">チーム支援</h4>
+
+                    <dl class="flex flex-wrap">
+                      <dt class="font-bold w-[100px] flex items-center mb-6">
+                        グループ名
+                      </dt>
+                      <dd class="w-[340px] mb-6">スマホ開発チーム</dd>
+                      <dt class="font-bold w-[100px] flex items-center mb-6">
+                        管理者
+                      </dt>
+                      <dd class="w-[340px] mb-6">Piacere</dd>
+                      <dt class="font-bold w-[100px] mb-6">メンバー</dt>
+                      <dd class="w-[340px] mb-6">
+                        <ul class="flex flex-wrap gap-y-1">
+                          <li
+                            class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
+                          >
+                            <a class="inline-flex items-center gap-x-6 w-full">
+                              <img
+                                class="inline-block h-10 w-10 rounded-full"
+                                src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                              />
+                              <div class="flex-auto">
+                                <p>nokichi</p>
+                                <p class="text-brightGray-300">
+                                  アプリエンジニア
+                                </p>
+                              </div>
+                            </a>
+                          </li>
+                          <li
+                            class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
+                          >
+                            <a class="inline-flex items-center gap-x-6 w-full">
+                              <img
+                                class="inline-block h-10 w-10 rounded-full"
+                                src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                              />
+                              <div class="flex-auto">
+                                <p>nokichi</p>
+                                <p class="text-brightGray-300">
+                                  アプリエンジニア
+                                </p>
+                              </div>
+                            </a>
+                          </li>
+                          <li
+                            class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
+                          >
+                            <a class="inline-flex items-center gap-x-6 w-full">
+                              <img
+                                class="inline-block h-10 w-10 rounded-full"
+                                src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                              />
+                              <div class="flex-auto">
+                                <p>nokichi</p>
+                                <p class="text-brightGray-300">
+                                  アプリエンジニア
+                                </p>
+                              </div>
+                            </a>
+                          </li>
+                        </ul>
+                      </dd>
+                    </dl>
+
+                    <div class="flex justify-end gap-x-4">
+                      <button
+                        class="text-sm font-bold px-5 py-2 rounded border bg-base text-white"
+                      >
+                        支援する
+                      </button>
+                      <button
+                        class="text-sm font-bold px-5 py-2 rounded border border-base text-base"
+                      >
+                        支援対象チームではない
                       </button>
                     </div>
                   </div>

--- a/frontend/dist/mypage_empty.html
+++ b/frontend/dist/mypage_empty.html
@@ -1,0 +1,1227 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="./output.css" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Round|Material+Icons+Sharp|Material+Icons+Two+Tone"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  </head>
+  <body class="w-[1920px]">
+    <div class="flex w-full">
+      <aside
+        class="flex bg-brightGray-900 min-h-screen flex-col w-[200px] pt-3"
+      >
+        <img src="./images/common/logo.svg" width="163px" class="ml-4" />
+        <ul class="grid pt-2">
+          <li>
+            <a
+              class="!text-white bg-white bg-opacity-30 text-base py-4 inline-block pl-4 w-full mb-1"
+              href="/mypage"
+              >マイページ</a
+            >
+          </li>
+          <li>
+            <a
+              class="!text-white text-base py-4 inline-block pl-4 w-full mb-1"
+              href="/"
+              >スキルを選ぶ</a
+            >
+          </li>
+          <li>
+            <a
+              class="!text-white text-base py-4 inline-block pl-4 w-full mb-1"
+              href="/mypage"
+              >成長を見る・比較する</a
+            >
+          </li>
+          <li>
+            <a
+              class="!text-white text-base py-4 inline-block pl-4 w-full mb-1"
+              href="/mypage"
+              >スキルパネルを入力</a
+            >
+          </li>
+
+          <li>
+            <a
+              class="!text-white text-base py-4 inline-block pl-4 w-full mb-1"
+              href="/mypage"
+              >スキルアップを目指す</a
+            >
+          </li>
+          <li>
+            <a
+              class="!text-white text-base py-4 inline-block pl-4 w-full mb-1"
+              href="/mypage"
+              >チームスキル分析</a
+            >
+          </li>
+          <li>
+            <a
+              class="!text-white text-base py-4 inline-block pl-4 w-full mb-1"
+              href="/mypage"
+              >キャリアパスを選ぶ</a
+            >
+          </li>
+        </ul>
+      </aside>
+      <main
+        class="bg-background flex flex-col flex-1 border-brightGray-100 border-r"
+      >
+        <!-- ヘッダー -->
+        <div
+          class="w-full flex justify-between py-2.5 px-10 border-brightGray-100 border-b bg-white"
+        >
+          <h4>マイページ</h4>
+          <div class="flex gap-x-5">
+            <button
+              type="button"
+              class="text-white bg-[#f57f3e] px-4 inline-flex rounded-md text-sm items-center font-bold h-9 hover:opacity-70"
+            >
+              <span
+                class="bg-white material-icons mr-1 !text-base !text-[#f57f3e] rounded-full h-6 w-6 !font-bold material-icons-outlined"
+                >upgrade</span
+              >
+              プランのアップグレード
+            </button>
+            <button
+              type="button"
+              class="text-white bg-brightGreen-300 px-4 inline-flex rounded-md text-sm items-center font-bold h-9 hover:opacity-70"
+            >
+              <span
+                class="bg-white material-icons mr-1 !text-base !text-brightGreen-300 rounded-full h-6 w-6 !font-bold material-icons-outlined"
+                >sms</span
+              >
+              カスタマーサクセスに連絡
+            </button>
+
+            <button
+              type="button"
+              class="text-white bg-brightGreen-300 px-4 inline-flex rounded-md text-sm items-center font-bold h-9 hover:opacity-70"
+            >
+              <span
+                class="bg-white material-icons mr-1 !text-base !text-brightGreen-300 rounded-full h-6 w-6 !font-bold"
+                >search</span
+              >
+              スキル保有者を検索
+            </button>
+
+            <button class="hover:opacity-70">
+              <img
+                class="inline-block h-10 w-10 rounded-full"
+                src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+              />
+            </button>
+
+            <button
+              class="rounded-full border border-brightGray-600 h-10 w-10 flex items-center justify-center"
+            >
+              <span class="material-icons text-brightGray-600">logout</span>
+            </button>
+          </div>
+        </div>
+        <div
+          id="mega-menu-dropdown"
+          class="absolute hidden z-10 w-[1000px] !top-1 min-h-full grid-cols-2 text-sm bg-white shadow-md dark:border-gray-700 md:grid-cols-3 dark:bg-gray-700"
+        >
+          <div class="p-4 pb-0 text-gray-900 md:pb-4 dark:text-white">
+            <ul class="space-y-4" aria-labelledby="mega-menu-dropdown-button">
+              <li>
+                <a
+                  href="#"
+                  class="text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-500"
+                >
+                  About Us
+                </a>
+              </li>
+              <li>
+                <a
+                  href="#"
+                  class="text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-500"
+                >
+                  Library
+                </a>
+              </li>
+              <li>
+                <a
+                  href="#"
+                  class="text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-500"
+                >
+                  Resources
+                </a>
+              </li>
+              <li>
+                <a
+                  href="#"
+                  class="text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-500"
+                >
+                  Pro Version
+                </a>
+              </li>
+            </ul>
+          </div>
+          <div class="p-4 pb-0 text-gray-900 md:pb-4 dark:text-white">
+            <ul class="space-y-4">
+              <li>
+                <a
+                  href="#"
+                  class="text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-500"
+                >
+                  Blog
+                </a>
+              </li>
+              <li>
+                <a
+                  href="#"
+                  class="text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-500"
+                >
+                  Newsletter
+                </a>
+              </li>
+              <li>
+                <a
+                  href="#"
+                  class="text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-500"
+                >
+                  Playground
+                </a>
+              </li>
+              <li>
+                <a
+                  href="#"
+                  class="text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-500"
+                >
+                  License
+                </a>
+              </li>
+            </ul>
+          </div>
+          <div class="p-4">
+            <ul class="space-y-4">
+              <li>
+                <a
+                  href="#"
+                  class="text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-500"
+                >
+                  Contact Us
+                </a>
+              </li>
+              <li>
+                <a
+                  href="#"
+                  class="text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-500"
+                >
+                  Support Center
+                </a>
+              </li>
+              <li>
+                <a
+                  href="#"
+                  class="text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-500"
+                >
+                  Terms
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <!-- プロフィール -->
+        <div class="flex justify-between py-6 px-10 bg-white">
+          <div class="w-[850px] pt-4">
+            <div class="flex">
+              <div
+                class="bg-test bg-contain h-20 w-20 mr-5"
+                style="
+                  background-image: url('./images/sample/sample-image.png');
+                "
+              ></div>
+              <div class="flex-1">
+                <div class="flex justify-between pb-2 items-end">
+                  <div class="text-2xl font-bold">piacere</div>
+                  <div class="flex gap-x-3">
+                    <button
+                      type="button"
+                      class="text-gray-900 bg-white px-2 py-1 inline-flex font-medium rounded-md text-sm items-center border hover:border-brightGreen-300 group"
+                    >
+                      <span
+                        class="material-icons md-18 mr-1 text-brightGray-200 group-hover:text-brightGreen-300"
+                        >share</span
+                      >
+                      優秀な人として紹介
+                    </button>
+
+                    <button
+                      type="button"
+                      id="dropcheckmenu"
+                      data-dropdown-toggle="checkmenu"
+                      class="text-gray-900 bg-white px-2 py-1 inline-flex font-medium rounded-md text-sm items-center border border-brightGray-200 hover:border-brightGreen-300 group"
+                    >
+                      <span
+                        class="material-icons md-18 mr-1 text-brightGray-200 group-hover:text-brightGreen-300"
+                        >star</span
+                      >
+                      気になる
+                    </button>
+                    <!-- 気になるDropdown menu -->
+                    <div
+                      id="checkmenu"
+                      class="z-10 hidden bg-white rounded-lg shadow min-w-[286px]"
+                    >
+                      <ul
+                        class="p-2 text-left text-base"
+                        aria-labelledby="dropcheckmenu"
+                      >
+                        <li>
+                          <a
+                            href="#"
+                            class="block px-4 py-3 hover:bg-brightGray-50 text-base"
+                            >気になるリスト</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="#"
+                            class="block px-4 py-3 hover:bg-brightGray-50 text-base"
+                            >メンバー候補</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="#"
+                            class="block px-4 py-3 hover:bg-brightGray-50 text-base"
+                            >java開発者リスト</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="#"
+                            class="block px-4 py-3 hover:bg-brightGray-50 text-base"
+                            >Python開発者リスト</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="#"
+                            class="block px-4 py-3 hover:bg-brightGray-50 text-base"
+                            >ジュニアエンジニア</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="#"
+                            class="block px-4 py-3 hover:bg-brightGray-50 text-base"
+                            >シニアエンジニア</a
+                          >
+                        </li>
+                        <li
+                          class="px-4 py-3 hover:bg-brightGray-50 flex justify-center gap-x-2"
+                        >
+                          <input
+                            type="text"
+                            placeholder="リスト名を入力"
+                            class="px-2 py-1 border border-brightGray-900 rounded-sm flex-1 w-full text-base w-[220px]"
+                          />
+                          <button
+                            class="text-sm font-bold px-4 py-1 rounded text-white bg-base"
+                          >
+                            新規作成
+                          </button>
+                        </li>
+                      </ul>
+                    </div>
+
+                    <button
+                      type="button"
+                      class="text-brightGreen-300 bg-white px-2 py-1 inline-flex rounded-md text-sm items-center border border-brightGreen-300 font-bold"
+                    >
+                      自分に戻す
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="flex justify-between pt-3 border-brightGray-100 border-t"
+                >
+                  <div class="text-2xl">リードプログラマー</div>
+                  <div class="flex gap-x-6 mr-2">
+                    <button type="button">
+                      <img src="./images/common/twitter.svg" width="26px" />
+                    </button>
+                    <button type="button">
+                      <img src="./images/common/github.svg" width="26px" />
+                    </button>
+                    <button type="button">
+                      <img src="./images/common/facebook.svg" width="26px" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="pt-5">
+              高校・大学と野球部に入っていました。チームで開発を行うような仕事が得意です。メインで使っている言語はJavaで中規模～大規模のシステム開発を受け持っています。最近Elixirを学び始め、Elixirで仕事ができると嬉しいです。
+            </div>
+          </div>
+          <div>
+            <p class="text-base !font-bold">
+              スキルセットジェム<span class="font-normal text-xs ml-2"
+                >※クリックしてください</span
+              >
+            </p>
+            <div class="chart-container flex justify-center h-[176px]">
+              <canvas id="myChart" height="100px" width="100px"></canvas>
+            </div>
+          </div>
+        </div>
+        <!-- コンテンツ -->
+        <div class="px-10 py-3 flex justify-between">
+          <div class="w-[850px] flex flex-col gap-y-6">
+            <!-- 重要な連絡 -->
+            <div>
+              <h5>重要な連絡</h5>
+              <div class="bg-white rounded-md mt-1">
+                <div
+                  class="text-sm font-medium text-center text-brightGray-500"
+                >
+                  <ul
+                    class="flex content-between border-b border-brightGray-200"
+                  >
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >チーム招待</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >デイリー</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >ウイークリー</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
+                        >採用の調整</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >スキルパネル更新</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >運営</a
+                      >
+                    </li>
+                  </ul>
+                  <div class="pt-4 px-6 min-h-[216px]">
+                    <ul class="flex gap-y-2.5 flex-col">
+                      <li class="flex">
+                        <div
+                          class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2"
+                        >
+                          重要な連絡はありません
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                  <div class="flex justify-center gap-x-14 pb-3">
+                    <button
+                      type="button"
+                      class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                    >
+                      <span
+                        class="material-icons md-18 mr-2 text-brightGray-200"
+                        >chevron_left</span
+                      >
+                      前
+                    </button>
+                    <button
+                      type="button"
+                      class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                    >
+                      次
+                      <span
+                        class="material-icons md-18 ml-2 text-brightGray-900"
+                        >chevron_right</span
+                      >
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- 保有スキル（ジェムをクリックすると成長グラフが見れます） -->
+            <div>
+              <h5>保有スキル（ジェムをクリックすると成長グラフが見れます）</h5>
+              <div class="bg-white rounded-md mt-1">
+                <div
+                  class="text-sm font-medium text-center text-brightGray-900"
+                >
+                  <ul
+                    class="flex content-between border-b border-brightGray-200"
+                  >
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
+                        >エンジニア</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >インフラ</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >デザイナー</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >マーケッター</a
+                      >
+                    </li>
+                  </ul>
+
+                  <div class="py-6 px-7 flex gap-y-4 flex-col min-h-[464px]">
+                    <ul class="flex gap-y-2.5 flex-col">
+                      <li class="flex">
+                        <div
+                          class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2"
+                        >
+                          保有スキルはありません
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+
+                  <div class="flex justify-center gap-x-14 pb-3">
+                    <button
+                      type="button"
+                      class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                    >
+                      <span
+                        class="material-icons md-18 mr-2 text-brightGray-200"
+                        >chevron_left</span
+                      >
+                      前
+                    </button>
+                    <button
+                      type="button"
+                      class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                    >
+                      次
+                      <span
+                        class="material-icons md-18 ml-2 text-brightGray-900"
+                        >chevron_right</span
+                      >
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="w-[750px] flex flex-col gap-y-6">
+            <!-- さまざまな人たちとの交流 -->
+            <div>
+              <h5>さまざまな人たちとの交流</h5>
+              <div class="bg-white rounded-md mt-1">
+                <div
+                  class="text-sm font-medium text-center text-brightGray-500"
+                >
+                  <ul
+                    class="flex content-between border-b border-brightGray-200"
+                  >
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >スキルアップ</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >1on1のお誘い</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
+                        >所属チームから</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >「気になる」された</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >運営公式チーム発足</a
+                      >
+                    </li>
+                  </ul>
+                  <div class="pt-4 px-6 min-h-[216px]">
+                    <ul class="flex gap-y-2.5 flex-col">
+                      <li class="flex">
+                        <div
+                          class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2"
+                        >
+                          交流はまだありません
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                  <div class="flex justify-center gap-x-14 pb-3">
+                    <button
+                      type="button"
+                      class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                    >
+                      <span
+                        class="material-icons md-18 mr-2 text-brightGray-200"
+                        >chevron_left</span
+                      >
+                      前
+                    </button>
+                    <button
+                      type="button"
+                      class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                    >
+                      次
+                      <span
+                        class="material-icons md-18 ml-2 text-brightGray-900"
+                        >chevron_right</span
+                      >
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- 関わっているチーム -->
+            <div>
+              <h5>関わっているチーム</h5>
+              <div class="bg-white rounded-md mt-1">
+                <div
+                  class="text-sm font-medium text-center text-brightGray-500"
+                >
+                  <ul
+                    class="flex content-between border-b border-brightGray-200"
+                  >
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
+                        >所属チーム</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >管轄チーム</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >カスタムグループ</a
+                      >
+                    </li>
+                  </ul>
+                  <div class="pt-4 px-6 min-h-[216px]">
+                    <ul class="flex gap-y-2.5 flex-col">
+                      <li class="flex">
+                        <div
+                          class="text-left flex items-center text-base px-1 py-1 hover:bg-brightGray-50 flex-1 mr-2"
+                        >
+                          所属しているチームはありません
+                        </div>
+                        <div class="flex gap-x-2">
+                          <button
+                            disabled
+                            class="text-bold inline-block bg-brightGray-900 !text-white min-w-[76px] rounded py-1 px-2 text-sm"
+                          >
+                            チームを作る
+                          </button>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                  <div class="flex justify-center gap-x-14 pb-3">
+                    <button
+                      type="button"
+                      class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                    >
+                      <span
+                        class="material-icons md-18 mr-2 text-brightGray-200"
+                        >chevron_left</span
+                      >
+                      前
+                    </button>
+                    <button
+                      type="button"
+                      class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                    >
+                      次
+                      <span
+                        class="material-icons md-18 ml-2 text-brightGray-900"
+                        >chevron_right</span
+                      >
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- 気になる -->
+            <div>
+              <h5>関わっているユーザー</h5>
+              <div class="bg-white rounded-md mt-1">
+                <div
+                  class="text-sm font-medium text-center text-brightGray-500"
+                >
+                  <ul
+                    class="flex content-between border-b border-brightGray-200"
+                  >
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
+                        >気になる人</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >チーム</a
+                      >
+                    </li>
+                    <li class="w-full">
+                      <a
+                        href="#"
+                        class="py-3.5 w-full items-center justify-center inline-block"
+                        >採用候補者</a
+                      >
+                    </li>
+                    <li class="flex items-center">
+                      <button
+                        type="button"
+                        id="dropmenu04"
+                        data-dropdown-offset-skidding="-130"
+                        data-dropdown-placement="bottom"
+                        data-dropdown-toggle="menu04"
+                        class="text-black rounded-full w-10 h-10 inline-flex items-center justify-center"
+                      >
+                        <span
+                          class="material-icons text-xs text-brightGreen-900"
+                          >more_vert</span
+                        >
+                      </button>
+                      <!-- 関わっているユーザー Dropdown menu -->
+                      <div
+                        id="menu04"
+                        class="z-10 hidden bg-white rounded-lg shadow-md min-w-[286px] border border-brightGray-50"
+                      >
+                        <ul
+                          class="p-2 text-left text-base"
+                          aria-labelledby="dropmenu04"
+                        >
+                          <li>
+                            <a
+                              href="#"
+                              class="block px-4 py-3 hover:bg-brightGray-50 text-base hover:cursor-pointer"
+                              >カスタムグループの編集</a
+                            >
+                          </li>
+                        </ul>
+                      </div>
+                    </li>
+                  </ul>
+                  <div
+                    class="flex border-b border-brightGray-50 min-h-[36px]"
+                  ></div>
+
+                  <div class="pt-3 pb-1 px-6 min-h-[192px]">
+                    <ul class="flex gap-y-2.5 flex-col">
+                      <li class="flex">
+                        <div
+                          class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2"
+                        >
+                          関わっているユーザーはいません
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                  <div class="flex justify-center gap-x-14 pb-3">
+                    <button
+                      type="button"
+                      class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                    >
+                      <span
+                        class="material-icons md-18 mr-2 text-brightGray-200"
+                        >chevron_left</span
+                      >
+                      前
+                    </button>
+                    <button
+                      type="button"
+                      class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                    >
+                      次
+                      <span
+                        class="material-icons md-18 ml-2 text-brightGray-900"
+                        >chevron_right</span
+                      >
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- チーム作成モーダル-->
+            <!-- Main modal -->
+            <div
+              id="defaultModal"
+              tabindex="-1"
+              aria-hidden="true"
+              class="bg-brightGray-900 bg-opacity-70 fixed top-0 left-0 right-0 z-50 hidden w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-full max-h-full"
+            >
+              <div class="relative w-[1500px] max-h-full">
+                <!-- close button -->
+                <button class="absolute right-5 top-5 z-10">
+                  <span class="material-icons !text-3xl text-brightGray-900"
+                    >close</span
+                  >
+                </button>
+                <!-- Modal content -->
+                <div class="relative bg-white rounded-sm shadow-md p-16 pt-14">
+                  <!-- Modal header -->
+                  <h3 class="text-[28px] mb-4">カスタムグループを作る</h3>
+                  <!-- Modal body -->
+                  <div class="flex">
+                    <!-- modal left -->
+                    <div
+                      class="w-[790px] pr-10 border-r border-r-brightGray-200 border-dashed"
+                    >
+                      <p class="text-base">
+                        <span class="font-bold">気になる</span
+                        >からメンバーとして追加
+                      </p>
+                      <div
+                        class="bg-white rounded-md border border-brightGray-100 mt-2 mb-4"
+                      >
+                        <div
+                          class="text-sm font-medium text-center text-brightGray-200"
+                        >
+                          <ul
+                            class="flex content-between border-b border-brightGray-100"
+                          >
+                            <li class="w-full">
+                              <a
+                                href="#"
+                                class="py-3.5 w-full items-center justify-center inline-block text-brightGreen-300 font-bold border-brightGreen-300 border-b-2"
+                                >参考になる人</a
+                              >
+                            </li>
+                            <li class="w-full">
+                              <a
+                                href="#"
+                                class="py-3.5 w-full items-center justify-center inline-block"
+                                >採用</a
+                              >
+                            </li>
+                            <li class="w-full">
+                              <a
+                                href="#"
+                                class="py-3.5 w-full items-center justify-center inline-block"
+                                >離任者</a
+                              >
+                            </li>
+                            <li class="w-full">
+                              <a
+                                href="#"
+                                class="py-3.5 w-full items-center justify-center inline-block"
+                                >スキルパネル</a
+                              >
+                            </li>
+                            <li class="w-full">
+                              <a
+                                href="#"
+                                class="py-3.5 w-full items-center justify-center inline-block"
+                                >ジョブ</a
+                              >
+                            </li>
+                            <li class="flex items-center">
+                              <button
+                                type="button"
+                                id="dropmenu04"
+                                data-dropdown-toggle="menu04"
+                                class="text-black rounded-full w-10 h-10 inline-flex items-center justify-center"
+                              >
+                                <span
+                                  class="material-icons text-xs text-brightGreen-900"
+                                  >more_vert</span
+                                >
+                              </button>
+                              <!-- Dropdown menu -->
+                              <div
+                                id="menu04"
+                                class="z-10 hidden bg-white divide-y divide-gray-100 rounded-lg shadow-md w-44 dark:bg-gray-700"
+                              >
+                                <ul
+                                  class="py-2 text-sm text-gray-700 dark:text-gray-200"
+                                  aria-labelledby="dropmenu04"
+                                >
+                                  <li>
+                                    <a
+                                      href="#"
+                                      class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
+                                      >menu4-1</a
+                                    >
+                                  </li>
+                                  <li>
+                                    <a
+                                      href="#"
+                                      class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
+                                      >menu4-2</a
+                                    >
+                                  </li>
+                                  <li>
+                                    <a
+                                      href="#"
+                                      class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
+                                      >menu4-3</a
+                                    >
+                                  </li>
+                                </ul>
+                              </div>
+                            </li>
+                          </ul>
+                          <div class="pt-3 pb-1 px-6">
+                            <ul class="flex flex-wrap gap-y-1">
+                              <li
+                                class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2"
+                              >
+                                <a class="inline-flex items-center gap-x-6">
+                                  <img
+                                    class="inline-block h-10 w-10 rounded-full"
+                                    src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                  />
+                                  <div>
+                                    <p>nokichi</p>
+                                    <p class="text-brightGray-300">
+                                      アプリエンジニア
+                                    </p>
+                                  </div>
+                                </a>
+                              </li>
+                            </ul>
+                          </div>
+                          <div class="flex justify-center gap-x-14 pb-3">
+                            <button
+                              type="button"
+                              class="text-brightGray-200 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                            >
+                              <span
+                                class="material-icons md-18 mr-2 text-brightGray-200"
+                                >chevron_left</span
+                              >
+                              前
+                            </button>
+                            <button
+                              type="button"
+                              class="text-brightGray-900 bg-white px-3 py-1.5 inline-flex font-medium rounded-md text-sm items-center"
+                            >
+                              次
+                              <span
+                                class="material-icons md-18 ml-2 text-brightGray-900"
+                                >chevron_right</span
+                              >
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div>
+                        <p class="pb-2 text-base">
+                          <span class="font-bold">ハンドル名</span>または<span
+                            class="font-bold"
+                            >メールアドレス</span
+                          >からメンバーとして追加
+                        </p>
+
+                        <input
+                          type="autocomplete"
+                          placeholder="ハンドル名またはメールアドレスを入力してください"
+                          class="px-5 py-2 border border-brightGray-100 rounded-sm flex-1 w-[390px]"
+                        />
+
+                        <button
+                          class="text-sm font-bold px-5 py-2 rounded border border-base ml-2.5"
+                        >
+                          追加
+                        </button>
+                      </div>
+                    </div>
+                    <!-- modal-right -->
+                    <div class="w-[580px] pl-10 flex flex-col justify-between">
+                      <div>
+                        <h5 class="text-[20px]">新しいグループ</h5>
+                        <div class="bg-brightGray-10 rounded-sm px-10 py-6">
+                          <dl class="flex flex-wrap w-full">
+                            <dt
+                              class="font-bold w-[100px] flex items-center mb-10"
+                            >
+                              チーム名
+                            </dt>
+                            <dd class="w-[340px] mb-10">
+                              <input
+                                type="text"
+                                placeholder="新しいチーム名を入力してください"
+                                class="px-5 py-2 border border-brightGray-100 rounded-sm flex-1 w-full"
+                              />
+                            </dd>
+                            <dt class="font-bold w-[100px] mb-10">メンバー</dt>
+                            <dd class="w-[340px]">
+                              <ul class="flex flex-wrap gap-y-1">
+                                <li
+                                  class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
+                                >
+                                  <a
+                                    class="inline-flex items-center gap-x-6 w-full"
+                                  >
+                                    <img
+                                      class="inline-block h-10 w-10 rounded-full"
+                                      src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                    />
+                                    <div class="flex-auto">
+                                      <p>nokichi</p>
+                                      <p class="text-brightGray-300">
+                                        アプリエンジニア
+                                      </p>
+                                    </div>
+                                    <button class="mx-4">
+                                      <span
+                                        class="material-icons text-white !text-sm bg-base rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                        >close</span
+                                      >
+                                    </button>
+                                  </a>
+                                </li>
+                                <li
+                                  class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
+                                >
+                                  <a
+                                    class="inline-flex items-center gap-x-6 w-full"
+                                  >
+                                    <img
+                                      class="inline-block h-10 w-10 rounded-full"
+                                      src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                    />
+                                    <div class="flex-auto">
+                                      <p>nokichi</p>
+                                      <p class="text-brightGray-300">
+                                        アプリエンジニア
+                                      </p>
+                                    </div>
+                                    <button class="mx-4">
+                                      <span
+                                        class="material-icons text-white !text-sm bg-base rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                        >close</span
+                                      >
+                                    </button>
+                                  </a>
+                                </li>
+                                <li
+                                  class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded border border-brightGray-100 bg-white w-full"
+                                >
+                                  <a
+                                    class="inline-flex items-center gap-x-6 w-full"
+                                  >
+                                    <img
+                                      class="inline-block h-10 w-10 rounded-full"
+                                      src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80"
+                                    />
+                                    <div class="flex-auto">
+                                      <p>nokichi</p>
+                                      <p class="text-brightGray-300">
+                                        アプリエンジニア
+                                      </p>
+                                    </div>
+                                    <button class="mx-4">
+                                      <span
+                                        class="material-icons text-white !text-sm bg-base rounded-full !inline-flex w-4 h-4 !items-center !justify-center"
+                                        >close</span
+                                      >
+                                    </button>
+                                  </a>
+                                </li>
+                              </ul>
+                            </dd>
+                          </dl>
+                        </div>
+                      </div>
+
+                      <div class="flex justify-center gap-x-4">
+                        <button
+                          class="text-sm font-bold px-5 py-3 rounded text-white bg-base"
+                        >
+                          チームを作成し、上記メンバーに招待を送る
+                        </button>
+                        <button
+                          class="text-sm font-bold px-5 py-3 rounded border border-base"
+                        >
+                          キャンセル
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- 人材チームへのチーム登録依頼Modal-->
+            <div
+              id="addTeamModal"
+              tabindex="-1"
+              aria-hidden="true"
+              class="bg-brightGray-900 bg-opacity-70 fixed top-0 left-0 right-0 z-50 hidden w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-full max-h-full"
+            >
+              <div class="relative">
+                <!-- close button -->
+                <button class="absolute right-3 top-3 z-10">
+                  <span class="material-icons !text-xl text-brightGray-900"
+                    >close</span
+                  >
+                </button>
+
+                <div class="relative bg-white rounded-sm shadow-md p-8">
+                  <div>
+                    <p class="pb-2 text-base font-bold">
+                      人材チームへのチーム登録依頼
+                    </p>
+
+                    <input
+                      type="autocomplete"
+                      placeholder="人材チーム名を入力"
+                      class="px-2 py-2 mb-4 border border-brightGray-100 rounded-sm flex-1 w-[420px]"
+                    />
+                    <div class="flex justify-end">
+                      <button
+                        class="text-sm font-bold px-5 py-2 rounded border bg-base text-white"
+                      >
+                        登録を依頼する
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- 検証 -->
+          </div>
+        </div>
+      </main>
+    </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.5/flowbite.min.js"></script>
+    <script>
+      const ctx = document.getElementById("myChart");
+
+      const data = {
+        labels: [
+          "エンジニア",
+          "デザイナー",
+          "マーケッター",
+          "セールス",
+          "インフラ",
+        ],
+        datasets: [
+          {
+            label: "My First Dataset",
+            data: [75, 30, 0, 0, 30],
+            fill: true,
+            backgroundColor: "rgba(82, 204, 181,0.6)",
+            borderWidth: 1,
+            pointRadius: 0,
+          },
+        ],
+      };
+      new Chart(ctx, {
+        type: "radar",
+        data: data,
+        options: {
+          plugins: {
+            legend: {
+              display: false,
+            },
+          },
+          scales: {
+            r: {
+              //グラフの最小値・最大値
+              min: 0,
+              max: 100,
+              //背景色
+              backgroundColor: "#EBFEFC",
+              ticks: {
+                min: 0, // 最小値
+                max: 100, // 最大値
+                stepSize: 20, // 目盛の間隔
+                display: false,
+              },
+              // グリッドライン
+              grid: {
+                color: "#ffffff",
+                lineWidth: 2,
+              },
+              // アングルライン
+              angleLines: {
+                color: "#ffffff",
+              },
+            },
+          },
+        },
+        layout: {
+          padding: {
+            top: 0, // 上
+            left: 0, // 左
+            right: 0, // 右
+            bottom: 0, // 下
+          },
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/frontend/dist/output.css
+++ b/frontend/dist/output.css
@@ -726,10 +726,6 @@ input.coustom-checkbox:checked:after{
   right: 0px;
 }
 
-.right-1{
-  right: 0.25rem;
-}
-
 .right-2{
   right: 0.5rem;
 }
@@ -1091,7 +1087,6 @@ input.coustom-checkbox:checked:after{
   margin-top: auto;
 }
 
-
 .mt-px{
   margin-top: 1px;
 }
@@ -1294,6 +1289,22 @@ input.coustom-checkbox:checked:after{
 
 .min-h-screen{
   min-height: 100vh;
+}
+
+.min-h-\[216px\]{
+  min-height: 216px;
+}
+
+.min-h-\[464px\]{
+  min-height: 464px;
+}
+
+.min-h-\[36px\]{
+  min-height: 36px;
+}
+
+.min-h-\[192px\]{
+  min-height: 192px;
 }
 
 .w-0{
@@ -1637,6 +1648,14 @@ input.coustom-checkbox:checked:after{
   width: 100vw;
 }
 
+.w-\[60px\]{
+  width: 60px;
+}
+
+.w-\[440px\]{
+  width: 440px;
+}
+
 .min-w-\[150px\]{
   min-width: 150px;
 }
@@ -1769,13 +1788,6 @@ input.coustom-checkbox:checked:after{
 .justify-around{
   justify-content: space-around;
 }
-.gap-1{
-  gap: 0.25rem;
-}
-
-.gap-1\.5{
-  gap: 0.375rem;
-}
 
 .gap-2{
   gap: 0.5rem;
@@ -1842,6 +1854,10 @@ input.coustom-checkbox:checked:after{
 
 .gap-y-6{
   row-gap: 1.5rem;
+}
+
+.gap-y-4{
+  row-gap: 1rem;
 }
 
 .space-y-4 > :not([hidden]) ~ :not([hidden]){
@@ -2183,6 +2199,11 @@ input.coustom-checkbox:checked:after{
   border-top-color: transparent;
 }
 
+.border-b-brightGray-300{
+  --tw-border-opacity: 1;
+  border-bottom-color: rgb(151 172 172 / var(--tw-border-opacity));
+}
+
 .bg-amethyst-50{
   --tw-bg-opacity: 1;
   background-color: rgb(244 229 246 / var(--tw-bg-opacity));
@@ -2353,6 +2374,25 @@ input.coustom-checkbox:checked:after{
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
 }
 
+.bg-\[F57D3E\]{
+  background-color: F57D3E;
+}
+
+.bg-\[\#F57D3E\]{
+  --tw-bg-opacity: 1;
+  background-color: rgb(245 125 62 / var(--tw-bg-opacity));
+}
+
+.bg-\[\#f57f3e\]{
+  --tw-bg-opacity: 1;
+  background-color: rgb(245 127 62 / var(--tw-bg-opacity));
+}
+
+.bg-brightGray-500{
+  --tw-bg-opacity: 1;
+  background-color: rgb(104 136 136 / var(--tw-bg-opacity));
+}
+
 .bg-opacity-30{
   --tw-bg-opacity: 0.3;
 }
@@ -2413,14 +2453,6 @@ input.coustom-checkbox:checked:after{
   background-repeat: no-repeat;
 }
 
-.fill-attention-900{
-  fill: #B71225;
-}
-
-.fill-brightGreen-900{
-  fill: #004D36;
-}
-
 .object-cover{
   -o-object-fit: cover;
      object-fit: cover;
@@ -2444,10 +2476,6 @@ input.coustom-checkbox:checked:after{
 
 .p-2{
   padding: 0.5rem;
-}
-
-.p-3{
-  padding: 0.75rem;
 }
 
 .p-4{
@@ -2706,13 +2734,16 @@ input.coustom-checkbox:checked:after{
   padding-top: 1.5rem;
 }
 
-
 .pt-px{
   padding-top: 1px;
 }
 
 .text-left{
   text-align: left;
+}
+
+.\!text-left{
+  text-align: left !important;
 }
 
 .text-center{
@@ -2837,26 +2868,12 @@ input.coustom-checkbox:checked:after{
   font-weight: 400;
 }
 
-
 .not-italic{
   font-style: normal;
 }
 
-
-.font-semibold{
-  font-weight: 600;
-}
-
 .leading-10{
   line-height: 2.5rem;
-}
-
-.leading-5{
-  line-height: 1.25rem;
-}
-
-.leading-6{
-  line-height: 1.5rem;
 }
 
 .leading-tight{
@@ -2953,6 +2970,16 @@ input.coustom-checkbox:checked:after{
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
+.\!text-\[\#f57f3e\]{
+  --tw-text-opacity: 1 !important;
+  color: rgb(245 127 62 / var(--tw-text-opacity)) !important;
+}
+
+.text-brightGreen-100{
+  --tw-text-opacity: 1;
+  color: rgb(169 224 215 / var(--tw-text-opacity));
+}
+
 .underline{
   text-decoration-line: underline;
 }
@@ -2967,14 +2994,8 @@ input.coustom-checkbox:checked:after{
   color: rgb(151 172 172 / var(--tw-placeholder-opacity));
 }
 
-
 .opacity-0{
   opacity: 0;
-}
-
-.opacity-40{
-  opacity: 0.4;
-
 }
 
 .shadow{
@@ -2992,22 +3013,6 @@ input.coustom-checkbox:checked:after{
 .outline-none{
   outline: 2px solid transparent;
   outline-offset: 2px;
-}
-
-.ring-1{
-  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-}
-
-.ring-attention-600{
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(229 50 63 / var(--tw-ring-opacity));
-}
-
-.ring-brightGreen-600{
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(0 137 113 / var(--tw-ring-opacity));
 }
 
 .filter{
@@ -3502,6 +3507,10 @@ input.coustom-checkbox:checked:after{
   opacity: 0.7;
 }
 
+.hover\:opacity-75:hover{
+  opacity: 0.75;
+}
+
 .hover\:before\:border-white:hover::before{
   content: var(--tw-content);
   --tw-border-opacity: 1;
@@ -3523,10 +3532,6 @@ input.coustom-checkbox:checked:after{
 .group:hover .group-hover\:text-brightGreen-300{
   --tw-text-opacity: 1;
   color: rgb(18 183 163 / var(--tw-text-opacity));
-}
-
-.group:hover .group-hover\:opacity-70{
-  opacity: 0.7;
 }
 
 .peer:checked ~ .peer-checked\:block{
@@ -3552,12 +3557,6 @@ input.coustom-checkbox:checked:after{
   .dark\:hover\:text-white:hover{
     --tw-text-opacity: 1;
     color: rgb(255 255 255 / var(--tw-text-opacity));
-  }
-}
-
-@media (min-width: 640px){
-  .sm\:w-96{
-    width: 24rem;
   }
 }
 

--- a/frontend/dist/skill_panel.html
+++ b/frontend/dist/skill_panel.html
@@ -129,7 +129,7 @@
               data-dropdown-toggle="dropdownOffset"
               data-dropdown-offset-skidding="320"
               data-dropdown-placement="bottom"
-              class="text-white bg-brightGreen-300 rounded-sm pl-3 flex items-center font-bold h-[35px]"
+              class="text-white bg-brightGreen-300 rounded pl-3 flex items-center font-bold h-[35px]"
               type="button"
             >
               <span class="min-w-[6em]">スキルパネル</span>
@@ -433,7 +433,7 @@
               data-dropdown-toggle="dropdown"
               data-dropdown-offset-skidding="20"
               data-dropdown-placement="bottom"
-              class="text-white bg-brightGreen-300 rounded-sm h-[35px] pl-3 flex items-center font-bold"
+              class="text-white bg-brightGreen-300 rounded h-[35px] pl-3 flex items-center font-bold"
               type="button"
             >
               スキルセット
@@ -485,7 +485,7 @@
               data-dropdown-toggle="dropdown2"
               data-dropdown-offset-skidding="302"
               data-dropdown-placement="bottom"
-              class="text-white bg-brightGreen-300 rounded-sm py-1.5 pl-3 flex items-center font-bold"
+              class="text-white bg-brightGreen-300 rounded py-1.5 pl-3 flex items-center font-bold"
               type="button"
             >
               <span class="min-w-[6em]">個人</span>
@@ -1082,7 +1082,7 @@
                     </div>
                     <div class="flex justify-center items-center ml-2">
                       <button
-                        class="w-6 h-8 bg-brightGray-300 flex justify-center items-center rounded"
+                        class="w-6 h-8 bg-brightGray-500 flex justify-center items-center rounded"
                       >
                         <span class="material-icons text-white !text-3xl"
                           >arrow_right</span
@@ -1602,15 +1602,15 @@
                       <div class="flex justify-center gap-x-1">
                         <div class="min-w-[3em] flex items-center">
                           <span
-                            class="h-4 w-4 rounded-full bg-brightGray-300 inline-block mr-1"
+                            class="h-4 w-4 rounded-full bg-brightGray-500 inline-block mr-1"
                           ></span
-                          >68％
+                          >68
                         </div>
                         <div class="min-w-[3em] flex items-center">
                           <span
-                            class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGray-100 inline-block mr-1"
+                            class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGray-300 inline-block mr-1"
                           ></span
-                          >12％
+                          >12
                         </div>
                       </div>
                     </td>
@@ -1711,15 +1711,15 @@
                       <div class="flex justify-center gap-x-1">
                         <div class="min-w-[3em] flex items-center">
                           <span
-                            class="h-4 w-4 rounded-full bg-brightGray-300 inline-block mr-1"
+                            class="h-4 w-4 rounded-full bg-brightGray-500 inline-block mr-1"
                           ></span
-                          >68％
+                          >68
                         </div>
                         <div class="min-w-[3em] flex items-center">
                           <span
-                            class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGray-100 inline-block mr-1"
+                            class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGray-300 inline-block mr-1"
                           ></span
-                          >12％
+                          >12
                         </div>
                       </div>
                     </td>
@@ -1775,15 +1775,15 @@
                       <div class="flex justify-center gap-x-1">
                         <div class="min-w-[3em] flex items-center">
                           <span
-                            class="h-4 w-4 rounded-full bg-brightGray-300 inline-block mr-1"
+                            class="h-4 w-4 rounded-full bg-brightGray-500 inline-block mr-1"
                           ></span
-                          >68％
+                          >68
                         </div>
                         <div class="min-w-[3em] flex items-center">
                           <span
-                            class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGray-100 inline-block mr-1"
+                            class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGray-300 inline-block mr-1"
                           ></span
-                          >12％
+                          >12
                         </div>
                       </div>
                     </td>
@@ -1875,15 +1875,15 @@
                       <div class="flex justify-center gap-x-1">
                         <div class="min-w-[3em] flex items-center">
                           <span
-                            class="h-4 w-4 rounded-full bg-brightGray-300 inline-block mr-1"
+                            class="h-4 w-4 rounded-full bg-brightGray-500 inline-block mr-1"
                           ></span
-                          >68％
+                          >68
                         </div>
                         <div class="min-w-[3em] flex items-center">
                           <span
-                            class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGray-100 inline-block mr-1"
+                            class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGray-300 inline-block mr-1"
                           ></span
-                          >12％
+                          >12
                         </div>
                       </div>
                     </td>
@@ -1945,15 +1945,15 @@
                       <div class="flex justify-center gap-x-1">
                         <div class="min-w-[3em] flex items-center">
                           <span
-                            class="h-4 w-4 rounded-full bg-brightGray-300 inline-block mr-1"
+                            class="h-4 w-4 rounded-full bg-brightGray-500 inline-block mr-1"
                           ></span
-                          >68％
+                          >68
                         </div>
                         <div class="min-w-[3em] flex items-center">
                           <span
-                            class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGray-100 inline-block mr-1"
+                            class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGray-300 inline-block mr-1"
                           ></span
-                          >12％
+                          >12
                         </div>
                       </div>
                     </td>
@@ -2045,15 +2045,15 @@
                       <div class="flex justify-center gap-x-1">
                         <div class="min-w-[3em] flex items-center">
                           <span
-                            class="h-4 w-4 rounded-full bg-brightGray-300 inline-block mr-1"
+                            class="h-4 w-4 rounded-full bg-brightGray-500 inline-block mr-1"
                           ></span
-                          >68％
+                          >68
                         </div>
                         <div class="min-w-[3em] flex items-center">
                           <span
-                            class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGray-100 inline-block mr-1"
+                            class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGray-300 inline-block mr-1"
                           ></span
-                          >12％
+                          >12
                         </div>
                       </div>
                     </td>


### PR DESCRIPTION
①マイページ　ヘッダー　プランのアップグレードボタン
②通知ボタン削除
③ログアウトアウトボタン追加
⑤「重要な連絡」「さまざまな人たちとの交流」「関わっているチーム」の高さを合わせる
・５行はいってないときも５行分の高さを確保（）
⑥「重要な連絡」のボックスシャドウをとる
⑦「関わっているユーザー」についている３点リーダー以外の３点リーダーがなくなった
⑧「関わっているチーム」に管理者のラベル
⑨保有スキルのデザインが変更された
⑩カードの高さ
⑪TwitterのX
⑫「関わっているチーム」所属しているチームはありませんの行とチームを作るボタンを追加
⑬「カスタムグループの編集」画面に「グループを削除する」ボタンを追加
⑭「関わっているユーザー」の「カスタムグループ」タブの高さを確保（タブがない時でも）
⑮「成長グラフ」の上にある４つのボタンを角丸にする
⑯「成長グラフ」の「他者との比較」ボタンの矢印を上向きにして、ドロップダウンも上に表示にする
⑰「スキルパネル」●と▲の合計から％を削除する
⑱上記●と▲の色を変更
⑲「チームスキル分析」にボタンが増えてデザインが変わった
・人材チームを作る
・チームを作る（デザイン変更）
・★（スター）のボタン
・編集
・人材チームにバックアップしてもらう
⑳対象者切り替えのボタンから「個人」を削除
㉑ボタンを押した時のモーダルをつくる
㉒「21.チームを作成／所属チームがない場合の表示」の画面を作る （編集済み） 