### PR TITLE
スキルパネル タイムライン対応

### DIFF
--- a/lib/bright/historical_skill_panels.ex
+++ b/lib/bright/historical_skill_panels.ex
@@ -7,6 +7,7 @@ defmodule Bright.HistoricalSkillPanels do
   alias Bright.Repo
 
   alias Bright.HistoricalSkillPanels.SkillPanel
+  alias Bright.HistoricalSkillPanels.HistoricalSkillClass
 
   @doc """
   Returns the list of skill_panels.
@@ -36,4 +37,22 @@ defmodule Bright.HistoricalSkillPanels do
 
   """
   def get_skill_panel!(id), do: Repo.get!(SkillPanel, id)
+
+  @doc """
+  スキルパネル＋日付条件に該当する過去スキルクラスを返す。
+
+  locked_dateはあくまでロックした日付のため（その日以降も使われる）、
+  引数date時点のスキルクラスを取るには、その前日より前にロックされたものを探す必要がある。
+  """
+  def get_historical_skill_class_on_date(skill_panel_id: skill_panel_id, class: class, date: date) do
+    from(
+      q in HistoricalSkillClass,
+      where: q.skill_panel_id == ^skill_panel_id,
+      where: q.class == ^class,
+      where: q.locked_date < ^date,
+      order_by: [desc: q.locked_date],
+      limit: 1
+    )
+    |> Repo.one()
+  end
 end

--- a/lib/bright/historical_skill_panels/historical_skill_class.ex
+++ b/lib/bright/historical_skill_panels/historical_skill_class.ex
@@ -6,6 +6,7 @@ defmodule Bright.HistoricalSkillPanels.HistoricalSkillClass do
   use Ecto.Schema
 
   alias Bright.HistoricalSkillPanels.SkillPanel
+  alias Bright.HistoricalSkillUnits.HistoricalSkillClassUnit
 
   @primary_key {:id, Ecto.ULID, autogenerate: true}
   @foreign_key_type Ecto.ULID
@@ -17,6 +18,13 @@ defmodule Bright.HistoricalSkillPanels.HistoricalSkillClass do
     field :class, :integer
 
     belongs_to :skill_panel, SkillPanel
+
+    has_many :historical_skill_class_units, HistoricalSkillClassUnit,
+      preload_order: [asc: :position],
+      on_replace: :delete
+
+    has_many :historical_skill_units,
+      through: [:historical_skill_class_units, :historical_skill_unit]
 
     has_many :historical_skill_class_scores,
              Bright.HistoricalSkillScores.HistoricalSkillClassScore

--- a/lib/bright/historical_skill_scores.ex
+++ b/lib/bright/historical_skill_scores.ex
@@ -1,0 +1,48 @@
+defmodule Bright.HistoricalSkillScores do
+  @moduledoc """
+  The HistoricalSkillScores context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Bright.Repo
+
+  alias Bright.HistoricalSkillUnits
+  alias Bright.HistoricalSkillScores.HistoricalSkillScore
+
+  @doc """
+  Returns the list of historical_skill_scores.
+
+  ## Examples
+
+      iex> list_historical_skill_scores()
+      [%HistoricalSkillScore{}, ...]
+
+  """
+  def list_historical_skill_scores(query \\ HistoricalSkillScore) do
+    query
+    |> Repo.all()
+  end
+
+  @doc """
+  Returns the list of historical_skill_scores from historical_skill_class_score
+  """
+  def list_historical_skill_scores_from_historical_skill_class_score(%{
+        historical_skill_class_id: historical_skill_class_id,
+        user_id: user_id
+      }) do
+    HistoricalSkillUnits.list_historical_skills_on_historical_skill_class(%{
+      id: historical_skill_class_id
+    })
+    |> Repo.preload(historical_skill_scores: HistoricalSkillScore.user_id_query(user_id))
+    |> Enum.flat_map(& &1.historical_skill_scores)
+  end
+
+  @doc """
+  Returns the list of historical_skill_scores from user and historical_skill_ids
+  """
+  def list_user_historical_skill_scores_from_historical_skill_ids(user, historical_skill_ids) do
+    HistoricalSkillScore.user_id_query(user.id)
+    |> HistoricalSkillScore.historical_skill_ids_query(historical_skill_ids)
+    |> list_historical_skill_scores()
+  end
+end

--- a/lib/bright/historical_skill_scores/historical_skill_score.ex
+++ b/lib/bright/historical_skill_scores/historical_skill_score.ex
@@ -4,6 +4,7 @@ defmodule Bright.HistoricalSkillScores.HistoricalSkillScore do
   """
 
   use Ecto.Schema
+  import Ecto.Query
 
   @primary_key {:id, Ecto.ULID, autogenerate: true}
   @foreign_key_type Ecto.ULID
@@ -18,5 +19,15 @@ defmodule Bright.HistoricalSkillScores.HistoricalSkillScore do
     belongs_to(:historical_skill, Bright.HistoricalSkillUnits.HistoricalSkill)
 
     timestamps()
