### PR TITLE
スキルパネル display_userに対応

### DIFF
--- a/lib/bright_web/live/skill_panel_live/graph.ex
+++ b/lib/bright_web/live/skill_panel_live/graph.ex
@@ -3,13 +3,17 @@ defmodule BrightWeb.SkillPanelLive.Graph do
 
   import BrightWeb.SkillPanelLive.SkillPanelComponents
   import BrightWeb.SkillPanelLive.SkillPanelHelper
+  import BrightWeb.DisplayUserHelper
 
   @impl true
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
     {:ok,
      socket
+     |> assign_display_user(params)
+     |> assign_skill_panel(params["skill_panel_id"], "graphs")
      |> assign(:select_label, "now")
-     |> assign(:page_title, "スキルパネル")}
+     |> assign(:page_title, "スキルパネル")
+     |> assign_page_sub_title()}
   end
 
   @impl true
@@ -18,18 +22,16 @@ defmodule BrightWeb.SkillPanelLive.Graph do
     {:noreply,
      socket
      |> assign_path(url)
-     |> assign_focus_user(params["user_name"])
-     |> assign_skill_panel(params["skill_panel_id"])
      |> assign_skill_classes()
      |> assign_skill_class_and_score(params["class"])
      |> create_skill_class_score_if_not_existing()
      |> assign_skill_score_dict()
-     |> assign_counter()
-     |> assign_page_sub_title()}
+     |> assign_counter()}
   end
 
   @impl true
   # TODO: デモ用実装のため対象ユーザー実装後に削除
+  # TODO: 匿名に注意すること
   def handle_event("demo_change_user", _params, socket) do
     users =
       Bright.Accounts.User

--- a/lib/bright_web/live/skill_panel_live/graph.html.heex
+++ b/lib/bright_web/live/skill_panel_live/graph.html.heex
@@ -1,7 +1,7 @@
 <!-- feat: スキルパネル更新 861b28d9a8ec541ac03fe716ac0926b4e5575d5e　まで適用 -->
 <div :if={@skill_panel}>
   <!-- card -->
-  <.navigations current_user={@current_user} root="graphs" />
+  <.navigations current_user={@current_user} display_user={@display_user} root="graphs" />
   <div class="mx-10">
     <div class="flex justify-between">
       <% # TODO: α版後にifと仮divブロックを除去して表示 %>
@@ -10,7 +10,7 @@
       <.class_tab skill_classes={@skill_classes} skill_class={@skill_class} path={@path} query={@query} />
     </div>
     <div class="bg-white shadow pl-7 pr-5 relative z-2 pb-10">
-      <.profile_area focus_user={@focus_user} skill_class_score={@skill_class_score} counter={@counter} num_skills={@num_skills} />
+      <.profile_area display_user={@display_user} anonymous={@anonymous} skill_class_score={@skill_class_score} counter={@counter} num_skills={@num_skills} />
       <div class="flex">
         <.live_component
           id="rowth-graph"

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -33,7 +33,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
   def navigations(assigns) do
     ~H"""
     <div class="flex gap-x-4 px-10 pt-4 pb-3">
-      <.skill_panel_switch current_user={@current_user} root={@root}/>
+      <.skill_panel_switch display_user={@display_user} root={@root}/>
       <.target_switch current_user={@current_user} />
     </div>
     """
@@ -42,40 +42,41 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
   def skill_panel_switch(assigns) do
     ~H"""
     <p class="leading-tight">対象スキルの<br />切り替え</p>
-    <.skill_panel_menu current_user={@current_user} root={@root} />
+    <.skill_panel_menu id="skill_panel_menu" display_user={@display_user} root={@root} />
     <% # TODO: α版後にifを除去して表示 %>
     <.skill_set_menu :if={false} />
     """
   end
 
   def skill_panel_menu(assigns) do
