### PR TITLE
スキルパネル 個人と比較の動作

### DIFF
--- a/lib/bright/skill_scores.ex
+++ b/lib/bright/skill_scores.ex
@@ -276,6 +276,15 @@ defmodule Bright.SkillScores do
   end
 
   @doc """
+  Returns the list of skill_scores from user and skill_ids
+  """
+  def list_user_skill_scores_from_skill_ids(user, skill_ids) do
+    SkillScore.user_id_query(user.id)
+    |> SkillScore.skill_ids_query(skill_ids)
+    |> list_skill_scores()
+  end
+
+  @doc """
   Gets a single skill_score.
 
   Raises `Ecto.NoResultsError` if the Skill score item does not exist.

--- a/lib/bright/skill_scores/skill_score.ex
+++ b/lib/bright/skill_scores/skill_score.ex
@@ -35,4 +35,9 @@ defmodule Bright.SkillScores.SkillScore do
     from q in __MODULE__,
       where: q.user_id == ^user_id
   end
+
+  def skill_ids_query(query, skill_ids) do
+    from q in query,
+      where: q.skill_id in ^skill_ids
+  end
 end

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -313,6 +313,42 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
     """
   end
 
+  def score_mark_class(score, :me) do
+    score
+    |> case do
+      :high ->
+        "score-mark-high h-4 w-4 rounded-full bg-skillPanel-brightGreen600"
+
+      :middle ->
+        "score-mark-middle h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGreen-300"
+
+      :low ->
+        "score-mark-low h-1 w-4 bg-brightGray-200"
+    end
+  end
+
+  def score_mark_class(score, :compared_user) do
+    score
+    |> case do
+      :high ->
+        "score-mark-high h-4 w-4 rounded-full bg-skillPanel-amethyst600"
+
+      :middle ->
+        "score-mark-middle h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-skillPanel-amethyst300 inline-block"
+
+      v when v in [nil, :low] ->
+        "score-mark-low h-1 w-4 bg-brightGray-200"
+    end
+  end
+
+  def skill_reference_existing?(skill_reference) do
+    skill_reference && skill_reference.url
+  end
+
+  def skill_exam_existing?(skill_exam) do
+    skill_exam && skill_exam.url
+  end
+
   defp profile_skill_class_level(%{level: :beginner} = assigns), do: ~H"見習い"
 
   defp profile_skill_class_level(%{level: :normal} = assigns), do: ~H"平均"

--- a/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
@@ -157,8 +157,14 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
       |> SkillUnits.list_skill_units()
       |> Bright.Repo.preload(skill_categories: [skills: [:skill_reference, :skill_exam]])
 
+    skills =
+      skill_units
+      |> Enum.flat_map(& &1.skill_categories)
+      |> Enum.flat_map(& &1.skills)
+
     socket
     |> assign(skill_units: skill_units)
+    |> assign(skills: skills)
   end
 
   def assign_skill_score_dict(socket) do

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -42,8 +42,8 @@ defmodule BrightWeb.SkillPanelLive.Skills do
      |> assign_counter()
      |> assign_table_structure()
      |> assign_page_sub_title()
-     |> assign(:compaired_users, ["mokichi", "koyo"])
-     |> assign_compaired_users_info()
+     |> assign(compared_users: [], compared_user_dict: %{}, compared_users_stats: %{})
+     |> assign_compared_users_info()
      |> apply_action(socket.assigns.live_action, params)}
   end
 
@@ -150,6 +150,39 @@ defmodule BrightWeb.SkillPanelLive.Skills do
      |> push_redirect(to: ~p"/panels/#{socket.assigns.skill_panel}/skills")}
   end
 