+  end
+
+  def user_id_query(user_id) do
+    from q in __MODULE__,
+      where: q.user_id == ^user_id
+  end
+
+  def historical_skill_ids_query(query, historical_skill_ids) do
+    from q in query,
+      where: q.historical_skill_id in ^historical_skill_ids
   end
 end

--- a/lib/bright/historical_skill_units.ex
+++ b/lib/bright/historical_skill_units.ex
@@ -7,6 +7,7 @@ defmodule Bright.HistoricalSkillUnits do
   alias Bright.Repo
 
   alias Bright.HistoricalSkillUnits.HistoricalSkillUnit
+  alias Bright.HistoricalSkillUnits.HistoricalSkill
 
   @doc """
   Returns the list of historical_skill_units.
@@ -36,4 +37,25 @@ defmodule Bright.HistoricalSkillUnits do
 
   """
   def get_historical_skill_unit!(id), do: Repo.get!(HistoricalSkillUnit, id)
+
+  @doc """
+  Returns the list of historical_skills
+
+  ## Examples
+
+      iex> list_historical_skills()
+      [%HistoricalSkil{}, ...]
+
+  """
+  def list_historical_skills(query \\ HistoricalSkill) do
+    Repo.all(query)
+  end
+
+  @doc """
+  Gets historical_skills on historical_skill_class
+  """
+  def list_historical_skills_on_historical_skill_class(historical_skill_class) do
+    HistoricalSkill.historical_skill_class_query(historical_skill_class.id)
+    |> list_historical_skills()
+  end
 end

--- a/lib/bright/historical_skill_units/historical_skill.ex
+++ b/lib/bright/historical_skill_units/historical_skill.ex
@@ -4,6 +4,7 @@ defmodule Bright.HistoricalSkillUnits.HistoricalSkill do
   """
 
   use Ecto.Schema
+  import Ecto.Query
 
   alias Bright.HistoricalSkillUnits.HistoricalSkillCategory
 
@@ -20,5 +21,13 @@ defmodule Bright.HistoricalSkillUnits.HistoricalSkill do
     has_many :historical_skill_scores, Bright.HistoricalSkillScores.HistoricalSkillScore
 
     timestamps()
+  end
+
+  def historical_skill_class_query(query \\ __MODULE__, historical_skill_class_id) do
+    from q in query,
+      join: sc in assoc(q, :historical_skill_category),
+      join: su in assoc(sc, :historical_skill_unit),
+      join: scu in assoc(su, :historical_skill_class_units),
+      where: scu.historical_skill_class_id == ^historical_skill_class_id
   end
 end

--- a/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
@@ -1,6 +1,5 @@
 defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
   alias Bright.SkillPanels
-  alias Bright.SkillUnits
   alias Bright.SkillScores
   alias Bright.Accounts
 
@@ -141,22 +140,6 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
   end
 
   def create_skill_class_score_if_not_existing(socket), do: socket
-
-  def assign_skill_units(socket) do
-    skill_units =
-      Ecto.assoc(socket.assigns.skill_class, :skill_units)
-      |> SkillUnits.list_skill_units()
-      |> Bright.Repo.preload(skill_categories: [skills: [:skill_reference, :skill_exam]])
-
-    skills =
-      skill_units
-      |> Enum.flat_map(& &1.skill_categories)
-      |> Enum.flat_map(& &1.skills)
-
-    socket
-    |> assign(skill_units: skill_units)
-    |> assign(skills: skills)
-  end
 
   def assign_skill_score_dict(socket) do
     skill_score_dict =

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -281,6 +281,8 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
         <%= for {[col1, col2, col3], row} <- @table_structure |> Enum.with_index(1) do %>
           <% focus = @focus_row == row %>
           <% skill_score = @skill_score_dict[col3.skill.id] %>
+          <% current_skill = Map.get(@current_skill_dict, col3.skill.trace_id) %>
+          <% current_skill_score = Map.get(@current_skill_score_dict, Map.get(current_skill, :id)) %>
 
           <tr id={"skill-#{row}"} class="focus:bg-brightGray-100">
             <td :if={col1} rowspan={col1.size} class="align-top"><%= col1.skill_unit.name %></td>
@@ -291,10 +293,9 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
               <div class="flex justify-between items-center">
                 <p><%= col3.skill.name %></p>
                 <div class="flex justify-between items-center gap-x-2">
-                  <% # TODO: 過去参照時はこのcol3.skillは使えないので今後修正 %>
-                  <.skill_evidence_link skill_panel={@skill_panel} skill={col3.skill} skill_score={skill_score} query={@query} />
-                  <.skill_reference_link skill_panel={@skill_panel} skill={col3.skill} skill_score={skill_score} query={@query} />
-                  <.skill_exam_link skill_panel={@skill_panel} skill={col3.skill} skill_score={skill_score} query={@query} />
+                  <.skill_evidence_link skill_panel={@skill_panel} skill={current_skill} skill_score={current_skill_score} query={@query} />
+                  <.skill_reference_link skill_panel={@skill_panel} skill={current_skill} skill_score={current_skill_score} query={@query} />
+                  <.skill_exam_link skill_panel={@skill_panel} skill={current_skill} skill_score={current_skill_score} query={@query} />
                 </div>
               </div>
             </td>
@@ -302,7 +303,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
               <div class="num-high-users flex justify-center gap-x-1">
                 <div class="min-w-[3em] flex items-center">
                   <span class={[score_mark_class(:high, :gray), "inline-block mr-1"]}></span>
-                  <%= if skill_score.score == :high do %>
+                  <%= if Map.get(skill_score, :score) == :high do %>
                     <%= get_in(@compared_users_stats, [col3.skill.id, :high_skills_count]) + 1 %>
                   <% else %>
                     <%= get_in(@compared_users_stats, [col3.skill.id, :high_skills_count]) %>
@@ -310,7 +311,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
                 </div>
                 <div class="min-w-[3em] flex items-center">
                   <span class={[score_mark_class(:middle, :gray), "inline-block mr-1"]}></span>
-                  <%= if skill_score.score == :middle do %>
+                  <%= if Map.get(skill_score, :score) == :middle do %>
                     <%= get_in(@compared_users_stats, [col3.skill.id, :middle_skills_count]) + 1 %>
                   <% else %>
                     <%= get_in(@compared_users_stats, [col3.skill.id, :middle_skills_count]) %>
@@ -387,6 +388,8 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
     """
   end
 