+    # TODO: 使えるならばMegaMenuComponentsに差し替え
     ~H"""
-      <button
-        id="dropdownOffsetButton"
-        data-dropdown-toggle="dropdownOffset"
-        data-dropdown-offset-skidding="256"
-        data-dropdown-placement="bottom"
-        class="text-white bg-brightGreen-300 rounded pl-3 flex items-center font-bold h-[35px]"
-        type="button"
-      >
-        <span class="min-w-[6em]">スキルパネル</span>
-        <span class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-8px] before:bg-brightGray-50 before:w-[1px] before:h-[42px]">
-          expand_more
-        </span>
-      </button>
+    <button
+      id={"dropdownOffsetButton-#{@id}"}
+      data-dropdown-toggle={"dropdownOffset-#{@id}"}
+      data-dropdown-offset-skidding="256"
+      data-dropdown-placement="bottom"
+      class="text-white bg-brightGreen-300 rounded pl-3 flex items-center font-bold h-[35px]"
+      type="button"
+    >
+      <span class="min-w-[6em]">スキルパネル</span>
+      <span class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-8px] before:bg-brightGray-50 before:w-[1px] before:h-[42px]">
+        expand_more
+      </span>
+    </button>
 
-      <!-- スキルパネル menu -->
-      <div
-        id="dropdownOffset"
-        class="z-10 hidden bg-white rounded-sm shadow"
-      >
-        <.live_component
-          id="skill_card"
-          module={BrightWeb.CardLive.SkillCardComponent}
-          current_user={@current_user}
-          root={@root}
-        />
-      </div>
+    <!-- スキルパネル menu -->
+    <div
+      id={"dropdownOffset-#{@id}"}
+      class="z-10 hidden bg-white rounded-sm shadow"
+    >
+      <.live_component
+        id="skill_card"
+        module={BrightWeb.CardLive.SkillCardComponent}
+        current_user={@display_user}
+        root={@root}
+      />
+    </div>
     """
   end
 
@@ -222,7 +223,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
 
   def return_myself_button(assigns) do
     ~H"""
-    <button phx-click="clear_focus_user" class="text-brightGreen-300 border bg-white border-brightGreen-300 rounded px-3 font-bold">
+    <button phx-click="clear_display_user" class="text-brightGreen-300 border bg-white border-brightGreen-300 rounded px-3 font-bold">
       自分に戻す
     </button>
     """
@@ -288,19 +289,19 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
       <div class="flex justify-between">
         <div class="w-[850px] pt-6">
           <% # TODO: α版後にexcellent_person/anxious_personをtrueに変更して表示 %>
-          <% # TODO: 他者のときの.profileの仕様確認と対応が必要 %>
           <.profile
-            user_name={@focus_user.name}
-            title={@focus_user.user_profile.title}
-            icon_file_path={@focus_user.user_profile.icon_file_path}
+            user_name={@display_user.name}
+            title={@display_user.user_profile.title}
+            detail={@display_user.user_profile.detail}
+            icon_file_path={@display_user.user_profile.icon_file_path}
             display_excellent_person={false}
             display_anxious_person={false}
             display_return_to_yourself={true}
             display_sns={true}
-            twitter_url={@focus_user.user_profile.twitter_url}
-            github_url={@focus_user.user_profile.github_url}
-            facebook_url={@focus_user.user_profile.facebook_url}
-            display_detail={false}
+            twitter_url={@display_user.user_profile.twitter_url}
+            github_url={@display_user.user_profile.github_url}
+            facebook_url={@display_user.user_profile.facebook_url}
+            is_anonymous={@anonymous}
           />
         </div>
         <div class="mr-auto flex ml-7">

--- a/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
@@ -1,9 +1,11 @@
 defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
   alias Bright.SkillPanels
   alias Bright.SkillScores
-  alias Bright.Accounts
 
   import Phoenix.Component, only: [assign: 2, assign: 3]
+  import Phoenix.LiveView, only: [push_redirect: 2]
+
+  alias BrightWeb.DisplayUserHelper
 
   @counter %{
     low: 0,
@@ -28,51 +30,45 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
     |> assign(query: query)
   end
 
-  def assign_focus_user(socket, nil) do
-    socket
-    |> assign(focus_user: socket.assigns.current_user, me: true)
-  end
+  def assign_skill_panel(socket, nil, _root) do
+    display_user = socket.assigns.display_user
 
-  def assign_focus_user(socket, user_name) do
-    user =
-      Accounts.get_user_by_name(user_name)
-      |> Bright.Repo.preload(:user_profile)
-
-    # TODO: userを参照してよいかどうかアクセス制限が必要
-    # （マイページと同様のはずなので共通処理を使う）
-    # 現状は見つかったとしての実装
-
-    socket
-    |> assign(focus_user: user, me: false)
-  end
-
-  def assign_skill_panel(socket, nil) do
-    focus_user = socket.assigns.focus_user
-
-    skill_panel = SkillPanels.get_user_latest_skill_panel!(focus_user)
+    skill_panel = SkillPanels.get_user_latest_skill_panel!(display_user)
 
     socket
     |> assign(:skill_panel, skill_panel)
   end
 
-  def assign_skill_panel(socket, skill_panel_id) do
-    focus_user = socket.assigns.focus_user
+  def assign_skill_panel(socket, skill_panel_id, root) do
+    display_user = socket.assigns.display_user
 
-    skill_panel =
-      SkillPanels.get_user_skill_panel(focus_user, skill_panel_id) ||
-        SkillPanels.get_user_latest_skill_panel!(focus_user)
+    skill_panel = SkillPanels.get_user_skill_panel(display_user, skill_panel_id)
 
-    socket
-    |> assign(:skill_panel, skill_panel)
+    if skill_panel do
+      socket
+      |> assign(:skill_panel, skill_panel)
+    else
+      # 指定されているスキルパネルがない場合は、
+      # 直近のスキルパネルを取得して、
+      # URLと矛盾した表示にならないようにリダイレクト
+      skill_panel = SkillPanels.get_user_latest_skill_panel!(display_user)
+
+      path =
+        build_path(root, skill_panel, display_user, socket.assigns.me, socket.assigns.anonymous)
+
+      socket
+      |> assign(:skill_panel, nil)
+      |> push_redirect(to: path)
+    end
   end
 
   def assign_skill_classes(socket) do
-    focus_user = socket.assigns.focus_user
+    display_user = socket.assigns.display_user
 
     skill_classes =
       Ecto.assoc(socket.assigns.skill_panel, :skill_classes)
       |> SkillPanels.list_skill_classes()
-      |> Bright.Repo.preload(skill_class_scores: Ecto.assoc(focus_user, :skill_class_scores))
+      |> Bright.Repo.preload(skill_class_scores: Ecto.assoc(display_user, :skill_class_scores))
 
     socket
     |> assign(:skill_classes, skill_classes)
@@ -171,6 +167,10 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
     end)
   end
 
