### PR TITLE
スキルパネル 画面へのアクセス時処理の整理

### DIFF
--- a/lib/bright/accounts/user.ex
+++ b/lib/bright/accounts/user.ex
@@ -37,6 +37,10 @@ defmodule Bright.Accounts.User do
     has_many :historical_career_field_scores,
              Bright.HistoricalSkillScores.HistoricalCareerFieldScore
 
+    has_many :user_skill_panels, Bright.UserSkillPanels.UserSkillPanel
+
+    has_many :skill_panels, through: [:user_skill_panels, :skill_panel]
+
     has_one :user_onboardings, Bright.Onboardings.UserOnboarding
     has_one :user_profile, Bright.UserProfiles.UserProfile
     has_one :user_job_profile, Bright.UserJobProfiles.UserJobProfile

--- a/lib/bright/skill_panels.ex
+++ b/lib/bright/skill_panels.ex
@@ -39,6 +39,22 @@ defmodule Bright.SkillPanels do
   """
   def get_skill_panel!(id), do: Repo.get!(SkillPanel, id)
 
+  def get_user_skill_panel!(user, skill_panel_id) do
+    user
+    |> Ecto.assoc(:skill_panels)
+    |> Bright.Repo.get_by!(id: skill_panel_id)
+  end
+
+  def get_user_latest_skill_panel!(user) do
+    from(q in SkillPanel,
+      join: u in assoc(q, :user_skill_panels),
+      where: u.user_id == ^user.id,
+      order_by: [desc: u.updated_at],
+      limit: 1
+    )
+    |> Repo.one!()
+  end
+
   @doc """
   Creates a skill_panel.
 

--- a/lib/bright/skill_panels/skill_panel.ex
+++ b/lib/bright/skill_panels/skill_panel.ex
@@ -18,6 +18,7 @@ defmodule Bright.SkillPanels.SkillPanel do
     has_many :skill_classes, SkillClass, preload_order: [asc: :class], on_replace: :delete
     has_many :job_skill_panels, JobSkillPanel, on_replace: :delete
     has_many :jobs, through: [:job_skill_panels, :job]
+    has_many :user_skill_panels, Bright.UserSkillPanels.UserSkillPanel
 
     timestamps()
   end

--- a/lib/bright/user_skill_panels.ex
+++ b/lib/bright/user_skill_panels.ex
@@ -163,4 +163,10 @@ defmodule Bright.UserSkillPanels do
     |> List.first()
     |> Map.get(:level)
   end
+
+  def touch_user_skill_panel_updated(user, skill_panel) do
+    Repo.get_by!(UserSkillPanel, user_id: user.id, skill_panel_id: skill_panel.id)
+    |> change_user_skill_panel()
+    |> Repo.update(force: true)
+  end
 end

