### PR TITLE
social_identifier_tokens の token, inserted_at にインデックス追加

### DIFF
--- a/priv/repo/migrations/20230811155442_social_indentifier_token_add_token_index.exs
+++ b/priv/repo/migrations/20230811155442_social_indentifier_token_add_token_index.exs
@@ -1,0 +1,7 @@
+defmodule Bright.Repo.Migrations.SocialIndentifierTokenAddTokenIndex do
+  use Ecto.Migration
+
+  def change do
+    create index(:social_identifier_tokens, [:token, :inserted_at])
+  end
+end


### PR DESCRIPTION
- #417 

# やったこと
インデックスのチェックをしていたら足りてないところがあったため。

https://github.com/bright-org/bright/blob/1a839e8c249e0eeefe20f1a82795c362c8ea7bfe/lib/bright/accounts.ex#L579-L587

https://github.com/bright-org/bright/blob/1a839e8c249e0eeefe20f1a82795c362c8ea7bfe/lib/bright/accounts.ex#L579-L587

token と inserted_at の組み合わせで検索しているが token にも inserted_at にもインデックスがなかった。