### PR TITLE
タイムラインバーを共通利用するためのモジュール切り出し対応

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -7,7 +7,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
   def compares(assigns) do
     ~H"""
     <div class="flex mt-4 items-center">
-      <.compare_timeline myself={@myself} />
+      <.compare_timeline myself={@myself} timeline={@timeline} />
       <% # TODO: 仮UI コンポーネント完成後に削除 %>
       <div class="flex gap-x-4">
         <button
@@ -35,24 +35,50 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
     ~H"""
     <div class="w-[566px] mr-10">
       <div class="flex">
+        <% # 過去方向ボタン %>
         <div class="flex justify-center items-center ml-1 mr-3">
-          <button class="w-6 h-8 bg-brightGray-900 flex justify-center items-center rounded">
-            <span class="material-icons text-white !text-3xl">arrow_left</span>
-          </button>
+          <%= if @timeline.past_enabled do %>
+            <button
+              class="w-6 h-8 bg-brightGray-900 flex justify-center items-center rounded"
+              phx-click="shift_timeline_past"
+              phx-target={@myself}
+            >
+              <span class="material-icons text-white !text-3xl">arrow_left</span>
+            </button>
+          <% else %>
+            <button class="w-6 h-8 bg-brightGray-300 flex justify-center items-center rounded">
+              <span class="material-icons text-white !text-3xl">arrow_left</span>
+            </button>
+          <% end %>
         </div>
+
+        <% # タイムラインバー %>
         <BrightWeb.TimelineBarComponents.timeline_bar
           id="timeline"
           target={@myself}
           type="myself"
-          dates={["2022.12", "2023.3", "2023.6", "2023.9", "2023.12"]}
-          selected_date={"2023.6"}
-          display_now={true}
+          dates={@timeline.labels}
+          selected_date={@timeline.selected_label}
+          display_now={@timeline.display_now}
           scale="sm"
         />
+
+        <% # 未来方向ボタン %>
         <div class="flex justify-center items-center ml-2">
-          <button class="w-6 h-8 bg-brightGray-300 flex justify-center items-center rounded">
-            <span class="material-icons text-white !text-3xl">arrow_right</span>
-          </button>
+          <%= if @timeline.future_enabled do %>
+            <button
+              class="w-6 h-8 bg-brightGray-900 flex justify-center items-center rounded"
+              phx-click="shift_timeline_future"
+              phx-target={@myself}
+              disabled={!@timeline.future_enabled}
+            >
+              <span class="material-icons text-white !text-3xl">arrow_right</span>
+            </button>
+          <% else %>
+            <button class="w-6 h-8 bg-brightGray-300 flex justify-center items-center rounded">
+              <span class="material-icons text-white !text-3xl">arrow_right</span>
+            </button>
+          <% end %>
         </div>
       </div>
     </div>

--- a/lib/bright_web/live/skill_panel_live/skills_field_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_field_component.ex
@@ -11,11 +11,12 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
 
   alias Bright.SkillUnits
   alias Bright.SkillScores