+  # TODO: デモ用実装のため対象ユーザー実装後に削除
+  def handle_event("demo_compare_user", _params, socket) do
+    users =
+      Bright.Accounts.User
+      |> Bright.Repo.all()
+      |> Enum.reject(fn user ->
+        user.id == socket.assigns.focus_user.id ||
+          Ecto.assoc(user, :user_skill_panels)
+          |> Bright.Repo.all()
+          |> Enum.empty?()
+      end)
+
+    if users != [] do
+      user = Enum.random(users)
+
+      {:noreply,
+       socket
+       |> update(:compared_users, &((&1 ++ [user]) |> Enum.uniq()))
+       |> assign_compared_user_dict(user)
+       |> assign_compared_users_info()}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("reject_compared_user", %{"name" => name}, socket) do
+    {:noreply,
+     socket
+     |> update(:compared_users, fn users -> Enum.reject(users, &(&1.name == name)) end)
+     |> update(:compared_user_dict, &Map.delete(&1, name))
+     |> assign_compared_users_info()}
+  end
+
   defp apply_action(socket, :show, _params), do: socket
 
   defp apply_action(socket, :show_evidences, params) do
@@ -172,11 +205,7 @@ defmodule BrightWeb.SkillPanelLive.Skills do
   end
 
   defp assign_skill(socket, skill_id) do
-    skill =
-      socket.assigns.skill_units
-      |> Enum.flat_map(& &1.skill_categories)
-      |> Enum.flat_map(& &1.skills)
-      |> Enum.find(&(&1.id == skill_id))
+    skill = socket.assigns.skills |> Enum.find(&(&1.id == skill_id))
 
     socket |> assign(skill: skill)
   end
@@ -262,28 +291,57 @@ defmodule BrightWeb.SkillPanelLive.Skills do
 
   defp create_skill_evidence_if_not_existing(socket), do: socket
 
-  defp assign_compaired_users_info(socket) do
-    # 比較対象になっているユーザーのデータを表示用に整理・集計
-    stats = %{
-      # スキルから数を引く
-    }
-    dict = %{
-      "mokichi" => %{
-        #スキルからスコアを引く
-        skill_score_dict: %{},
-        high_percentage: 0,
-        low_percentage: 0,
-      },
-      "koyo" => %{
-        skill_score_dict: %{},
-        high_percentage: 0,
-        low_percentage: 0,
-      }
-    }
+  defp assign_compared_user_dict(socket, user) do
+    # 比較対象になっているユーザーのデータを表示用に整理・集計してアサイン
+    skill_ids = Enum.map(socket.assigns.skills, & &1.id)
+    skill_scores = SkillScores.list_user_skill_scores_from_skill_ids(user, skill_ids)
+
+    {skill_score_dict, high_skills_count, middle_skills_count} =
+      skill_scores
+      |> Enum.reduce({%{}, 0, 0}, fn skill_score, {dict, high_c, middle_c} ->
+        score = skill_score.score
+
+        {
+          dict |> Map.put(skill_score.skill_id, score),
+          high_c + if(score == :high, do: 1, else: 0),
+          middle_c + if(score == :middle, do: 1, else: 0)
+        }
+      end)
+
+    size = Enum.count(skill_scores)
+    high_skills_percentage = calc_percentage(high_skills_count, size)
+    middle_skills_percentage = calc_percentage(middle_skills_count, size)
 
     socket
-    |> assign(:compaired_users_dict, dict)
-    |> assign(:compaired_users_stats, stats)
+    |> update(
+      :compared_user_dict,
+      &Map.put(&1, user.name, %{
+        high_skills_percentage: high_skills_percentage,
+        middle_skills_percentage: middle_skills_percentage,
+        skill_score_dict: skill_score_dict
+      })
+    )
+  end
+
+  defp assign_compared_users_info(socket) do
+    # 比較対象ユーザーのデータを集計してスキルの合計用データをアサイン
+    compared_users_stats =
+      socket.assigns.skills
+      |> Enum.reduce(%{}, fn skill, acc ->
+        scores =
+          socket.assigns.compared_user_dict
+          |> Map.values()
+          |> Enum.map(&get_in(&1, [:skill_score_dict, skill.id]))
+
+        acc
+        |> Map.put(skill.id, %{
+          high_skills_count: Enum.count(scores, &(&1 == :high)),
+          middle_skills_count: Enum.count(scores, &(&1 == :middle))
+        })
+      end)
+
+    socket
+    |> assign(compared_users_stats: compared_users_stats)
   end
 
   defp get_skill_score_from_table_structure(socket, row) do
