### PR TITLE
スキルパネルと成長パネルに遷移するパラメータ無しのURLを変更

### DIFF
--- a/lib/bright_web/components/layout_components.ex
+++ b/lib/bright_web/components/layout_components.ex
@@ -110,8 +110,8 @@ defmodule BrightWeb.LayoutComponents do
   def links() do
     [
       {"スキルを選ぶ", "/onboardings"},
-      {"成長を見る・比較する", "/panels/graph"},
-      {"スキルパネルを入力", "/panels/skills"},
+      {"成長を見る・比較する", "/graphs"},
+      {"スキルパネルを入力", "/panels"},
       {"スキルアップを目指す", "/skill_up"},
       {"チームスキル分析", "/teams"},
       {"キャリアパスを選ぶ", "/"}

--- a/lib/bright_web/router.ex
+++ b/lib/bright_web/router.ex
@@ -165,8 +165,8 @@ defmodule BrightWeb.Router do
       live "/users/settings/confirm_email/:token", UserSettingsLive, :confirm_email
       live "/mypage", MypageLive.Index, :index
       live "/skill_up", SkillUpDummyLive, :index
-      live "/panels/graph", SkillPanelLive.Graph, :show
-      live "/panels/skills", SkillPanelLive.Skills, :show
+      live "/graphs", SkillPanelLive.Graph, :show
+      live "/panels", SkillPanelLive.Skills, :show
       live "/panels/:skill_panel_id/graph", SkillPanelLive.Graph, :show
       live "/panels/:skill_panel_id/graph/:user_name", SkillPanelLive.Graph, :show
       live "/panels/:skill_panel_id/skills", SkillPanelLive.Skills, :show

--- a/test/bright_web/live/skill_panel_live/graph_test.exs
+++ b/test/bright_web/live/skill_panel_live/graph_test.exs
@@ -27,5 +27,18 @@ defmodule BrightWeb.SkillPanelLive.GraphTest do
       assert show_live
              |> has_element?("#class_tab_1", skill_class.name)
     end
+
+    test "shows content without parameters", %{
+      conn: conn,
+      skill_panel: skill_panel,
+      skill_class: skill_class
+    } do
+      {:ok, show_live, html} = live(conn, ~p"/graphs")
+
+      assert html =~ skill_panel.name
+
+      assert show_live
+             |> has_element?("#class_tab_1", skill_class.name)
+    end
   end
 end

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -55,6 +55,19 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
              |> has_element?("#class_tab_1", skill_class.name)
     end
 
+    test "shows content without parameters", %{
+      conn: conn,
+      skill_panel: skill_panel,
+      skill_class: skill_class
+    } do
+      {:ok, show_live, html} = live(conn, ~p"/panels")
+
+      assert html =~ skill_panel.name
+
+      assert show_live
+             |> has_element?("#class_tab_1", skill_class.name)
+    end
+
     test "shows skills table", %{
       conn: conn,
       skill_panel: skill_panel,


### PR DESCRIPTION
## 対応内容

/graphs
/panels

のURLを定義しました。
メール文言に記載される各画面への入り口／サイドメニューのリンクです。