+  alias BrightWeb.SkillPanelLive.TimelineHelper
 
   def render(assigns) do
     ~H"""
     <div id={@id}>
-      <.compares current_user={@current_user} myself={@myself} />
+      <.compares current_user={@current_user} myself={@myself} timeline={@timeline} />
       <.skills_table
          table_structure={@table_structure}
          skill_panel={@skill_panel}
@@ -40,7 +41,8 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
   def mount(socket) do
     {:ok,
      socket
-     |> assign(compared_users: [], compared_user_dict: %{})}
+     |> assign(compared_users: [], compared_user_dict: %{})
+     |> assign(timeline: TimelineHelper.get_current())}
   end
 
   def update(assigns, socket) do
@@ -85,8 +87,30 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
      |> update(:compared_user_dict, &Map.delete(&1, name))}
   end
 
-  def handle_event("timeline_bar_button_click", _params, socket) do
-    {:noreply, socket}
+  def handle_event("timeline_bar_button_click", %{"date" => date}, socket) do
+    timeline =
+      socket.assigns.timeline
+      |> TimelineHelper.select_label(date)
+
+    # <= その他処理
+
+    {:noreply, socket |> assign(timeline: timeline)}
+  end
+
+  def handle_event("shift_timeline_past", _params, socket) do
+    timeline =
+      socket.assigns.timeline
+      |> TimelineHelper.shift_for_past()
+
+    {:noreply, socket |> assign(timeline: timeline)}
+  end
+
+  def handle_event("shift_timeline_future", _params, socket) do
+    timeline =
+      socket.assigns.timeline
+      |> TimelineHelper.shift_for_future()
+
+    {:noreply, socket |> assign(timeline: timeline)}
   end
 
   def assign_skill_units(socket) do

--- a/lib/bright_web/live/skill_panel_live/timeline_helper.ex
+++ b/lib/bright_web/live/skill_panel_live/timeline_helper.ex
@@ -1,0 +1,114 @@
+defmodule BrightWeb.SkillPanelLive.TimelineHelper do
+  @moduledoc """
+  タイムラインバー表示のためのデータ作成用の共通処理
+  表示用データは以下の通り。
+
+  labels: 表示するラベル。ただし「現在」は含まない
+  selected_label: 選択されているラベル。ただし「現在」に関しては"now"で格納
+  future_enabled: これ以上の未来を考慮できるかどうかのフラグ
+  past_enabled: これ以上の過去を考慮できるかどうかのフラグ
+  display_now: 「現在」ボタンを表示するかどうかのフラグ
+  """
+
+  # スタートはElixirスキルシート(Excel)の運用開始日時
+  @start_label "2021.10"
+  @start_month 10
+  @monthly_interval 3
+  @num_labels 5
+
+  def get_current do
+    future_date = get_future_month()
+    start_date = future_date |> Timex.shift(months: -1 * @monthly_interval * (@num_labels - 1))
+    {_, labels} = create_months(start_date, 0)
+    future_enabled = future_enabled?(labels, future_date)
+    past_enabled = past_enabled?(labels)
+
+    %{
+      future_date: future_date,
+      start_date: start_date,
+      labels: labels,
+      selected_label: "now",
+      future_enabled: future_enabled,
+      past_enabled: past_enabled,
+      display_now: !future_enabled
+    }
+  end
+
+  def select_label(timeline, label) do
+    timeline
+    |> Map.put(:selected_label, label)
+  end
+
+  def shift_for_future(timeline) do
+    {start_date, labels} = create_months(timeline.start_date, @monthly_interval)
+    future_enabled = future_enabled?(labels, timeline.future_date)
+    past_enabled = past_enabled?(labels)
+
+    timeline
+    |> Map.merge(%{
+      start_date: start_date,
+      labels: labels,
+      future_enabled: future_enabled,
+      past_enabled: past_enabled,
+      display_now: !future_enabled
+    })
+  end
+
+  def shift_for_past(timeline) do
+    {start_date, labels} = create_months(timeline.start_date, -1 * @monthly_interval)
+    future_enabled = future_enabled?(labels, timeline.future_date)
+    past_enabled = past_enabled?(labels)
+
+    timeline
+    |> Map.merge(%{
+      start_date: start_date,
+      labels: labels,
+      future_enabled: future_enabled,
+      past_enabled: past_enabled,
+      display_now: !future_enabled
+    })
+  end
+
+  defp get_future_month(), do: get_future_month(@start_month, Date.utc_today())
+
+  defp get_future_month(start_month, now) do
+    {:ok, now} = Date.new(now.year, now.month, 1)
+
+    1..24//3
+    |> Enum.map(fn x -> x + start_month - 1 end)
+    |> Enum.map(fn x -> month_shiht_add(now.year - 1, x) end)
+    |> Enum.map(fn x -> Date.from_erl!(x) end)
+    |> Enum.filter(fn x -> Timex.compare(x, now) > 0 end)
+    |> List.first()
+  end
+
+  defp create_months(current_start_date, shift_month) do
+    start_date =
+      current_start_date
+      |> Timex.shift(months: shift_month)
+
+    labels =
+      0..(@num_labels - 1)
+      |> Enum.map(fn nth ->
+        start_date
+        |> Timex.shift(months: @monthly_interval * nth)
+        |> date_to_label()
+      end)
+
+    {start_date, labels}
+  end
+
+  defp month_shiht_add(year, month) when month > 24, do: {year + 2, month - 24, 1}
+  defp month_shiht_add(year, month) when month > 12, do: {year + 1, month - 12, 1}
+  defp month_shiht_add(year, month) when month <= 12, do: {year, month, 1}
+
+  defp date_to_label(data), do: "#{data.year}.#{data.month}"
+
+  defp future_enabled?(labels, future) do
+    List.last(labels) != date_to_label(future)
+  end
+
+  defp past_enabled?(labels) do
+    List.first(labels) != @start_label
+  end
+end


### PR DESCRIPTION
refs: #622 

## 対応内容

タイムラインバー初期化やUI押下時のタイムラインバーUI上での動作を実装しました。
成長グラフ側で作られていた処理を共有できるような形でモジュールに切り出しました。

成長グラフ側の処理を、共有モジュールを使う形にするのは本PRに含まれません。
（このあたりテストがないので、現状では手に負えないと判断しました）

**未対応**

- タイムラインバーで操作したときのタイムラインバー以外への影響

## 画面

![sample26](https://github.com/bright-org/bright/assets/121112529/23e1a031-9b88-4399-a038-067ee10e9188)
