### PR TITLE
マイページ、スキルパネルのURL追加と変更

### DIFF
--- a/lib/bright_web/live/card_live/skill_card_component.ex
+++ b/lib/bright_web/live/card_live/skill_card_component.ex
@@ -34,7 +34,7 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
             <div class="w-36 font-bold">クラス3</div>
           </div>
           <%= for skill_panel <- @skill_panels do %>
-            <.skill_panel skill_panel={skill_panel} path={@path} />
+            <.skill_panel skill_panel={skill_panel} root={@root} />
           <% end %>
         </div>
       </.tab>
@@ -46,7 +46,8 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
     ~H"""
     <div class="flex">
       <div class="flex-1 text-left font-bold">
-        <.link href={"/panels/#{@skill_panel.id}/#{@path}"} >
+        <% # TODO: 対象ユーザーが指定されている場合jの対応 %>
+        <.link href={"/#{@root}/#{@skill_panel.id}"} >
           <%= @skill_panel.name %>
         </.link>
       </div>
@@ -55,7 +56,7 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
           score={List.first(class.skill_class_scores)}
           class_num={class.class}
           skill_panel_id={@skill_panel.id}
-          path={@path}
+          root={@root}
         />
       <% end %>
     </div>
@@ -76,7 +77,7 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
 
     ~H"""
     <div class="w-36">
-      <.link href={"/panels/#{@skill_panel_id}/#{@path}?class=#{@class_num}"}>
+      <.link href={"/#{@root}/#{@skill_panel_id}?class=#{@class_num}"}>
         <p class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1">
           <img src={@icon_path} class="mr-1" />
           <span class="w-16"><%= level_text(@level) %></span>

--- a/lib/bright_web/live/mypage_live/index.html.heex
+++ b/lib/bright_web/live/mypage_live/index.html.heex
@@ -48,7 +48,7 @@
         id="skill_card"
         module={BrightWeb.CardLive.SkillCardComponent}
         current_user={@current_user}
-        path="graph"
+        root="graphs"
       />
     </div>
   </div>

--- a/lib/bright_web/live/onboarding_live/skill_panel.ex
+++ b/lib/bright_web/live/onboarding_live/skill_panel.ex
@@ -109,7 +109,7 @@ defmodule BrightWeb.OnboardingLive.SkillPanel do
 
     socket
     |> put_flash(:info, "スキルパネル:#{name}を取得しました")
-    |> redirect(to: "/panels/#{skill_panel_id}/graph")
+    |> redirect(to: "/graphs/#{skill_panel_id}")
     |> then(&{:noreply, &1})
   end
 

--- a/lib/bright_web/live/skill_panel_live/graph.ex
+++ b/lib/bright_web/live/skill_panel_live/graph.ex
@@ -46,12 +46,12 @@ defmodule BrightWeb.SkillPanelLive.Graph do
 
       {:noreply,
        socket
-       |> push_redirect(to: ~p"/panels/#{socket.assigns.skill_panel}/graph/#{user.name}")}
+       |> push_redirect(to: ~p"/graphs/#{socket.assigns.skill_panel}/#{user.name}")}
     else
       {:noreply,
        socket
        |> put_flash(:info, "demo: ユーザーがいません")
-       |> push_redirect(to: ~p"/panels/#{socket.assigns.skill_panel}/graph")}
+       |> push_redirect(to: ~p"/graphs/#{socket.assigns.skill_panel}")}
     end
   end
 
@@ -59,7 +59,7 @@ defmodule BrightWeb.SkillPanelLive.Graph do
   def handle_event("clear_target_user", _params, socket) do
     {:noreply,
      socket
-     |> push_redirect(to: ~p"/panels/#{socket.assigns.skill_panel}/graph")}
+     |> push_redirect(to: ~p"/graphs/#{socket.assigns.skill_panel}")}
   end
 
   @impl true

--- a/lib/bright_web/live/skill_panel_live/graph.html.heex
+++ b/lib/bright_web/live/skill_panel_live/graph.html.heex
@@ -1,7 +1,7 @@
 <!-- feat: スキルパネル更新 861b28d9a8ec541ac03fe716ac0926b4e5575d5e　まで適用 -->
 <div :if={@skill_panel}>
   <!-- card -->
