### PR TITLE
スキルパネル 対象ユーザー切り替えの仮実装

### DIFF
--- a/lib/bright/accounts.ex
+++ b/lib/bright/accounts.ex
@@ -605,6 +605,13 @@ defmodule Bright.Accounts do
     |> Repo.one()
   end
 
+  def get_user_by_name(name) do
+    User
+    |> where([user], not is_nil(user.confirmed_at))
+    |> where([user], user.name == ^name)
+    |> Repo.one()
+  end
+
   @doc """
   Check if onboarding is already finished.
 

--- a/lib/bright/skill_panels.ex
+++ b/lib/bright/skill_panels.ex
@@ -45,6 +45,12 @@ defmodule Bright.SkillPanels do
     |> Bright.Repo.get_by!(id: skill_panel_id)
   end
 
+  def get_user_skill_panel(user, skill_panel_id) do
+    user
+    |> Ecto.assoc(:skill_panels)
+    |> Bright.Repo.get_by(id: skill_panel_id)
+  end
+
   def get_user_latest_skill_panel!(user) do
     from(q in SkillPanel,
       join: u in assoc(q, :user_skill_panels),

--- a/lib/bright_web/live/skill_panel_live/graph.ex
+++ b/lib/bright_web/live/skill_panel_live/graph.ex
@@ -17,6 +17,7 @@ defmodule BrightWeb.SkillPanelLive.Graph do
     # TODO: データ取得方法検討／LiveVIewコンポーネント化検討
     {:noreply,
      socket
+     |> assign_focus_user(params["user_name"])
      |> assign_skill_panel(params["skill_panel_id"])
      |> assign_skill_class_and_score(params["class"])
      |> create_skill_class_score_if_not_existing()
@@ -27,6 +28,39 @@ defmodule BrightWeb.SkillPanelLive.Graph do
   end
 
   @impl true
+  # TODO: デモ用実装のため対象ユーザー実装後に削除
+  def handle_event("demo_change_user", _params, socket) do
+    users =
+      Bright.Accounts.User
+      |> Bright.Repo.all()
+      |> Enum.reject(fn user ->
+        user.id == socket.assigns.current_user.id ||
+          Ecto.assoc(user, :user_skill_panels)
+          |> Bright.Repo.all()
+          |> Enum.empty?()
+      end)
+
+    if users != [] do
+      user = Enum.random(users)
+
+      {:noreply,
+       socket
+       |> push_redirect(to: ~p"/panels/#{socket.assigns.skill_panel}/graph/#{user.name}")}
+    else
+      {:noreply,
+       socket
+       |> put_flash(:info, "demo: ユーザーがいません")
+       |> push_redirect(to: ~p"/panels/#{socket.assigns.skill_panel}/graph")}
+    end
+  end
+
+  # TODO: 検討：本実装で同じ処理をまるっと共通化するのはimportではできそうにない
+  def handle_event("clear_focus_user", _params, socket) do
+    {:noreply,
+     socket
+     |> push_redirect(to: ~p"/panels/#{socket.assigns.skill_panel}/graph")}
+  end
+
   def handle_event(_event_name, _params, socket) do
     # # TODO タイムラインバーイベント検証 タイムラインイベント周りの実装後削除予定
     # IO.inspect("------------------")

--- a/lib/bright_web/live/skill_panel_live/graph.html.heex
+++ b/lib/bright_web/live/skill_panel_live/graph.html.heex
@@ -10,7 +10,7 @@
       <.class_tab :if={false} skill_class={@skill_class} />
     </div>
     <div class="bg-white shadow pl-7 pr-5 relative z-2 pb-10">
-      <.profile_area current_user={@current_user} skill_class_score={@skill_class_score} counter={@counter} num_skills={@num_skills} />
+      <.profile_area focus_user={@focus_user} skill_class_score={@skill_class_score} counter={@counter} num_skills={@num_skills} />
       <div class="flex">
         <div class="w-[880px] flex flex-col">
           <!-- グラフ -->

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -114,10 +114,23 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
 
   def target_switch(assigns) do
     ~H"""
