### PR TITLE
α版対応「あと8%でベテランになれます。次のレベルまでのスキル数10個」を非表示にする

### DIFF
--- a/lib/bright_web/live/skill_panel_live/graph.html.heex
+++ b/lib/bright_web/live/skill_panel_live/graph.html.heex
@@ -27,7 +27,8 @@
             skill_panel_id={@skill_panel.id}
             class={@skill_class.class}
           />
-          <div class="flex justify-center">
+          <% # TODO: α版後に:if={false}を除去して表示 %>
+          <div :if={false} class="flex justify-center">
             <p>
               あと<span class="text-error !text-2xl font-bold">8</span>%でベテランになれます。
             </p>


### PR DESCRIPTION
修正前
![Screenshot from 2023-08-15 17-45-16](https://github.com/bright-org/bright/assets/13599847/323af360-cbbd-4e95-af3c-ab566338ce4d)

修正後
![image](https://github.com/bright-org/bright/assets/13599847/fa32106f-6655-4d31-a0b5-e22835671c02)