-  <.navigations current_user={@current_user} path="graph" />
+  <.navigations current_user={@current_user} root="graphs" />
   <div class="mx-10">
     <div class="flex justify-between">
       <% # TODO: α版後にifと仮divブロックを除去して表示 %>

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -33,7 +33,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
   def navigations(assigns) do
     ~H"""
     <div class="flex gap-x-4 px-10 pt-4 pb-3">
-      <.skill_panel_switch current_user={@current_user} path={@path}/>
+      <.skill_panel_switch current_user={@current_user} root={@root}/>
       <.target_switch current_user={@current_user} />
     </div>
     """
@@ -42,7 +42,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
   def skill_panel_switch(assigns) do
     ~H"""
     <p class="leading-tight">対象スキルの<br />切り替え</p>
-    <.skill_panel_menu current_user={@current_user} path={@path} />
+    <.skill_panel_menu current_user={@current_user} root={@root} />
     <% # TODO: α版後にifを除去して表示 %>
     <.skill_set_menu :if={false} />
     """
@@ -73,7 +73,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
           id="skill_card"
           module={BrightWeb.CardLive.SkillCardComponent}
           current_user={@current_user}
-          path={@path}
+          root={@root}
         />
       </div>
     """
@@ -231,7 +231,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
   def toggle_link(assigns) do
     ~H"""
       <div class="bg-white text-brightGray-500 rounded-full inline-flex text-sm font-bold h-10">
-      <.link href={"/panels/dummy_id/graph"}>
+      <.link href="#">
         <button
           id="grid"
           class={
@@ -242,7 +242,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
           成長パネル
         </button>
         </.link>
-        <.link href={"/panels/#{@skill_panel.id}/skills?class=1"}>
+        <.link href="#">
           <button
             id="list"
             class={

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -135,19 +135,19 @@ defmodule BrightWeb.SkillPanelLive.Skills do
 
       {:noreply,
        socket
-       |> push_redirect(to: ~p"/panels/#{socket.assigns.skill_panel}/skills/#{user.name}")}
+       |> push_redirect(to: ~p"/panels/#{socket.assigns.skill_panel}/#{user.name}")}
     else
       {:noreply,
        socket
        |> put_flash(:info, "demo: ユーザーがいません")
-       |> push_redirect(to: ~p"/panels/#{socket.assigns.skill_panel}/skills")}
+       |> push_redirect(to: ~p"/panels/#{socket.assigns.skill_panel}")}
     end
   end
 
   def handle_event("clear_target_user", _params, socket) do
     {:noreply,
      socket
-     |> push_redirect(to: ~p"/panels/#{socket.assigns.skill_panel}/skills")}
+     |> push_redirect(to: ~p"/panels/#{socket.assigns.skill_panel}")}
   end
 
   # TODO: デモ用実装のため対象ユーザー実装後に削除

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -1,5 +1,5 @@
 <!-- card -->
-<.navigations current_user={@current_user} path="skills" />
+<.navigations current_user={@current_user} root="panels" />
 <div class="mx-10">
   <div class="flex justify-between">
     <% # TODO: α版後にifと仮divブロックを除去して表示 %>
@@ -33,7 +33,7 @@
   id="skill-evidence-modal"
   show
   style_of_modal_flame_out="w-full max-w-3xl p-4 sm:p-6 lg:py-8"
-  on_cancel={JS.patch(~p"/panels/#{@skill_panel}/skills?class=#{@skill_class.class}")}>
+  on_cancel={JS.patch(~p"/panels/#{@skill_panel}?class=#{@skill_class.class}")}>
 
   <.live_component
     module={BrightWeb.SkillPanelLive.SkillEvidenceComponent}
@@ -41,7 +41,7 @@
     skill={@skill}
     skill_evidence={@skill_evidence}
     user={@current_user}
-    patch={~p"/panels/#{@skill_panel}/skills?class=#{@skill_class.class}"}
+    patch={~p"/panels/#{@skill_panel}?class=#{@skill_class.class}"}
   />
 </.bright_modal>
 
@@ -49,7 +49,7 @@
   :if={:show_reference == @live_action}
   id="skill-reference-modal"
   show
-  on_cancel={JS.patch(~p"/panels/#{@skill_panel}/skills?class=#{@skill_class.class}")}>
+  on_cancel={JS.patch(~p"/panels/#{@skill_panel}?class=#{@skill_class.class}")}>
 
   <.header><%= @skill.name %></.header>
 
@@ -62,7 +62,7 @@
   :if={:show_exam == @live_action}
   id="skill-exam-modal"
   show
-  on_cancel={JS.patch(~p"/panels/#{@skill_panel}/skills?class=#{@skill_class.class}")}>
+  on_cancel={JS.patch(~p"/panels/#{@skill_panel}?class=#{@skill_class.class}")}>
 
   <.header><%= @skill.name %></.header>
 

