### PR TITLE
成長グラフ「未来」の表現対応（DBからのデータはまだ）

### DIFF
--- a/lib/bright_web/live/chart_live/growth_graph_component.ex
+++ b/lib/bright_web/live/chart_live/growth_graph_component.ex
@@ -149,13 +149,12 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
     labels = create_months(String.to_integer(year), String.to_integer(month), diff)
 
     future = get_future_month()
-    futureEnabled = labels |> List.last() == "#{future.year}.#{future.month}"
+    future_enabled = labels |> List.last() == "#{future.year}.#{future.month}"
 
     data =
       socket.assigns.data
       |> Map.put(:labels, labels)
-      |> Map.put(:futureEnabled, futureEnabled)
-
+      |> Map.put(:futureEnabled, future_enabled)
 
     assign(socket, :data, data)
   end


### PR DESCRIPTION
このプルリクで実施すること
・一つ先の未来のみ表示できる
・「現在」は未来が表示している時のみ表示
![image](https://github.com/bright-org/bright/assets/13599847/aa593db8-0e7b-4f8a-a523-3fcab6e36bbd)

![image](https://github.com/bright-org/bright/assets/13599847/2bc25c9f-5910-440f-852e-d90f8116b138)