+  def assign_page_sub_title(%{assigns: %{skill_panel: nil}} = socket) do
+    socket
+  end
+
   def assign_page_sub_title(socket) do
     socket
     |> assign(:page_sub_title, socket.assigns.skill_panel.name)
@@ -182,5 +182,21 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
     (count / num_skills)
     |> Kernel.*(100)
     |> floor()
+  end
+
+  defp build_path(root, skill_panel, _display_user, true, _anonymous) do
+    # 自ユーザー
+    "/#{root}/#{skill_panel.id}"
+  end
+
+  defp build_path(root, skill_panel, display_user, _me, true) do
+    # 対象ユーザーかつ匿名
+    encrypted = DisplayUserHelper.encrypt_user_name(display_user)
+    "/#{root}/#{skill_panel.id}/anon/#{encrypted}"
+  end
+
+  defp build_path(root, skill_panel, display_user, _me, false) do
+    # 対象ユーザーかつ匿名ではない
+    "/#{root}/#{skill_panel.id}/#{display_user.name}"
   end
 end

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -4,6 +4,7 @@ defmodule BrightWeb.SkillPanelLive.Skills do
   import BrightWeb.BrightModalComponents
   import BrightWeb.SkillPanelLive.SkillPanelComponents
   import BrightWeb.SkillPanelLive.SkillPanelHelper
+  import BrightWeb.DisplayUserHelper
 
   alias Bright.SkillUnits
   alias Bright.SkillScores
@@ -19,10 +20,13 @@ defmodule BrightWeb.SkillPanelLive.Skills do
   }
 
   @impl true
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
     {:ok,
      socket
+     |> assign_display_user(params)
+     |> assign_skill_panel(params["skill_panel_id"], "panels")
      |> assign(:page_title, "スキルパネル")
+     |> assign_page_sub_title()
      |> assign_edit_off()}
   end
 
@@ -32,20 +36,17 @@ defmodule BrightWeb.SkillPanelLive.Skills do
     {:noreply,
      socket
      |> assign_path(url)
-     |> assign_focus_user(params["user_name"])
-     |> assign_skill_panel(params["skill_panel_id"])
      |> assign_skill_classes()
      |> assign_skill_class_and_score(params["class"])
      |> create_skill_class_score_if_not_existing()
      |> assign_skill_score_dict()
      |> assign_counter()
-     |> assign_page_sub_title()
      |> apply_action(socket.assigns.live_action, params)}
   end
 
   @impl true
   def handle_event("edit", _params, socket) do
-    skill_class_score_author?(socket.assigns.skill_class_score, socket.assigns.current_user)
+    socket.assigns.me
     |> if do
       {:noreply, socket |> assign_edit_on()}
     else
@@ -114,6 +115,7 @@ defmodule BrightWeb.SkillPanelLive.Skills do
   end
 
   # TODO: デモ用実装のため対象ユーザー実装後に削除
+  # TODO: 匿名に注意すること
   def handle_event("demo_change_user", _params, socket) do
     users =
       Bright.Accounts.User
@@ -274,8 +276,4 @@ defmodule BrightWeb.SkillPanelLive.Skills do
   end
 
   defp create_skill_evidence_if_not_existing(socket), do: socket
-
-  defp skill_class_score_author?(skill_class_score, user) do
-    skill_class_score.user_id == user.id
-  end
 end

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -1,5 +1,5 @@
 <!-- card -->
