### PR TITLE
メガメニューのボタン名を「スキルパネル」→「スキル」に変更

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -59,7 +59,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
       class="text-white bg-brightGreen-300 rounded pl-3 flex items-center font-bold h-[35px]"
       type="button"
     >
-      <span class="min-w-[6em]">スキルパネル</span>
+      <span class="min-w-[6em]">スキル</span>
       <span class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-8px] before:bg-brightGray-50 before:w-[1px] before:h-[42px]">
         expand_more
       </span>


### PR DESCRIPTION
![image](https://github.com/bright-org/bright/assets/13599847/d9fb160a-383d-45c7-b49e-9d815447881a)