--- a/lib/bright_web/live/skill_up_live/skill_up_dummy_live.ex
+++ b/lib/bright_web/live/skill_up_live/skill_up_dummy_live.ex
@@ -56,7 +56,7 @@ defmodule BrightWeb.SkillUpDummyLive do
 
     socket
     |> put_flash(:info, "スキルパネル:#{name}を取得しました")
-    |> push_navigate(to: "/panels/#{skill_panel_id}/graph")
+    |> push_navigate(to: "/graphs/#{skill_panel_id}")
     |> then(&{:noreply, &1})
   end
 end

--- a/lib/bright_web/router.ex
+++ b/lib/bright_web/router.ex
@@ -156,13 +156,19 @@ defmodule BrightWeb.Router do
       live "/users/settings", UserSettingsLive, :edit
       live "/users/settings/confirm_email/:token", UserSettingsLive, :confirm_email
       live "/mypage", MypageLive.Index, :index
+      live "/mypage/:user_name", MypageLive.Index, :index
+      live "/mypage/anon/:user_name_crypted", MypageLive.Index, :index
       live "/skill_up", SkillUpDummyLive, :index
+
       live "/graphs", SkillPanelLive.Graph, :show
+      live "/graphs/:skill_panel_id", SkillPanelLive.Graph, :show
+      live "/graphs/:skill_panel_id/:user_name", SkillPanelLive.Graph, :show
+      live "/graphs/:skill_panel_id/anon/:user_name_crypted", SkillPanelLive.Graph, :show
+
       live "/panels", SkillPanelLive.Skills, :show
-      live "/panels/:skill_panel_id/graph", SkillPanelLive.Graph, :show
-      live "/panels/:skill_panel_id/graph/:user_name", SkillPanelLive.Graph, :show
-      live "/panels/:skill_panel_id/skills", SkillPanelLive.Skills, :show
-      live "/panels/:skill_panel_id/skills/:user_name", SkillPanelLive.Skills, :show
+      live "/panels/:skill_panel_id", SkillPanelLive.Skills, :show
+      live "/panels/:skill_panel_id/:user_name", SkillPanelLive.Skills, :show
+      live "/panels/:skill_panel_id/anon/:user_name_crypted", SkillPanelLive.Skills, :show
 
       live "/panels/:skill_panel_id/skills/:skill_id/evidences",
            SkillPanelLive.Skills,

--- a/test/bright_web/live/skill_panel_live/graph_test.exs
+++ b/test/bright_web/live/skill_panel_live/graph_test.exs
@@ -20,7 +20,7 @@ defmodule BrightWeb.SkillPanelLive.GraphTest do
       skill_panel: skill_panel,
       skill_class: skill_class
     } do
-      {:ok, show_live, html} = live(conn, ~p"/panels/#{skill_panel}/graph")
+      {:ok, show_live, html} = live(conn, ~p"/graphs/#{skill_panel}")
 
       assert html =~ skill_panel.name
 

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -47,7 +47,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       skill_panel: skill_panel,
       skill_class: skill_class
     } do
-      {:ok, show_live, html} = live(conn, ~p"/panels/#{skill_panel}/skills")
+      {:ok, show_live, html} = live(conn, ~p"/panels/#{skill_panel}")
 
       assert html =~ "スキルパネル"
 
@@ -86,7 +86,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       insert_skill_categories_and_skills(skill_unit_2, [1, 1, 2])
       insert_skill_categories_and_skills(skill_unit_dummy, [1])
 
-      {:ok, show_live, html} = live(conn, ~p"/panels/#{skill_panel}/skills")
+      {:ok, show_live, html} = live(conn, ~p"/panels/#{skill_panel}")
 
       assert html =~ "スキルパネル"
 
@@ -119,7 +119,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       skill_class_2 = insert(:skill_class, skill_panel: skill_panel, class: 2)
       insert(:init_skill_class_score, user: user, skill_class: skill_class_2)
 
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=2")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=2")
 
       assert show_live
              |> has_element?("#class_tab_2", skill_class_2.name)
@@ -131,7 +131,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
 
     @tag score: :low
     test "shows mark when score: low", %{conn: conn, skill_panel: skill_panel} do
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       assert show_live
              |> element(".score-mark-low")
@@ -140,7 +140,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
 
     @tag score: :middle
     test "shows mark when score: middle", %{conn: conn, skill_panel: skill_panel} do
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       assert show_live
              |> element(".score-mark-middle")