-<.navigations current_user={@current_user} root="panels" />
+<.navigations current_user={@current_user} display_user={@display_user} root="panels" />
 <div class="mx-10">
   <div class="flex justify-between">
     <% # TODO: α版後にifと仮divブロックを除去して表示 %>
@@ -8,7 +8,7 @@
     <.class_tab skill_classes={@skill_classes} skill_class={@skill_class} path={@path} query={@query} />
   </div>
   <div class="bg-white shadow pl-7 pr-5 relative z-2 pb-10">
-    <.profile_area focus_user={@focus_user} skill_class_score={@skill_class_score} counter={@counter} num_skills={@num_skills} />
+    <.profile_area display_user={@display_user} anonymous={@anonymous} skill_class_score={@skill_class_score} counter={@counter} num_skills={@num_skills} />
     <.live_component
       id="skills-field"
       module={BrightWeb.SkillPanelLive.SkillsFieldComponent}
@@ -21,8 +21,9 @@
       focus_row={@focus_row}
       path={@path}
       query={@query}
-      focus_user={@focus_user}
-      editable={skill_class_score_author?(@skill_class_score, @current_user)}
+      display_user={@display_user}
+      me={@me}
+      anonymous={@anonymous}
       edit={@edit}
     />
   </div>

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -203,7 +203,9 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
           </td>
           <td class="!border-l !border-brightGray-200">
             <div class="flex justify-center items-center min-w-[150px]">
-              <p class="inline-flex flex-1 justify-center"><%= @focus_user.name %></p>
+              <p class="inline-flex flex-1 justify-center">
+                <%= if(@anonymous, do: "非表示", else: @display_user.name) %>
+              </p>
 
               <%= if @editable do %>
                 <button
@@ -294,8 +296,8 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
                 <p><%= col3.skill.name %></p>
                 <div class="flex justify-between items-center gap-x-2">
                   <.skill_evidence_link skill_panel={@skill_panel} skill={current_skill} skill_score={current_skill_score} query={@query} />
-                  <.skill_reference_link skill_panel={@skill_panel} skill={current_skill} skill_score={current_skill_score} query={@query} />
-                  <.skill_exam_link skill_panel={@skill_panel} skill={current_skill} skill_score={current_skill_score} query={@query} />
+                  <.skill_reference_link :if={@me} skill_panel={@skill_panel} skill={current_skill} skill_score={current_skill_score} query={@query} />
+                  <.skill_exam_link :if={@me} skill_panel={@skill_panel} skill={current_skill} skill_score={current_skill_score} query={@query} />
                 </div>
               </div>
             </td>

--- a/lib/bright_web/live/skill_panel_live/skills_field_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_field_component.ex
@@ -32,12 +32,14 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
          compared_user_dict={@compared_user_dict}
          path={@path}
          query={@query}
-         focus_user={@focus_user}
+         display_user={@display_user}
          editable={@editable}
          edit={@edit}
          current_skill_dict={@current_skill_dict}
          current_skill_score_dict={@current_skill_score_dict}
          myself={@myself}
+         me={@me}
+         anonymous={@anonymous}
       />
     </div>
     """
@@ -65,7 +67,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
       Bright.Accounts.User
       |> Bright.Repo.all()
       |> Enum.reject(fn user ->
-        user.id == socket.assigns.focus_user.id ||
+        user.id == socket.assigns.display_user.id ||
           Ecto.assoc(user, :user_skill_panels)
           |> Bright.Repo.all()
           |> Enum.empty?()
@@ -163,7 +165,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
   end
 
   defp assign_skill_units(socket, :past, label) do
-    focus_user = socket.assigns.focus_user
+    display_user = socket.assigns.display_user
 
     historical_skill_class =
       HistoricalSkillPanels.get_historical_skill_class_on_date(
@@ -172,7 +174,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
         date: TimelineHelper.label_to_date(label)
       )
       |> Bright.Repo.preload(
-        historical_skill_class_scores: Ecto.assoc(focus_user, :historical_skill_class_scores)
+        historical_skill_class_scores: Ecto.assoc(display_user, :historical_skill_class_scores)
       )
 
     # 過去分のため存在しない可能性がある
@@ -225,7 +227,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
     |> assign_counter()
     |> assign_compared_user_dict_from_users()
     |> assign_compared_users_info()
-    |> assign(:editable, true)
+    |> assign(:editable, socket.assigns.me)
   end
 
   defp assign_on_timeline(socket, :future) do


### PR DESCRIPTION
refs: #549 

## 対応内容

対象ユーザーを設定したときの処理群が `BrightWeb.DisplayUserHelper` として入ったので、
そちらでアサインされている変数を使うように対応しました。

（`focus_user`という名前で仮入れしていたのを、`display_user`にするなど）