### PR TITLE
α版表示対応：重要な連絡を「運営」のみ表示にする

### DIFF
--- a/lib/bright_web/live/card_live/contact_card_component.ex
+++ b/lib/bright_web/live/card_live/contact_card_component.ex
@@ -10,13 +10,13 @@ defmodule BrightWeb.CardLive.ContactCardComponent do
   alias Bright.Notifications
 
   @tabs [
-    {"team_invitation", "チーム招待"}
     # TODO α版では実装しない
+    # {"team_invitation", "チーム招待"},
     # {"daily", "デイリー"},
     # {"weekly", "ウイークリー"},
     # {"recruitment_coordination", "採用の調整"},
     # {"skill_panel_update", "スキルパネル更新"},
-    # {"operation", "運営"}
+    {"operation", "運営"}
   ]
 
   @impl true
@@ -55,7 +55,7 @@ defmodule BrightWeb.CardLive.ContactCardComponent do
      socket
      |> assign(assigns)
      |> assign(:tabs, @tabs)
-     |> assign(:card, create_card_param("team_invitation"))
+     |> assign(:card, create_card_param("operation"))
      |> assign_card()}
   end
 

--- a/test/bright_web/live/mypage_live_test.exs
+++ b/test/bright_web/live/mypage_live_test.exs
@@ -37,7 +37,7 @@ defmodule BrightWeb.MypageLiveTest do
 
       # 各カードがあることを確認（コンポーネントが貼られていることのみを確認）
       assert index_live |> has_element?("h5", "重要な連絡")
-      assert index_live |> has_element?("li a", "チーム招待")
+      assert index_live |> has_element?("li a", "運営")
 
       # αリリース対象外
       # assert index_live |> has_element?("h5", "保有スキル（ジェムをクリックすると成長グラフが見れます）")


### PR DESCRIPTION
タイトル通り