@@ -149,7 +149,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
 
     @tag score: :high
     test "shows mark when score: high", %{conn: conn, skill_panel: skill_panel} do
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       assert show_live
              |> element(".score-mark-high")
@@ -162,7 +162,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
 
     @tag score: :low
     test "update scores", %{conn: conn, skill_panel: skill_panel} do
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       # 編集モード IN
       show_live
@@ -194,7 +194,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       assert show_live |> has_element?("#skill-3 .score-mark-high")
 
       # 永続化確認のための再描画
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       assert show_live |> has_element?("#skill-1 .score-mark-low")
       assert show_live |> has_element?("#skill-2 .score-mark-middle")
@@ -203,7 +203,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
 
     @tag score: nil
     test "edits by key input", %{conn: conn, skill_panel: skill_panel} do
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       # 編集モード IN
       show_live
@@ -236,7 +236,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       |> render_click()
 
       # 永続化確認のための再描画
-      {:ok, _show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, _show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       assert show_live |> has_element?("#skill-1 .score-mark-high")
       assert show_live |> has_element?("#skill-2 .score-mark-middle")
@@ -245,7 +245,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
 
     @tag score: nil
     test "move by key input", %{conn: conn, skill_panel: skill_panel} do
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       # 編集モード IN
       show_live
@@ -292,7 +292,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
 
     @tag score: nil
     test "shows updated value", %{conn: conn, skill_panel: skill_panel} do
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       # 初期表示
       assert show_live
@@ -336,7 +336,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       |> element(~s{button[phx-click="submit"]})
       |> render_click()
 
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       assert show_live
              |> element(".score-high-percentage", "66％")
@@ -367,7 +367,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       |> element(~s{button[phx-click="submit"]})
       |> render_click()
 
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       assert show_live
              |> element(".score-high-percentage", "0％")
@@ -385,7 +385,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
 
     @tag score: nil
     test "shows modal", %{conn: conn, skill_panel: skill_panel, skill_1: skill_1} do
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       show_live
       |> element("#skill-1 .link-evidence")
@@ -416,7 +416,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
           content: "some content"
         )
 
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       show_live
       |> element("#skill-1 .link-evidence")
@@ -455,7 +455,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
     @tag score: nil
     test "shows modal", %{conn: conn, skill_panel: skill_panel, skill_1: skill_1} do
       skill_reference = insert(:skill_reference, skill: skill_1)
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       show_live
       |> element("#skill-1 .link-reference")
@@ -471,7 +471,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
 
     @tag score: nil
     test "教材がないスキルのリンクが表示されないこと", %{conn: conn, skill_panel: skill_panel} do
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       refute show_live
              |> element("#skill-1 .link-reference")
@@ -481,7 +481,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
     @tag score: nil
     test "教材のURLがないスキルのリンクが表示されないこと", %{conn: conn, skill_panel: skill_panel, skill_1: skill_1} do
       insert(:skill_reference, skill: skill_1, url: nil)
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       refute show_live
              |> element("#skill-1 .link-reference")
@@ -496,7 +496,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
     @tag score: nil
     test "shows modal", %{conn: conn, skill_panel: skill_panel, skill_1: skill_1} do
       skill_exam = insert(:skill_exam, skill: skill_1)
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       show_live
       |> element("#skill-1 .link-exam")
@@ -512,7 +512,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
 
     @tag score: nil
     test "試験がないスキルのリンクが表示されないこと", %{conn: conn, skill_panel: skill_panel} do
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       refute show_live
              |> element("#skill-1 .link-exam")
@@ -522,7 +522,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
     @tag score: nil
     test "試験のURLがないスキルのリンクが表示されないこと", %{conn: conn, skill_panel: skill_panel, skill_1: skill_1} do
       insert(:skill_exam, skill: skill_1, url: nil)
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       refute show_live
              |> element("#skill-1 .link-exam")
@@ -548,7 +548,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       insert(:init_skill_class_score, user: dummy_user, skill_class: skill_class)
       insert(:skill_score, user: dummy_user, skill: skill, score: :high)
 
-      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}/skills?class=1")
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
 
       refute show_live
              |> element(".score-mark-high")


### PR DESCRIPTION
refs: [かんばん](https://github.com/orgs/bright-org/projects/3/views/1?pane=issue&itemId=35985758)

設計: #267 

## 対応内容

メールに載せるURL

/graphs
/panels

に合わせて、現存のURLを書き換えました。
加えて、匿名ユーザーのURLも追加だけしています。
処理はありません。

grepなどで探して修正＋そもそもverified_routesが使われていればエラーになります。