+  def skill_evidence_link(%{skill_score: nil} = assigns), do: ~H""
+
   def skill_evidence_link(assigns) do
     ~H"""
     <.link class="link-evidence" patch={~p"/panels/#{@skill_panel}/skills/#{@skill}/evidences?#{@query}"}>
@@ -399,6 +402,8 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
     """
   end
 
+  def skill_reference_link(%{skill_score: nil} = assigns), do: ~H""
+
   def skill_reference_link(assigns) do
     ~H"""
     <.link :if={skill_reference_existing?(@skill.skill_reference)} class="link-reference" patch={~p"/panels/#{@skill_panel}/skills/#{@skill}/reference?#{@query}"}>
@@ -410,6 +415,8 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
     </.link>
     """
   end
+
+  def skill_exam_link(%{skill_score: nil} = assigns), do: ~H""
 
   def skill_exam_link(assigns) do
     ~H"""

--- a/lib/bright_web/live/skill_panel_live/skills_field_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_field_component.ex
@@ -7,10 +7,13 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
   use BrightWeb, :live_component
 
   import BrightWeb.SkillPanelLive.SkillsComponents
-  import BrightWeb.SkillPanelLive.SkillPanelHelper, only: [calc_percentage: 2]
+  import BrightWeb.SkillPanelLive.SkillPanelHelper, only: [calc_percentage: 2, assign_counter: 1]
 
   alias Bright.SkillUnits
   alias Bright.SkillScores
+  alias Bright.HistoricalSkillUnits
+  alias Bright.HistoricalSkillPanels
+  alias Bright.HistoricalSkillScores
   alias BrightWeb.SkillPanelLive.TimelineHelper
 
   def render(assigns) do
@@ -32,6 +35,8 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
          focus_user={@focus_user}
          editable={@editable}
          edit={@edit}
+         current_skill_dict={@current_skill_dict}
+         current_skill_score_dict={@current_skill_score_dict}
          myself={@myself}
       />
     </div>
@@ -41,6 +46,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
   def mount(socket) do
     {:ok,
      socket
+     |> assign(skill_class: nil)
      |> assign(compared_users: [], compared_user_dict: %{})
      |> assign(timeline: TimelineHelper.get_current())}
   end
@@ -48,11 +54,8 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
   def update(assigns, socket) do
     {:ok,
      socket
-     |> assign(assigns)
-     |> assign_skill_units()
-     |> assign_table_structure()
-     # 初期は「現在」
-     |> assign(:skill_score_dict, assigns.current_skill_score_dict)
+     |> assign_assigns_with_current_if_updated(assigns)
+     |> assign_on_timeline(TimelineHelper.get_selected_tense(socket.assigns.timeline))
      |> assign_compared_users_info()}
   end
 
@@ -74,7 +77,8 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
       {:noreply,
        socket
        |> update(:compared_users, &((&1 ++ [user]) |> Enum.uniq()))
-       |> assign_compared_user_dict(user)}
+       |> assign_compared_user_dict(user)
+       |> assign_compared_users_info()}
     else
       {:noreply, socket}
     end
@@ -84,7 +88,8 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
     {:noreply,
      socket
      |> update(:compared_users, fn users -> Enum.reject(users, &(&1.name == name)) end)
-     |> update(:compared_user_dict, &Map.delete(&1, name))}
+     |> update(:compared_user_dict, &Map.delete(&1, name))
+     |> assign_compared_users_info()}
   end
 
   def handle_event("timeline_bar_button_click", %{"date" => date}, socket) do
@@ -92,9 +97,11 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
       socket.assigns.timeline
       |> TimelineHelper.select_label(date)
 
-    # <= その他処理
-
-    {:noreply, socket |> assign(timeline: timeline)}
+    {:noreply,
+     socket
+     |> clear_for_timeline_changed()
+     |> assign(timeline: timeline)
+     |> assign_on_timeline(TimelineHelper.get_selected_tense(timeline))}
   end
 
   def handle_event("shift_timeline_past", _params, socket) do
@@ -113,7 +120,24 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
     {:noreply, socket |> assign(timeline: timeline)}
   end
 
-  def assign_skill_units(socket) do
+  defp assign_assigns_with_current_if_updated(socket, assigns) do
+    # 基本的には assigns をアサインするのみ
+    # ただし、表示上「現在」の情報を必要とするため、スキルクラスが更新されている場合には「現在」の情報を更新する
+    prev_skill_class = socket.assigns.skill_class
+    new_skill_class = assigns.skill_class
+
+    if prev_skill_class == new_skill_class do
+      socket
+      |> assign(assigns)
+    else
+      socket
+      |> assign(assigns)
+      |> assign_current_skill_units()
+      |> assign_current_skill_dict()
+    end
+  end
+
+  defp assign_current_skill_units(socket) do
     skill_units =
       Ecto.assoc(socket.assigns.skill_class, :skill_units)
       |> SkillUnits.list_skill_units()
@@ -125,8 +149,163 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
       |> Enum.flat_map(& &1.skills)
 
     socket
-    |> assign(skill_units: skill_units)
-    |> assign(skills: skills)
+    |> assign(current_skill_units: skill_units)
+    |> assign(current_skills: skills)
+  end
+
+  defp assign_current_skill_dict(socket) do
+    current_skill_dict =
+      socket.assigns.current_skills
+      |> Map.new(&{&1.trace_id, &1})
+
+    socket
+    |> assign(current_skill_dict: current_skill_dict)
+  end
+
+  defp assign_skill_units(socket, :past, label) do
+    focus_user = socket.assigns.focus_user
+
+    historical_skill_class =
+      HistoricalSkillPanels.get_historical_skill_class_on_date(
+        skill_panel_id: socket.assigns.skill_panel.id,
+        class: socket.assigns.skill_class.class,
+        date: TimelineHelper.label_to_date(label)
+      )
+      |> Bright.Repo.preload(
+        historical_skill_class_scores: Ecto.assoc(focus_user, :historical_skill_class_scores)
+      )
+
+    # 過去分のため存在しない可能性がある
+    if historical_skill_class do
+      skill_units =
+        Ecto.assoc(historical_skill_class, :historical_skill_units)
+        |> HistoricalSkillUnits.list_historical_skill_units()
+        |> Bright.Repo.preload(historical_skill_categories: [:historical_skills])
+
+      skills =
+        skill_units
+        |> Enum.flat_map(& &1.historical_skill_categories)
+        |> Enum.flat_map(& &1.historical_skills)
+
+      socket
+      |> assign(skill_units: skill_units)
+      |> assign(skills: skills)
+      |> assign(historical_skill_class: historical_skill_class)
+    else
+      socket
+      |> assign(skill_units: [])
+      |> assign(skills: [])
+      |> assign(historical_skill_class: nil)
+    end
+  end
+
+  defp clear_for_timeline_changed(socket) do
+    # スキル一覧で表示するための情報を初期化
+    socket
+    |> assign(skill_units: [])
+    |> assign(skills: [])
+    |> assign(skill_score_dict: %{})
+    |> assign(table_structure: [])
+    |> assign(counter: %{})
+    |> assign(num_skills: [])
+    |> assign(compared_users_stats: %{})
+    |> assign(compared_user_dict: %{})
+    |> assign(edit: false)
+    |> assign(editable: false)
+  end
+
+  defp assign_on_timeline(socket, :now) do
+    socket
+    |> assign(:tense, :now)
+    # 「現在」であればいまの情報で良い
+    |> assign(:skill_units, socket.assigns.current_skill_units)
+    |> assign(:skills, socket.assigns.current_skills)
+    |> assign(:skill_score_dict, socket.assigns.current_skill_score_dict)
+    |> assign_table_structure()
+    |> assign_counter()
+    |> assign_compared_user_dict_from_users()
+    |> assign_compared_users_info()
+    |> assign(:editable, true)
+  end
+
+  defp assign_on_timeline(socket, :future) do
+    # TODO: スキルアップ機能後に実装
+    socket
+    |> assign(:tense, :future)
+    |> assign_on_timeline(:now)
+    |> assign(editable: false)
+  end
+
+  defp assign_on_timeline(socket, :past) do
+    socket
+    |> assign(:tense, :past)
+    |> assign_skill_units(:past, socket.assigns.timeline.selected_label)
+    |> assign_table_structure()
+    |> assign_skill_score_dict(:past)
+    |> assign_counter()
+    |> assign_compared_user_dict_from_users()
+    |> assign_compared_users_info()
+    |> assign(:editable, false)
+  end
+
+  defp assign_skill_score_dict(%{assigns: %{historical_skill_class: nil}} = socket, _past) do
+    socket
+    |> assign(skill_class_score: nil)
+    |> assign(skill_score_dict: %{})
+  end
+
+  defp assign_skill_score_dict(socket, :past) do
+    skill_class_score =
+      socket.assigns.historical_skill_class.historical_skill_class_scores |> List.first()
+
+    skill_score_dict =
+      skill_class_score
+      |> HistoricalSkillScores.list_historical_skill_scores_from_historical_skill_class_score()
+      |> Map.new(&{&1.historical_skill_id, &1})
+
+    socket
+    |> assign(skill_class_score: skill_class_score)
+    |> assign(skill_score_dict: skill_score_dict)
+  end
+
+  defp assign_compared_user_dict_from_users(socket) do
+    socket.assigns.compared_users
+    |> Enum.reduce(socket, fn user, acc ->
+      acc
+      |> assign_compared_user_dict(user)
+    end)
+  end
+
+  defp assign_compared_user_dict(socket, user) do
+    # 比較対象になっているユーザーのデータを表示用に整理・集計してアサイン
+    skill_ids = Enum.map(socket.assigns.skills, & &1.id)
+    skill_scores = list_user_skill_scores_from_skill_ids(user, skill_ids, socket.assigns.tense)
+
+    {skill_score_dict, high_skills_count, middle_skills_count} =
+      skill_scores
+      |> Enum.reduce({%{}, 0, 0}, fn skill_score, {dict, high_c, middle_c} ->
+        score = skill_score.score
+
+        {
+          dict |> Map.put(skill_scores_skill_id(skill_score), score),
+          high_c + if(score == :high, do: 1, else: 0),
+          middle_c + if(score == :middle, do: 1, else: 0)
+        }
+      end)
+
+    size = Enum.count(skill_scores)
+    high_skills_percentage = calc_percentage(high_skills_count, size)
+    middle_skills_percentage = calc_percentage(middle_skills_count, size)
+
+    socket
+    |> update(
+      :compared_user_dict,
+      &Map.put(&1, user.name, %{
+        high_skills_percentage: high_skills_percentage,
+        middle_skills_percentage: middle_skills_percentage,
+        skill_score_dict: skill_score_dict
+      })
+    )
   end
 
   defp assign_compared_users_info(socket) do
@@ -148,38 +327,6 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
 
     socket
     |> assign(compared_users_stats: compared_users_stats)
-  end
-
-  defp assign_compared_user_dict(socket, user) do
-    # 比較対象になっているユーザーのデータを表示用に整理・集計してアサイン
-    skill_ids = Enum.map(socket.assigns.skills, & &1.id)
-    skill_scores = SkillScores.list_user_skill_scores_from_skill_ids(user, skill_ids)
-
-    {skill_score_dict, high_skills_count, middle_skills_count} =
-      skill_scores
-      |> Enum.reduce({%{}, 0, 0}, fn skill_score, {dict, high_c, middle_c} ->
-        score = skill_score.score
-
-        {
-          dict |> Map.put(skill_score.skill_id, score),
-          high_c + if(score == :high, do: 1, else: 0),
-          middle_c + if(score == :middle, do: 1, else: 0)
-        }
-      end)
-
-    size = Enum.count(skill_scores)
-    high_skills_percentage = calc_percentage(high_skills_count, size)
-    middle_skills_percentage = calc_percentage(middle_skills_count, size)
-
-    socket
-    |> update(
-      :compared_user_dict,
-      &Map.put(&1, user.name, %{
-        high_skills_percentage: high_skills_percentage,
-        middle_skills_percentage: middle_skills_percentage,
-        skill_score_dict: skill_score_dict
-      })
-    )
   end
 
   defp assign_table_structure(socket) do
@@ -206,7 +353,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
     skill_units
     |> Enum.flat_map(fn skill_unit ->
       skill_category_items =
-        skill_unit.skill_categories
+        list_skill_categories(skill_unit)
         |> Enum.flat_map(&build_skill_category_table_structure/1)
 
       build_skill_unit_table_structure(skill_unit, skill_category_items)
@@ -214,10 +361,11 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
   end
 
   defp build_skill_category_table_structure(skill_category) do
-    size = length(skill_category.skills)
+    skills = list_skills(skill_category)
+    size = length(skills)
     skill_category_item = %{size: size, skill_category: skill_category}
 
-    skill_category.skills
+    skills
     |> Enum.with_index()
     |> Enum.map(fn
       {skill, 0} -> [skill_category_item] ++ [%{skill: skill}]
@@ -241,5 +389,47 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
       {skill_category_item, 0} -> [skill_unit_item] ++ skill_category_item
       {skill_category_item, _i} -> [nil] ++ skill_category_item
     end)
+  end
+
+  defp list_skill_categories(%SkillUnits.SkillUnit{} = skill_unit) do
+    skill_unit.skill_categories
+  end
+
+  defp list_skill_categories(%HistoricalSkillUnits.HistoricalSkillUnit{} = skill_unit) do
+    skill_unit.historical_skill_categories
+  end
+
+  defp list_skills(%SkillUnits.SkillCategory{} = skill_category) do
+    skill_category.skills
+  end
+
+  defp list_skills(%HistoricalSkillUnits.HistoricalSkillCategory{} = skill_category) do
+    skill_category.historical_skills
+  end
+
+  defp list_user_skill_scores_from_skill_ids(user, skill_ids, :now) do
+    SkillScores.list_user_skill_scores_from_skill_ids(user, skill_ids)
+  end
+
+  defp list_user_skill_scores_from_skill_ids(user, skill_ids, :future) do
+    # TODO: スキルアップ対応後に実装。比較ユーザー分のスキルアップを加味する（大変そう）
+    SkillScores.list_user_skill_scores_from_skill_ids(user, skill_ids)
+  end
+
+  defp list_user_skill_scores_from_skill_ids(user, skill_ids, :past) do
+    HistoricalSkillScores.list_user_historical_skill_scores_from_historical_skill_ids(
+      user,
+      skill_ids
+    )
+  end
+
+  defp skill_scores_skill_id(%SkillScores.SkillScore{} = skill_score) do
+    skill_score.skill_id
+  end
+
+  defp skill_scores_skill_id(
+         %HistoricalSkillScores.HistoricalSkillScore{} = historical_skill_score
+       ) do
+    historical_skill_score.historical_skill_id
   end
 end

--- a/lib/bright_web/live/skill_panel_live/timeline_helper.ex
+++ b/lib/bright_web/live/skill_panel_live/timeline_helper.ex
@@ -70,6 +70,24 @@ defmodule BrightWeb.SkillPanelLive.TimelineHelper do
   end
 
   def get_monthly_interval, do: @monthly_interval
+
+  @doc """
+  現在選択されているものが「現在」「未来」「過去」のいずれかを返す
+  """
+  def get_selected_tense(timeline) do
+    {timeline.selected_label, timeline.future_enabled, List.last(timeline.labels)}
+    |> case do
+      {"now", _, _} -> :now
+      {selected_label, false, latest_label} when selected_label == latest_label -> :future
+      _ -> :past
+    end
+  end
+
+  def label_to_date(label) do
+    [year, month] = label |> String.split(".") |> Enum.map(&String.to_integer/1)
+    Date.new!(year, month, 1)
+  end
+
   defp get_future_month(), do: get_future_month(@start_month, Date.utc_today())
 
   defp get_future_month(start_month, now) do

--- a/test/bright/historical_skill_panels_test.exs
+++ b/test/bright/historical_skill_panels_test.exs
@@ -15,4 +15,97 @@ defmodule Bright.HistoricalSkillPanelsTest do
       assert HistoricalSkillPanels.get_skill_panel!(skill_panel.id) == skill_panel
     end
   end
+
+  describe "historical_skill_class" do
+    test "get_historical_skill_class_on_date returns a historical_skill_class on locked_date" do
+      skill_panel = insert(:historical_skill_panel)
+
+      historical_skill_class_month_7 =
+        insert(:historical_skill_class,
+          skill_panel: skill_panel,
+          class: 1,
+          locked_date: ~D[2023-07-01]
+        )
+
+      historical_skill_class_month_4 =
+        insert(:historical_skill_class,
+          skill_panel: skill_panel,
+          class: 1,
+          locked_date: ~D[2023-04-01]
+        )
+
+      historical_skill_class =
+        HistoricalSkillPanels.get_historical_skill_class_on_date(
+          skill_panel_id: skill_panel.id,
+          class: 1,
+          date: ~D[2023-10-01]
+        )
+
+      assert historical_skill_class.id == historical_skill_class_month_7.id
+
+      ret =
+        HistoricalSkillPanels.get_historical_skill_class_on_date(
+          skill_panel_id: skill_panel.id,
+          class: 1,
+          date: ~D[2023-07-01]
+        )
+
+      assert ret.id == historical_skill_class_month_4.id
+    end
+
+    test "get_historical_skill_class_on_date returns a historical_skill_class on skill_panel_id" do
+      skill_panel_1 = insert(:historical_skill_panel)
+      skill_panel_2 = insert(:historical_skill_panel)
+
+      _historical_skill_class_1 =
+        insert(:historical_skill_class,
+          skill_panel: skill_panel_1,
+          class: 1,
+          locked_date: ~D[2023-07-01]
+        )
+
+      historical_skill_class_2 =
+        insert(:historical_skill_class,
+          skill_panel: skill_panel_2,
+          class: 1,
+          locked_date: ~D[2023-07-01]
+        )
+
+      ret =
+        HistoricalSkillPanels.get_historical_skill_class_on_date(
+          skill_panel_id: skill_panel_2.id,
+          class: 1,
+          date: ~D[2023-10-01]
+        )
+
+      assert ret.id == historical_skill_class_2.id
+    end
+
+    test "get_historical_skill_class_on_date returns a historical_skill_class on class" do
+      skill_panel = insert(:historical_skill_panel)
+
+      _historical_skill_class_1 =
+        insert(:historical_skill_class,
+          skill_panel: skill_panel,
+          class: 1,
+          locked_date: ~D[2023-07-01]
+        )
+
+      historical_skill_class_2 =
+        insert(:historical_skill_class,
+          skill_panel: skill_panel,
+          class: 2,
+          locked_date: ~D[2023-07-01]
+        )
+
+      ret =
+        HistoricalSkillPanels.get_historical_skill_class_on_date(
+          skill_panel_id: skill_panel.id,
+          class: 2,
+          date: ~D[2023-10-01]
+        )
+
+      assert ret.id == historical_skill_class_2.id
+    end
+  end
 end

--- a/test/bright/historical_skill_scores_test.exs
+++ b/test/bright/historical_skill_scores_test.exs
@@ -1,0 +1,122 @@
+defmodule Bright.HistoricalSkillScoresTest do
+  use Bright.DataCase
+  import Bright.Factory
+
+  alias Bright.HistoricalSkillScores
+
+  @current_tl ~D[2023-10-01]
+  @back_tl_1 ~D[2023-07-01]
+
+  describe "historical_skill_scores" do
+    setup do
+      user = insert(:user)
+
+      historical_skill_class =
+        insert(:historical_skill_class,
+          skill_panel: build(:historical_skill_panel),
+          class: 1,
+          locked_date: @back_tl_1
+        )
+
+      historical_skill_unit = insert(:historical_skill_unit)
+
+      insert(:historical_skill_class_unit,
+        historical_skill_class_id: historical_skill_class.id,
+        historical_skill_unit_id: historical_skill_unit.id
+      )
+
+      historical_skill_category =
+        insert(:historical_skill_category,
+          historical_skill_unit: historical_skill_unit,
+          position: 1
+        )
+
+      historical_skill =
+        insert(:historical_skill,
+          historical_skill_category: historical_skill_category,
+          position: 1
+        )
+
+      %{
+        user: user,
+        historical_skill_class: historical_skill_class,
+        historical_skill_unit: historical_skill_unit,
+        historical_skill_category: historical_skill_category,
+        historical_skill: historical_skill
+      }
+    end
+
+    test "list_historical_skill_scores returns historical_skill_scores", %{
+      user: user,
+      historical_skill: historical_skill
+    } do
+      historical_skill_score =
+        insert(:historical_skill_score, user: user, historical_skill: historical_skill)
+
+      assert HistoricalSkillScores.list_historical_skill_scores()
+             |> Enum.map(& &1.id) == [historical_skill_score.id]
+    end
+
+    test "list_historical_skill_scores_from_historical_skill_class_score", %{
+      user: user,
+      historical_skill_class: historical_skill_class,
+      historical_skill: historical_skill
+    } do
+      # ダミーとして別ユーザー(user_2)データを作成
+      user_2 = insert(:user)
+
+      insert(:historical_skill_class_score,
+        user: user_2,
+        historical_skill_class: historical_skill_class,
+        locked_date: @current_tl
+      )
+
+      insert(:historical_skill_score, user: user_2, historical_skill: historical_skill)
+
+      historical_skill_class_score =
+        insert(:historical_skill_class_score,
+          user: user,
+          historical_skill_class: historical_skill_class,
+          locked_date: @current_tl
+        )
+
+      historical_skill_score =
+        insert(:historical_skill_score, user: user, historical_skill: historical_skill)
+
+      ret =
+        HistoricalSkillScores.list_historical_skill_scores_from_historical_skill_class_score(
+          historical_skill_class_score
+        )
+
+      assert ret |> Enum.map(& &1.id) == [historical_skill_score.id]
+    end
+
+    test "list_user_historical_skill_scores_from_historical_skill_ids", %{
+      user: user,
+      historical_skill_category: historical_skill_category,
+      historical_skill: historical_skill
+    } do
+      # ダミーとして別ユーザー(user_2)データを作成
+      user_2 = insert(:user)
+      insert(:historical_skill_score, user: user_2, historical_skill: historical_skill)
+      # ダミーとして別スキルデータを作成
+      historical_skill_2 =
+        insert(:historical_skill,
+          historical_skill_category: historical_skill_category,
+          position: 2
+        )
+
+      insert(:historical_skill_score, user: user, historical_skill: historical_skill_2)
+
+      historical_skill_score =
+        insert(:historical_skill_score, user: user, historical_skill: historical_skill)
+
+      ret =
+        HistoricalSkillScores.list_user_historical_skill_scores_from_historical_skill_ids(user, [
+          historical_skill.id
+        ])
+
+      assert ret |> Enum.map(& &1.id) == [historical_skill_score.id]
+    end
+  end
+end

--- a/test/bright/historical_skill_units_test.exs
+++ b/test/bright/historical_skill_units_test.exs
@@ -4,6 +4,9 @@ defmodule Bright.HistoricalSkillUnitsTest do
 
   alias Bright.HistoricalSkillUnits
 
+  # @current_tl ~D[2023-10-01]
+  @back_tl_1 ~D[2023-07-01]
+
   describe "historical_skill_units" do
     test "list_historical_skill_units/0 returns all historical_skill_units" do
       historical_skill_unit = insert(:historical_skill_unit)
@@ -15,6 +18,47 @@ defmodule Bright.HistoricalSkillUnitsTest do
 
       assert HistoricalSkillUnits.get_historical_skill_unit!(historical_skill_unit.id) ==
                historical_skill_unit
+    end
+  end
+
+  describe "historical_skills" do
+    test "list_historical_skills_on_historical_skill_class" do
+      # ダミーと合わせて２つのスキルクラスとスキルを用意
+      [{historical_skill_class, historical_skill}, _] =
+        insert_pair(:historical_skill_class,
+          skill_panel: build(:historical_skill_panel),
+          class: 1,
+          locked_date: @back_tl_1
+        )
+        |> Enum.map(fn historical_skill_class ->
+          historical_skill_unit = insert(:historical_skill_unit)
+
+          insert(:historical_skill_class_unit,
+            historical_skill_class_id: historical_skill_class.id,
+            historical_skill_unit_id: historical_skill_unit.id
+          )
+
+          historical_skill_category =
+            insert(:historical_skill_category,
+              historical_skill_unit: historical_skill_unit,
+              position: 1
+            )
+
+          historical_skill =
+            insert(:historical_skill,
+              historical_skill_category: historical_skill_category,
+              position: 1
+            )
+
+          {historical_skill_class, historical_skill}
+        end)
+
+      ret =
+        HistoricalSkillUnits.list_historical_skills_on_historical_skill_class(
+          historical_skill_class
+        )
+
+      assert ret |> Enum.map(& &1.id) == [historical_skill.id]
     end
   end
 end

--- a/test/factories/historical_skill_class_score_factory.ex
+++ b/test/factories/historical_skill_class_score_factory.ex
@@ -1,0 +1,20 @@
+defmodule Bright.HistoricalSkillClassScoreFactory do
+  @moduledoc """
+  Factory for Bright.HistoricalSkillScores.HistoricalSkillClassScore
+  """
+
+  alias Bright.HistoricalSkillScores.HistoricalSkillClassScore
+
+  defmacro __using__(_opts) do
+    quote do
+      def historical_skill_class_score_factory do
+        %HistoricalSkillClassScore{
+          user: build(:user),
+          historical_skill_class: build(:historical_skill_class),
+          level: Enum.random(Ecto.Enum.values(HistoricalSkillClassScore, :level)),
+          percentage: Enum.random(0..100)
+        }
+      end
+    end
+  end
+end

--- a/test/factories/historical_skill_class_unit_factory.ex
+++ b/test/factories/historical_skill_class_unit_factory.ex
@@ -1,0 +1,16 @@
+defmodule Bright.HistoricalSkillClassUnitFactory do
+  @moduledoc """
+  Factory for Bright.HistoricalSkillUnits.SkillClassUnit
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      def historical_skill_class_unit_factory do
+        %Bright.HistoricalSkillUnits.HistoricalSkillClassUnit{
+          trace_id: Ecto.ULID.generate(),
+          position: sequence(:position, & &1)
+        }
+      end
+    end
+  end
+end

