### PR TITLE
スキルパネル クラス切り替えパーツの実装

### DIFF
--- a/lib/bright_web/live/skill_panel_live/graph.ex
+++ b/lib/bright_web/live/skill_panel_live/graph.ex
@@ -12,10 +12,11 @@ defmodule BrightWeb.SkillPanelLive.Graph do
   end
 
   @impl true
-  def handle_params(params, _url, socket) do
+  def handle_params(params, url, socket) do
     # TODO: データ取得方法検討／LiveVIewコンポーネント化検討
     {:noreply,
      socket
+     |> assign_path(url)
      |> assign_focus_user(params["user_name"])
      |> assign_skill_panel(params["skill_panel_id"])
      |> assign_skill_class_and_score(params["class"])

--- a/lib/bright_web/live/skill_panel_live/graph.html.heex
+++ b/lib/bright_web/live/skill_panel_live/graph.html.heex
@@ -4,10 +4,10 @@
   <.navigations current_user={@current_user} />
   <div class="mx-10">
     <div class="flex justify-between">
-      <% # TODO: α版後にifを除去して表示 %>
+      <% # TODO: α版後にifと仮divブロックを除去して表示 %>
       <.toggle_link :if={false} skill_panel={@skill_panel} active="graph" />
-      <% # TODO: α版後にifを除去して表示 %>
-      <.class_tab :if={false} skill_class={@skill_class} />
+      <div> </div>
+      <.class_tab skill_classes={@skill_panel.skill_classes} skill_class={@skill_class} path={@path} query={@query} />
     </div>
     <div class="bg-white shadow pl-7 pr-5 relative z-2 pb-10">
       <.profile_area focus_user={@focus_user} skill_class_score={@skill_class_score} counter={@counter} num_skills={@num_skills} />

--- a/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
@@ -15,6 +15,20 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
     evidence_filled: 0
   }
 
+  @queries ~w(class)
+
+  def assign_path(socket, url) do
+    %{path: path, query: query} = URI.parse(url)
+
+    query =
+      URI.decode_query(query || "")
+      |> Map.take(@queries)
+
+    socket
+    |> assign(path: path)
+    |> assign(query: query)
+  end
+
   def assign_focus_user(socket, nil) do
     socket
     |> assign(focus_user: socket.assigns.current_user, me: true)

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -24,10 +24,11 @@ defmodule BrightWeb.SkillPanelLive.Skills do
   end
 
   @impl true
-  def handle_params(params, _url, socket) do
+  def handle_params(params, url, socket) do
     # TODO: データ取得方法検討／LiveVIewコンポーネント化検討
     {:noreply,
      socket
+     |> assign_path(url)
      |> assign_focus_user(params["user_name"])
      |> assign_skill_panel(params["skill_panel_id"])
      |> assign_skill_class_and_score(params["class"])

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -3,10 +3,10 @@
   <.navigations current_user={@current_user} />
   <div class="mx-10">
     <div class="flex justify-between">
-      <% # TODO: α版後にifを除去して表示 %>
-      <.toggle_link :if={false} skill_panel={@skill_panel} active="panel" />
-      <% # TODO: α版後にifを除去して表示 %>
-      <.class_tab :if={false} skill_class={@skill_class} />
+      <% # TODO: α版後にifと仮divブロックを除去して表示 %>
+      <.toggle_link :if={false} skill_panel={@skill_panel} active="graph" />
+      <div> </div>
+      <.class_tab skill_classes={@skill_panel.skill_classes} skill_class={@skill_class} path={@path} query={@query} />
     </div>
     <div class="bg-white shadow pl-7 pr-5 relative z-2 pb-10">
       <.profile_area focus_user={@focus_user} skill_class_score={@skill_class_score} counter={@counter} num_skills={@num_skills} />

--- a/test/bright_web/live/skill_panel_live/graph_test.exs
+++ b/test/bright_web/live/skill_panel_live/graph_test.exs
@@ -15,10 +15,17 @@ defmodule BrightWeb.SkillPanelLive.GraphTest do
       %{skill_panel: skill_panel, skill_class: skill_class}
     end
 
-    test "shows content", %{conn: conn, skill_panel: skill_panel} do
-      {:ok, _show_live, html} = live(conn, ~p"/panels/#{skill_panel}/graph")
+    test "shows content", %{
+      conn: conn,
+      skill_panel: skill_panel,
+      skill_class: skill_class
+    } do
+      {:ok, show_live, html} = live(conn, ~p"/panels/#{skill_panel}/graph")
 
       assert html =~ skill_panel.name
+
+      assert show_live
+             |> has_element?("#class_tab_1", skill_class.name)
     end
   end
 end

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -42,19 +42,18 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       %{skill_panel: skill_panel, skill_class: skill_class}
     end
 
-    # # TODO: メニューを隠したために一時的にコメントアウト
-    # test "shows content", %{
-    #   conn: conn,
-    #   skill_panel: skill_panel,
-    #   skill_class: skill_class
-    # } do
-    #   {:ok, show_live, html} = live(conn, ~p"/panels/#{skill_panel}/skills")
-    #
-    #   assert html =~ "スキルパネル"
-    #   assert show_live
-    #          |> element("#class_tab_1", skill_class.name)
-    #          |> has_element?()
-    # end
+    test "shows content", %{
+      conn: conn,
+      skill_panel: skill_panel,
+      skill_class: skill_class
+    } do
+      {:ok, show_live, html} = live(conn, ~p"/panels/#{skill_panel}/skills")
+
+      assert html =~ "スキルパネル"
+
+      assert show_live
+             |> has_element?("#class_tab_1", skill_class.name)
+    end
 
     test "shows skills table", %{
       conn: conn,
@@ -99,18 +98,19 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       end)
     end
 
-    # # TODO: メニューを隠したために一時的にコメントアウト
-    # test "shows the skill class by query string parameter", %{
-    #   conn: conn,
-    #   skill_panel: skill_panel
-    # } do
-    #   skill_class_2 = insert(:skill_class, skill_panel: skill_panel, class: 2)
-    #   {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=2")
-    #
-    #   assert show_live
-    #          |> element("#class_tab_1", skill_class_2.name)
-    #          |> has_element?()
-    # end
+    test "shows the skill class by query string parameter", %{
+      conn: conn,
+      user: user,
+      skill_panel: skill_panel
+    } do
+      skill_class_2 = insert(:skill_class, skill_panel: skill_panel, class: 2)
+      insert(:skill_class_score, user: user, skill_class: skill_class_2)
+
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=2")
+
+      assert show_live
+             |> has_element?("#class_tab_2", skill_class_2.name)
+    end
   end
 
   describe "Show skill scores" do


### PR DESCRIPTION
## 対応内容

refs https://github.com/bright-org/bright/issues/47

基本的に、#570 の焼き直しです。αには含まれるとのことでPRになります。

スキルクラス開放処理がまだ未実装なので画面でどうとかできませんが、パーツとして実装しています。
上記実装は別RPで出します。

## 画面

![image](https://github.com/bright-org/bright/assets/121112529/bdb7d8ee-9efe-4ef1-916d-d4b2213b0a3e)

- クラス開放まえは灰色表示になるデザインです。対応してもらいました。 