@@ -351,27 +409,5 @@ defmodule BrightWeb.SkillPanelLive.Skills do
 
   defp skill_class_score_author?(skill_class_score, user) do
     skill_class_score.user_id == user.id
-  end
-
-  defp skill_reference_existing?(skill_reference) do
-    skill_reference && skill_reference.url
-  end
-
-  defp skill_exam_existing?(skill_exam) do
-    skill_exam && skill_exam.url
-  end
-
-  defp score_mark_class(skill_score) do
-    skill_score.score
-    |> case do
-      :high ->
-        "score-mark-high h-4 w-4 rounded-full bg-brightGreen-600"
-
-      :middle ->
-        "score-mark-middle h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGreen-300"
-
-      :low ->
-        "score-mark-low h-1 w-4 bg-brightGray-200"
-    end
   end
 end

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -18,7 +18,7 @@
             </td>
             <td class="!border-l !border-brightGray-200">
               <div class="flex justify-center items-center min-w-[150px]">
-                <p class="inline-flex flex-1 justify-center"><%= @current_user.name %></p>
+                <p class="inline-flex flex-1 justify-center"><%= @focus_user.name %></p>
 
                 <%= if skill_class_score_author?(@skill_class_score, @current_user) do %>
                   <button
@@ -40,25 +40,26 @@
                 <% end %>
               </div>
             </td>
-            <td>
+            <td :for={user <- @compared_users} class="!border-l !border-brightGray-200">
               <div class="flex justify-center items-center">
-                <p class="inline-flex flex-1 justify-center">mokichi</p>
+                <p class="inline-flex flex-1 justify-center"><%= user.name %></p>
                 <button
-                    type="button"
-                    class="text-brightGray-900 rounded-full w-3 h-3 inline-flex items-center justify-center"
-                    >
-                    <span class="material-icons-outlined !text-xs">close</span>
+                  type="button"
+                  class="text-brightGray-900 rounded-full w-3 h-3 inline-flex items-center justify-center"
+                  phx-click="reject_compared_user"
+                  phx-value-name={user.name}
+                >
+                  <span class="material-icons-outlined !text-xs">close</span>
                 </button>
               </div>
             </td>
           </tr>
-          <!-- 未実装：デザインまま END -->
           <tr>
             <th class="bg-base text-white text-center w-[200px]">
               知識エリア
             </th>
             <th class="bg-base text-white text-center w-[200px]">
-              カテゴリ
+              カテゴリー
             </th>
             <th class="bg-base text-white text-center w-[420px]">
               スキル
@@ -68,13 +69,24 @@
             </th>
             <td>
               <div class="flex justify-center gap-x-2">
-                <div class="min-w-[4em] flex items-center">
-                  <span class="h-4 w-4 rounded-full bg-brightGreen-600 inline-block mr-1" />
+                <div class="min-w-[3em] flex items-center">
+                  <span class="h-4 w-4 rounded-full bg-skillPanel-brightGreen600 inline-block mr-1" />
                   <span class="score-high-percentage"><%= floor calc_percentage(@counter.high, @num_skills) %>％</span>
                 </div>
-                <div class="min-w-[4em] flex items-center">
-                  <span class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGreen-300 inline-block mr-1" />
+                <div class="min-w-[3em] flex items-center">
+                  <span class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-skillPanel-brightGreen300 inline-block mr-1" />
                   <span class="score-middle-percentage"><%= floor calc_percentage(@counter.middle, @num_skills) %>％</span>
+                </div>
+              </div>
+            </td>
+            <td :for={user <- @compared_users}>
+              <% user_data = Map.get(@compared_user_dict, user.name) %>
+              <div class="flex justify-center gap-x-2">
+                <div class="min-w-[3em] flex items-center">
+                  <span class="h-4 w-4 rounded-full bg-skillPanel-amethyst600 inline-block mr-1"></span><%= user_data.high_skills_percentage %>％
+                </div>
+                <div class="min-w-[3em] flex items-center">
+                  <span class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-skillPanel-amethyst300 inline-block mr-1"></span><%= user_data.middle_skills_percentage %>％
                 </div>
               </div>
             </td>