--- a/test/factories/historical_skill_score_factory.ex
+++ b/test/factories/historical_skill_score_factory.ex
@@ -1,0 +1,22 @@
+defmodule Bright.HistoricalSkillScoreFactory do
+  @moduledoc """
+  Factory for Bright.HistoricalSkillScores.SkillScore
+  """
+
+  alias Bright.HistoricalSkillScores.HistoricalSkillScore
+
+  defmacro __using__(_opts) do
+    quote do
+      def historical_skill_score_factory do
+        %HistoricalSkillScore{
+          user: build(:user),
+          historical_skill: build(:historical_skill),
+          score: Enum.random(Ecto.Enum.values(HistoricalSkillScore, :score)),
+          exam_progress: Enum.random(Ecto.Enum.values(HistoricalSkillScore, :exam_progress)),
+          reference_read: Enum.random([false, true]),
+          evidence_filled: Enum.random([false, true])
+        }
+      end
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -73,6 +73,11 @@ defmodule Bright.Factory do
   use Bright.HistoricalSkillUnitFactory
   use Bright.HistoricalSkillCategoryFactory
   use Bright.HistoricalSkillFactory
+  use Bright.HistoricalSkillClassUnitFactory
+
+  # HistoricalSkillScores context
+  use Bright.HistoricalSkillScoreFactory
+  use Bright.HistoricalSkillClassScoreFactory
 
   # NotificationsFactory context
   use Bright.NotificationFactory


### PR DESCRIPTION
closes #622 

## 対応内容

タイムライン切り替え時の処理に対応しました。
過去データ作成処理が修正中のため、手元で作った仮データでいったん動作確認をしています。

未来分は「現在」表示にしています。
（スキルアップ機能がないため）

## 画面

![sample27](https://github.com/bright-org/bright/assets/121112529/5d4d022f-e05c-4073-8e19-d266c1697e93)

- 過去分のスキル並び順が変ですが、その辺りも過去データによるので本PR外です。
