### PR TITLE
ドーナツグラフまわりの表示に伴うスキーマ定義

### DIFF
--- a/docs/conceptual_schemas/skill_user_relations.md
+++ b/docs/conceptual_schemas/skill_user_relations.md
@@ -38,10 +38,8 @@ erDiagram
 - [スキル、スキルスコア系は別ファイルにあります](./skills.md)
 
 
-### テーブル定義案１：スキルスコアにフラグ系を集約
+### テーブル定義案
 
-- シンプル
-- １カラムレベルでのテーブルがなくなる
 
 ```mermaid
 erDiagram
@@ -96,77 +94,11 @@ erDiagram
   }
 ```
 
+備考
 
-### テーブル定義案２：それぞれテーブルに保持
-
-- 複数の意味を持たないので、その意味でシンプル
-- テーブルはやや冗長にもみえる
-- 変更にはこちらが強いかもしれない
-  - 例えば、別のexamができたときに初期化するとか
-
-```mermaid
-erDiagram
-  skill_scores ||--|| skills : ""
-  skills ||--|| skill_evidences : ""
-  skills ||--|| skill_exams : ""
-  skills ||--|| skill_references : ""
-
-  users ||--o{ skill_scores : ""
-  users ||--o{ skill_evidences : ""
-  users ||--o{ skill_evidence_posts : "投稿"
-  skill_evidences ||--o{ skill_evidence_posts : ""
-  users ||--o{ skill_exam_results : ""
-  skill_exams ||--o{ skill_exam_results : ""
-  users ||--o{ skill_reference_reads : ""
-  skill_references ||--o{ skill_reference_reads : ""
-
-  users {
-  }
-
-  skills {
-    id skill_categories_id FK
-    string name "スキル（小分類）名"
-    int position
-  }
-
-  skill_exams {
-    id skill_id FK
-    string url
-  }
-
-  skill_references {
-    id skill_id FK
-    string url
-  }
-
-  skill_scores {
-    id user_id FK
-    id skill_id FK
-    string score "enum（low=－、middle=△、high=◯）"
-  }
-
-  skill_evidences {
-    id skill_id FK
-    id user_id FK
-    string progress "enum（wip、help、done）"
-  }
-
-  skill_evidence_posts {
-    id skill_id FK
-    id user_id FK
-    string content
-  }
-
-  skill_exam_results {
-    id skill_exam_id FK
-    id user_id FK
-    string progress "enum（wip、done）"
-  }
-
-  skill_reference_reads {
-    id skill_reference_id FK
-    id user_id FK
-    boolean read
-  }
-```
+- 下記のデータをskill_scoresに保持する
+  - スキル試験結果
+  - スキル教材閲覧有無
+  - エビデンスを一度でも入れたかどうか
+    - ※wip/help/doneの詳細ステータスはskill_evidencesがもつ
 

--- a/docs/conceptual_schemas/skills.md
+++ b/docs/conceptual_schemas/skills.md
@@ -133,18 +133,14 @@ erDiagram
   skill_class_scores {
     id user_id FK
     id skill_class_id FK
-    float high_skills_percentage
-    float middle_skills_percentage
-    float exam_try_percentage
-    float reference_read_percentage
-    float evidence_filled_percentage
+    float percentage
     string level
   }
 
   skill_unit_scores {
     id user_id FK
     id skill_unit_id FK
-    float high_skills_percentage
+    float percentage
   }
 
   skill_scores {


### PR DESCRIPTION
ドーナツグラフを出すために必要なカラム定義です。

![スクリーンショット 2023-08-10 150113](https://github.com/bright-org/bright/assets/121112529/167a374e-4d0f-46ea-835f-ea4c6453e2c7)


**要相談資料**

スキルクラス単位で追加が必要な集計データ
- △の習得率
- エビデンスの登録率
- 教材の学習率
- 試験の受験率

表示箇所
- （現状）成長パネルとスキルパネル画面のみ
- （現状）過去分は必要なし

**相談点**

（１）集計値がカラムに必要かどうか？
（１ー２）skil_class_scoresに入れてしまうという判断はどうか？

=> 集計値はいらない。成長パネルとスキルパネルで個人単位でしか出さないので、コード中で割合するのみ。

（２）教材を開いたかどうかのカラムがどこかに必要になった

この際に、skill_scoresにまとめて入れてしまうという判断はどうか？
まとめてしまって、skill_exam_resultsテーブルは廃止する。

=> skill_scoresにまとめる。１情報のテーブルを持つほどのものではない。（また、スキル一覧で、教材・試験・エビデンスの状況でアイコン色がかわることもあり、各テーブルを結合しない方が都合もいい）
