### PR TITLE
スキルパネル クラス切り替えパーツの実装

### DIFF
--- a/lib/bright_web.ex
+++ b/lib/bright_web.ex
@@ -66,6 +66,14 @@ defmodule BrightWeb do
     end
   end
 
+  def component do
+    quote do
+      use Phoenix.Component
+
+      unquote(html_helpers())
+    end
+  end
+
   def html do
     quote do
       use Phoenix.Component

--- a/lib/bright_web/live/skill_panel_live/graph.ex
+++ b/lib/bright_web/live/skill_panel_live/graph.ex
@@ -1,45 +1,25 @@
 defmodule BrightWeb.SkillPanelLive.Graph do
   use BrightWeb, :live_view
+  use BrightWeb.SkillPanelLive.SkillPanel
+
   import BrightWeb.ChartComponents
   import BrightWeb.TimelineBarComponents
-  import BrightWeb.SkillPanelLive.SkillPanelComponents
-  alias Bright.SkillPanels
-
-  # 全体が仮実装です。
-  # - リソースロード回りは、Skillsと処理が被る可能性が高いです。参照（必要に応じて共通化）してください。
 
   @impl true
-  def mount(%{"skill_panel_id" => skill_panel_id}, _session, socket) do
-    skill_panel = get_skill_panel(skill_panel_id)
-
-    skill_class =
-      skill_panel.skill_classes
-      # 別タスクでクラスを表すカラムを追加必要（？）
-      |> Enum.sort_by(& &1.inserted_at, {:asc, NaiveDateTime})
-      |> List.first()
-
+  def mount(_params, _session, socket) do
     {:ok,
      socket
-     |> assign(:page_title, "スキルパネル")
-     |> assign(:page_sub_title, skill_panel.name)
-     |> assign(:skill_panel, skill_panel)
-     |> assign(:skill_class, skill_class)}
+     |> assign(:page_title, "スキルパネル")}
   end
 
-  defp get_skill_panel("dummy_id") do
-    # TODO dummy_idはダミー用で実装完了後に消すこと
-    # リンクを出すための実装
-    # - 実際にはparamsからもろもろを引く
-
-    SkillPanels.list_skill_panels()
-    |> Enum.sort_by(& &1.inserted_at, {:desc, NaiveDateTime})
-    |> List.first()
-    |> Bright.Repo.preload(:skill_classes)
-  end
-
-  defp get_skill_panel(skill_panel_id) do
-    SkillPanels.get_skill_panel!(skill_panel_id)
-    |> Bright.Repo.preload(:skill_classes)
+  @impl true
+  def handle_params(params, url, socket) do
+    {:noreply,
+     socket
+     |> assign_path(url)
+     |> assign_skill_panel(params["skill_panel_id"])
+     |> assign_page_sub_title()
+     |> assign_skill_class_and_score(params["class"])}
   end
 
   @impl true

--- a/lib/bright_web/live/skill_panel_live/graph.html.heex
+++ b/lib/bright_web/live/skill_panel_live/graph.html.heex
@@ -5,7 +5,7 @@
   <div class="mx-10">
     <div class="flex justify-between">
       <.toggle_link skill_panel={@skill_panel} active="graph" />
-      <.class_tab skill_class={@skill_class} />
+      <.class_tab skill_classes={@skill_panel.skill_classes} skill_class={@skill_class} path={@path} query={@query} />
     </div>
     <div class="bg-white shadow pl-7 pr-5 relative z-2 pb-10">
       <.profile_area current_user={@current_user} />

