### PR TITLE
【保有スキルカード】クラスが３つ以下でも出力に対応する

### DIFF
--- a/lib/bright_web/live/card_live/skill_card_component.ex
+++ b/lib/bright_web/live/card_live/skill_card_component.ex
@@ -44,13 +44,7 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
 
   defp skill_panel(assigns) do
     skill_classes = assigns.skill_panel.skill_classes
-
-    dummy =
-      %Bright.SkillPanels.SkillClass{}
-      |> Map.put(:skill_class_scores, [nil])
-
-    dummy_count = 3 - Enum.count(skill_classes)
-    dummy_classes = List.duplicate(dummy, dummy_count)
+    dummy_classes = cleate_dummy_classes(skill_classes)
 
     assigns =
       assigns
@@ -74,6 +68,15 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
       <% end %>
     </div>
     """
+  end
+
+  defp cleate_dummy_classes(skill_classes) do
+    dummy =
+      %Bright.SkillPanels.SkillClass{}
+      |> Map.put(:skill_class_scores, [nil])
+
+    dummy_count = 3 - Enum.count(skill_classes)
+    List.duplicate(dummy, dummy_count)
   end
 
   defp skill_gem(%{score: nil} = assigns) do


### PR DESCRIPTION
【結合】テスト障害表（【結合試験】3.成長グラフ①／③～⑤／⑧／⑩～⑬）
err-8対応

対応前
クラスが一つしかない場合は本来はクラス１の位置にいないとおかしい
![image](https://github.com/bright-org/bright/assets/13599847/dbd579c6-ea07-44aa-bf02-a5aad692d83c)

対応後
![image](https://github.com/bright-org/bright/assets/13599847/1da660e0-d2b9-480b-9b7d-474b58060745)

![image](https://github.com/bright-org/bright/assets/13599847/a359b655-340e-4484-ad4e-15ae6d151b75)

![image](https://github.com/bright-org/bright/assets/13599847/254ac83e-edd8-45dd-8115-0a6a662fea32)



close　#679