--- a/lib/bright_web/components/layout_components.ex
+++ b/lib/bright_web/components/layout_components.ex
@@ -110,8 +110,8 @@ defmodule BrightWeb.LayoutComponents do
   def links() do
     [
       {"スキルを選ぶ", "/onboardings"},
-      {"成長を見る・比較する", "/panels/dummy_id/graph"},
-      {"スキルパネルを入力", "/panels/dummy_id/skills"},
+      {"成長を見る・比較する", "/panels/graph"},
+      {"スキルパネルを入力", "/panels/skills"},
       {"スキルアップを目指す", "/skill_up"},
       {"チームスキル分析", "/teams"},
       {"キャリアパスを選ぶ", "/"}

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -10,6 +10,7 @@ defmodule BrightWeb.SkillPanelLive.Skills do
   alias Bright.SkillEvidences
   alias Bright.SkillReferences
   alias Bright.SkillExams
+  alias Bright.UserSkillPanels
 
   @shortcut_key_score %{
     "1" => :high,
@@ -55,6 +56,11 @@ defmodule BrightWeb.SkillPanelLive.Skills do
 
     {:ok, _} = SkillScores.update_skill_scores(socket.assigns.current_user, target_skill_scores)
     skill_class_score = SkillScores.get_skill_class_score!(socket.assigns.skill_class_score.id)
+
+    UserSkillPanels.touch_user_skill_panel_updated(
+      socket.assigns.current_user,
+      socket.assigns.skill_panel
+    )
 
     {:noreply,
      socket

--- a/lib/bright_web/router.ex
+++ b/lib/bright_web/router.ex
@@ -165,6 +165,8 @@ defmodule BrightWeb.Router do
       live "/users/settings/confirm_email/:token", UserSettingsLive, :confirm_email
       live "/mypage", MypageLive.Index, :index
       live "/skill_up", SkillUpDummyLive, :index
+      live "/panels/graph", SkillPanelLive.Graph, :show
+      live "/panels/skills", SkillPanelLive.Skills, :show
       live "/panels/:skill_panel_id/graph", SkillPanelLive.Graph, :show
       live "/panels/:skill_panel_id/skills", SkillPanelLive.Skills, :show
 

--- a/test/bright/skill_panels_test.exs
+++ b/test/bright/skill_panels_test.exs
@@ -3,6 +3,7 @@ defmodule Bright.SkillPanelsTest do
   import Bright.Factory
 
   alias Bright.SkillPanels
+  alias Bright.UserSkillPanels
 
   describe "skill_panels" do
     alias Bright.SkillPanels.SkillPanel
@@ -81,6 +82,35 @@ defmodule Bright.SkillPanelsTest do
     test "change_skill_panel/1 returns a skill_panel changeset" do
       skill_panel = insert(:skill_panel)
       assert %Ecto.Changeset{} = SkillPanels.change_skill_panel(skill_panel)
+    end
+
+    test "get_user_skill_panel!/1 returns the skill_panel with given user and id" do
+      user = insert(:user)
+      skill_panel = insert(:skill_panel)
+      insert(:user_skill_panel, user: user, skill_panel: skill_panel)
+      assert SkillPanels.get_user_skill_panel!(user, skill_panel.id) == skill_panel
+    end
+
+    test "get_user_skill_panel!/1 raises NoResultsError" do
+      [user, user_2] = insert_pair(:user)
+      skill_panel = insert(:skill_panel)
+      insert(:user_skill_panel, user: user, skill_panel: skill_panel)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        SkillPanels.get_user_skill_panel!(user_2, skill_panel.id)
+      end
+    end
+
+    test "get_user_latest_skill_panel!/1 returns the skill_panel with given user" do
+      user = insert(:user)
+      [skill_panel_1, skill_panel_2] = insert_pair(:skill_panel)
+
+      [skill_panel_1, skill_panel_2]
+      |> Enum.each(&insert(:user_skill_panel, user: user, skill_panel: &1))
+
+      :timer.sleep(1000)
+      UserSkillPanels.touch_user_skill_panel_updated(user, skill_panel_1)
+      assert SkillPanels.get_user_latest_skill_panel!(user) == skill_panel_1
     end
   end
 

--- a/test/bright_web/live/skill_panel_live/graph_test.exs
+++ b/test/bright_web/live/skill_panel_live/graph_test.exs
@@ -7,15 +7,16 @@ defmodule BrightWeb.SkillPanelLive.GraphTest do
   describe "Show" do
     setup [:register_and_log_in_user]
 
-    setup do
+    setup %{user: user} do
       skill_panel = insert(:skill_panel)
+      insert(:user_skill_panel, user: user, skill_panel: skill_panel)
       skill_class = insert(:skill_class, skill_panel: skill_panel, class: 1)
 
       %{skill_panel: skill_panel, skill_class: skill_class}
     end
 
     test "shows content", %{conn: conn, skill_panel: skill_panel} do
-      {:ok, _show_live, html} = live(conn, ~p"/panels/dummy_id/graph")
+      {:ok, _show_live, html} = live(conn, ~p"/panels/#{skill_panel}/graph")
 
       assert html =~ skill_panel.name
     end

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -6,6 +6,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
 
   defp setup_skills(%{user: user, score: score}) do
     skill_panel = insert(:skill_panel)
+    insert(:user_skill_panel, user: user, skill_panel: skill_panel)
     skill_class = insert(:skill_class, skill_panel: skill_panel, class: 1)
 
     skill_unit =
@@ -33,8 +34,9 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
   describe "Show" do
     setup [:register_and_log_in_user]
 
-    setup do
+    setup %{user: user} do
       skill_panel = insert(:skill_panel)
+      insert(:user_skill_panel, user: user, skill_panel: skill_panel)
       skill_class = insert(:skill_class, skill_panel: skill_panel, class: 1)
 
       %{skill_panel: skill_panel, skill_class: skill_class}
@@ -519,8 +521,9 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
   describe "Security" do
     setup [:register_and_log_in_user]
 
-    test "別のユーザーのスキルスコアが表示されないこと", %{conn: conn} do
+    test "別のユーザーのスキルスコアが表示されないこと", %{conn: conn, user: user} do
       skill_panel = insert(:skill_panel)
+      insert(:user_skill_panel, user: user, skill_panel: skill_panel)
       skill_class = insert(:skill_class, skill_panel: skill_panel, class: 1)
 
       skill_unit =


### PR DESCRIPTION
## 対応内容

- サイドメニューにURLを設定 /panels/graph, /panels/skills
- 上記、アクセス時に
  - 最新のスキルパネルにアクセスすること(user_skill_panels.updated_at参照)
- スコアをいじったときに user_skill_panels.updated_at が更新されること

合わせて
 - クラス指定がないときに、最後に更新された skill_class_scores を参照して決めること（これはいま画面で確認できないので仮）

に対応しました。
 
## 画面

![sample16](https://github.com/bright-org/bright/assets/121112529/333be1f5-e590-4f56-ba88-15c4d906b78b)