--- a/lib/bright_web/live/skill_panel_live/skill_panel.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel.ex
@@ -1,0 +1,74 @@
+defmodule BrightWeb.SkillPanelLive.SkillPanel do
+  @moduledoc """
+  成長パネルとスキルパネル 両画面の共通実装用モジュール
+  """
+
+  def commons do
+    quote do
+      alias Bright.SkillPanels
+
+      import BrightWeb.SkillPanelLive.SkillPanelComponents
+
+      @queries ~w(class)
+
+      defp assign_skill_panel(socket, "dummy_id") do
+        # TODO: dummy_idはダミー用で実装完了後に消すこと
+        # リンクを出すための実装
+        skill_panel =
+          SkillPanels.list_skill_panels()
+          |> Enum.sort_by(& &1.inserted_at, {:desc, NaiveDateTime})
+          |> List.first()
+
+        assign_skill_panel(socket, skill_panel.id)
+      end
+
+      defp assign_skill_panel(socket, skill_panel_id) do
+        current_user = socket.assigns.current_user
+
+        skill_panel =
+          SkillPanels.get_skill_panel!(skill_panel_id)
+          |> Bright.Repo.preload(
+            skill_classes: [skill_class_scores: Ecto.assoc(current_user, :skill_class_scores)]
+          )
+
+        socket
+        |> assign(:skill_panel, skill_panel)
+      end
+
+      defp assign_skill_class_and_score(socket, nil),
+        do: assign_skill_class_and_score(socket, "1")
+
+      defp assign_skill_class_and_score(socket, class) do
+        class = String.to_integer(class)
+        skill_class = socket.assigns.skill_panel.skill_classes |> Enum.find(&(&1.class == class))
+        # List.first(): preload時に絞り込んでいるためfirstで取得可能
+        skill_class_score = skill_class.skill_class_scores |> List.first()
+
+        socket
+        |> assign(:skill_class, skill_class)
+        |> assign(:skill_class_score, skill_class_score)
+      end
+
+      defp assign_page_sub_title(socket) do
+        socket
+        |> assign(:page_sub_title, socket.assigns.skill_panel.name)
+      end
+
+      defp assign_path(socket, url) do
+        %{path: path, query: query} = URI.parse(url)
+
+        query =
+          URI.decode_query(query || "")
+          |> Map.take(@queries)
+
+        socket
+        |> assign(path: path)
+        |> assign(query: query)
+      end
+    end
+  end
+
+  defmacro __using__(_opts) do
+    apply(__MODULE__, :commons, [])
+  end
+end

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -1,5 +1,5 @@
 defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
-  use Phoenix.Component
+  use BrightWeb, :component
   import BrightWeb.ChartComponents
   import BrightWeb.ProfileComponents
 
@@ -217,23 +217,22 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
 
   def class_tab(assigns) do
     ~H"""
-      <ul class="flex text-center shadow relative z-1 -bottom-1 text-md font-bold text-brightGray-500 bg-brightGreen-50">
-        <li class="bg-white text-base">
-          <a id="class_tab_1" href="#" class="inline-block p-4 pt-3" aria-current="page">
-            <%= @skill_class.name %> <span class="text-xl ml-4">52</span>％
-          </a>
+    <ul class="flex text-center shadow relative z-1 -bottom-1 text-md font-bold text-brightGray-500 bg-brightGreen-50">
+      <%= for {skill_class, skill_class_score} <- pair_skill_class_score(@skill_classes) do %>
+        <% current = @skill_class.class == skill_class.class %>
+        <li class={current && "bg-white text-base"}>
+          <%= if skill_class_score do %>
+            <.link id={"class_tab_#{skill_class.class}"} patch={"#{@path}?#{build_query(@query, %{"class" => skill_class.class})}"} class="inline-block p-4 pt-3" aria-current={current && "page"}>
+              <%= skill_class.name %> <span class="text-xl ml-4"><%= floor skill_class_score.percentage %></span>％
+            </.link>
+          <% else %>
+            <p id={"class_tab_#{skill_class.class}"} class="inline-block p-4 pt-3">
+              <%= skill_class.name %> <span class="text-xl ml-4">0</span>％
+            </p>
+          <% end %>
         </li>
-        <li class="">
-          <a id="class_tab_2" href="#" class="inline-block p-4 pt-3">
-            クラス2 <span class="text-xl ml-4">52</span>％
-          </a>
-        </li>
-        <li class="">
-          <a id="class_tab_3" href="#" class="inline-block p-4 pt-3">
-          クラス3 <span class="text-xl ml-4">52</span>％
-        </a>
-        </li>
-      </ul>
+      <% end %>
+    </ul>
     """
   end
 