@@ -106,13 +118,23 @@
                 </div>
               </td>
               <td>
-                <% # 「個人と比較」対応時に本実装箇所。現在は一人なので0/1 %>
-                <div class="num-high-users flex justify-center px-4">
-                  <%= if skill_score.score == :high do %>
-                  1
-                  <% else %>
-                  0
-                  <% end %>
+                <div class="num-high-users flex justify-center gap-x-1">
+                  <div class="min-w-[3em] flex items-center">
+                    <span class="h-4 w-4 rounded-full bg-brightGray-500 inline-block mr-1"></span>
+                    <%= if skill_score.score == :high do %>
+                      <%= get_in(@compared_users_stats, [col3.skill.id, :high_skills_count]) + 1 %>
+                    <% else %>
+                      <%= get_in(@compared_users_stats, [col3.skill.id, :high_skills_count]) %>
+                    <% end %>
+                  </div>
+                  <div class="min-w-[3em] flex items-center">
+                    <span class="h-0 w-0 border-solid border-t-0 border-r-8 border-l-8 border-transparent border-b-[14px] border-b-brightGray-300 inline-block mr-1"></span>
+                    <%= if skill_score.score == :middle do %>
+                      <%= get_in(@compared_users_stats, [col3.skill.id, :middle_skills_count]) + 1 %>
+                    <% else %>
+                      <%= get_in(@compared_users_stats, [col3.skill.id, :middle_skills_count]) %>
+                    <% end %>
+                  </div>
                 </div>
               </td>
               <td class={[focus && "bg-brightGray-50"]}>
@@ -165,12 +187,16 @@
                     </label>
                   </div>
                 <% else %>
-                  <div class="flex justify-center gap-x-4 px-4">
-                    <div class="flex items-center">
-                      <div class={score_mark_class(skill_score)} />
-                    </div>
+                  <div class="flex justify-center gap-x-4 px-4 min-w-[150px]">
+                    <div class={score_mark_class(skill_score.score, :me)} />
                   </div>
                 <% end %>
+              </td>
+              <td :for={user <- @compared_users}>
+                <% score = get_in(@compared_user_dict, [user.name, :skill_score_dict, col3.skill.id]) %>
+                <div class="flex justify-center gap-x-4 px-4 h-[21px] items-center">
+                  <div class={score_mark_class(score, :compared_user)} />
+                </div>
               </td>
             </tr>
           <% end %>

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -5,8 +5,19 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
     ~H"""
     <div class="flex mt-4 items-center">
       <.compare_timeline />
+      <% # TODO: 仮UI コンポーネント完成後に削除 %>
       <div class="flex gap-x-4">
-        <.compare_individual current_user={@current_user} />
+        <button
+          class="border border-brightGray-200 rounded-md py-1.5 pl-3 flex items-center"
+          type="button"
+          phx-click="demo_compare_user"
+        >
+          <span class="min-w-[6em]">個人と比較</span>
+          <span
+            class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-7px] before:bg-brightGray-200 before:w-[1px] before:h-[38px]">add</span>
+        </button>
+        <% # TODO: コンポーネント完成後にifを除去して表示 %>
+        <.compare_individual :if={false} current_user={@current_user} />
         <% # TODO: α版後にifを除去して表示 %>
         <.compare_team :if={false} current_user={@current_user} />
         <% # TODO: α版後にifを除去して表示 %>


### PR DESCRIPTION
## 対応内容

refs: #609 

スキルパネル画面での個人との比較の動作部分の実装です。
UIは本来メガメニューがでますが、別件対応のため、先に動きを作りました。

未対応
- メガメニューからのユーザー選択
- タイムライン切り替え時との連携動作


## 画面
![sample21](https://github.com/bright-org/bright/assets/121112529/51e6192f-d12a-4283-bad7-617c8058c05e)

- 「個人と比較」をクリック時に、メガメニューは出さずに、こちらで勝手にユーザーをチョイスしています（これは完全に今だけ動作です）