-      <p class="leading-tight ml-4">対象者の<br />切り替え</p>
-      <.individual_menu current_user={@current_user} />
-      <% # TODO: α版後にifを除去して表示 %>
-      <.team_menu :if={false} current_user={@current_user} />
+    <p class="leading-tight ml-4">対象者の<br />切り替え</p>
+    <% # TODO: 共通コンポーネント完成後に表示 %>
+    <.individual_menu :if={false} current_user={@current_user} />
+    <% # TODO: α版後にifを除去して表示 %>
+    <.team_menu :if={false} current_user={@current_user} />
+
+    <% # TODO: 仮実装のため実装後に削除 %>
+    <button
+      class="text-white bg-brightGreen-300 rounded-sm py-1.5 pl-3 flex items-center font-bold"
+      type="button"
+      phx-click="demo_change_user"
+    >
+      <span class="min-w-[6em]">個人</span>
+      <span class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-8px] before:bg-brightGray-50 before:w-[1px] before:h-[42px]">
+        expand_more
+      </span>
+    </button>
     """
   end
 
@@ -183,9 +196,9 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
 
   def return_myself_button(assigns) do
     ~H"""
-      <button class="text-brightGreen-300 border bg-white border-brightGreen-300 rounded px-3 font-bold">
-        自分に戻す
-      </button>
+    <button phx-click="clear_focus_user" class="text-brightGreen-300 border bg-white border-brightGreen-300 rounded px-3 font-bold">
+      自分に戻す
+    </button>
     """
   end
 
@@ -241,21 +254,23 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
   end
 
   def profile_area(assigns) do
+    # TODO: 自分に戻す、に対応が必要
     ~H"""
       <div class="flex justify-between">
         <div class="w-[850px] pt-6">
           <% # TODO: α版後にexcellent_person/anxious_personをtrueに変更して表示 %>
+          <% # TODO: 他者のときの.profileの仕様確認と対応が必要 %>
           <.profile
-            user_name={@current_user.name}
-            title={@current_user.user_profile.title}
-            icon_file_path={@current_user.user_profile.icon_file_path}
+            user_name={@focus_user.name}
+            title={@focus_user.user_profile.title}
+            icon_file_path={@focus_user.user_profile.icon_file_path}
             display_excellent_person={false}
             display_anxious_person={false}
             display_return_to_yourself={true}
             display_sns={true}
-            twitter_url={@current_user.user_profile.twitter_url}
-            github_url={@current_user.user_profile.github_url}
-            facebook_url={@current_user.user_profile.facebook_url}
+            twitter_url={@focus_user.user_profile.twitter_url}
+            github_url={@focus_user.user_profile.github_url}
+            facebook_url={@focus_user.user_profile.facebook_url}
             display_detail={false}
           />
         </div>

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -9,7 +9,7 @@
       <.class_tab :if={false} skill_class={@skill_class} />
     </div>
     <div class="bg-white shadow pl-7 pr-5 relative z-2 pb-10">
-      <.profile_area current_user={@current_user} skill_class_score={@skill_class_score} counter={@counter} num_skills={@num_skills} />
+      <.profile_area focus_user={@focus_user} skill_class_score={@skill_class_score} counter={@counter} num_skills={@num_skills} />
       <.compares current_user={@current_user} />
       <div class="mt-4">
         <table class="table-fixed skill-panel-table border-t border-l border-brightGray-200">

--- a/lib/bright_web/router.ex
+++ b/lib/bright_web/router.ex
@@ -168,7 +168,9 @@ defmodule BrightWeb.Router do
       live "/panels/graph", SkillPanelLive.Graph, :show
       live "/panels/skills", SkillPanelLive.Skills, :show
       live "/panels/:skill_panel_id/graph", SkillPanelLive.Graph, :show
+      live "/panels/:skill_panel_id/graph/:user_name", SkillPanelLive.Graph, :show
       live "/panels/:skill_panel_id/skills", SkillPanelLive.Skills, :show
+      live "/panels/:skill_panel_id/skills/:user_name", SkillPanelLive.Skills, :show
 
       live "/panels/:skill_panel_id/skills/:skill_id/evidences",
            SkillPanelLive.Skills,


### PR DESCRIPTION
## 対応内容

ユーザー切り替えの仮実装です。
動きの感じと実装イメージをしたかったので想定で入れています。

メガメニューのコンポーネントができてから本実装になります。

## 画面

デモ的な暫定対応で、個人を押したらユーザーがランダムに変わる感じにしています。

![sample17](https://github.com/bright-org/bright/assets/121112529/545ea85e-2c0f-41da-8c5a-1756332b868d)