@@ -291,5 +290,24 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
         </div>
       </div>
     """
+  end
+
+  defp pair_skill_class_score(nil), do: []
+
+  defp pair_skill_class_score(skill_classes) do
+    skill_classes
+    |> Enum.map(fn skill_class ->
+      skill_class.skill_class_scores
+      |> case do
+        [] -> {skill_class, nil}
+        [skill_class_score] -> {skill_class, skill_class_score}
+      end
+    end)
+  end
+
+  defp build_query(base, query) do
+    base
+    |> Map.merge(query)
+    |> URI.encode_query()
   end
 end

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -4,7 +4,7 @@
   <div class="mx-10">
     <div class="flex justify-between">
       <.toggle_link skill_panel={@skill_panel} active="panel" />
-      <.class_tab skill_class={@skill_class} />
+      <.class_tab skill_classes={@skill_panel.skill_classes} skill_class={@skill_class} path={@path} query={@query} />
     </div>
     <div class="bg-white shadow pl-7 pr-5 relative z-2 pb-10">
       <.profile_area current_user={@current_user} />

--- a/test/bright_web/live/skill_panel_live/graph_test.exs
+++ b/test/bright_web/live/skill_panel_live/graph_test.exs
@@ -9,15 +9,28 @@ defmodule BrightWeb.SkillPanelLive.GraphTest do
 
     setup do
       skill_panel = insert(:skill_panel)
-      skill_class = insert(:skill_class, skill_panel: skill_panel)
+      skill_class = insert(:skill_class, skill_panel: skill_panel, class: 1)
 
       %{skill_panel: skill_panel, skill_class: skill_class}
     end
 
-    test "shows content", %{conn: conn} do
+    test "shows dummy", %{conn: conn} do
       {:ok, _show_live, html} = live(conn, ~p"/panels/dummy_id/graph")
 
       assert html =~ "成長パネル"
+    end
+
+    test "shows content", %{
+      conn: conn,
+      skill_panel: skill_panel,
+      skill_class: skill_class
+    } do
+      {:ok, show_live, html} = live(conn, ~p"/panels/#{skill_panel}/graph")
+
+      assert html =~ "成長パネル"
+
+      assert show_live
+             |> has_element?("#class_tab_1", skill_class.name)
     end
   end
 end

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -50,8 +50,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       assert html =~ "スキルパネル"
 
       assert show_live
-             |> element("#class_tab_1", skill_class.name)
-             |> has_element?()
+             |> has_element?("#class_tab_1", skill_class.name)
     end
 
     test "shows skills table", %{
@@ -105,7 +104,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=2")
 
       assert show_live
-             |> element("#class_tab_1", skill_class_2.name)
+             |> element("#class_tab_2", skill_class_2.name)
              |> has_element?()
     end
   end


### PR DESCRIPTION
## 対応内容

refs #47 

- スキルクラス開放処理がまだ未実装なので画面でどうとかできませんが、パーツとして実装しています。
  - ↑の実装を次にしてしまう予定です。
- スキルクラスが未開放状態のデザインがなさそう(?)なのでその辺りは確認して、別で対応します。

その他

- 成長パネルとスキルパネルの共通処理を括りだしています。
- component用のuseを定義しています。

## 画面

下記の箇所です。

![スクリーンショット 2023-08-09 160620](https://github.com/bright-org/bright/assets/121112529/659b53fd-9cc0-4d90-9ea2-19c24c39e8e0)
