### PR TITLE
保有スキル 対象ユーザー切り替え時の遷移に対応

### DIFF
--- a/lib/bright_web/live/card_live/skill_card_component.ex
+++ b/lib/bright_web/live/card_live/skill_card_component.ex
@@ -6,6 +6,7 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
   use BrightWeb, :live_component
   import BrightWeb.TabComponents
   alias Bright.{CareerFields, SkillPanels}
+  alias BrightWeb.PathHelper
 
   @impl true
   def render(assigns) do
@@ -34,7 +35,13 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
             <div class="w-36 font-bold">クラス3</div>
           </div>
           <%= for skill_panel <- @skill_panels do %>
-            <.skill_panel skill_panel={skill_panel} root={@root} />
+            <.skill_panel
+              skill_panel={skill_panel}
+              display_user={@display_user}
+              me={@me}
+              anonymous={@anonymous}
+              root={@root}
+            />
           <% end %>
         </div>
       </.tab>
@@ -53,8 +60,7 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
     ~H"""
     <div class="flex">
       <div class="flex-1 text-left font-bold">
-        <% # TODO: 対象ユーザーが指定されている場合jの対応 %>
-        <.link href={"/#{@root}/#{@skill_panel.id}"} >
+        <.link href={PathHelper.skill_panel_path(@root, @skill_panel, @display_user, @me, @anonymous)}>
           <%= @skill_panel.name %>
         </.link>
       </div>
@@ -62,7 +68,10 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
         <.skill_gem
           score={List.first(class.skill_class_scores)}
           class_num={class.class}
-          skill_panel_id={@skill_panel.id}
+          skill_panel={@skill_panel}
+          display_user={@display_user}
+          me={@me}
+          anonymous={@anonymous}
           root={@root}
         />
       <% end %>
@@ -93,7 +102,7 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
 
     ~H"""
     <div class="w-36">
-      <.link href={"/#{@root}/#{@skill_panel_id}?class=#{@class_num}"}>
+      <.link href={PathHelper.skill_panel_path(@root, @skill_panel, @display_user, @me, @anonymous) <> "?class=#{@class_num}"}>
         <p class="hover:bg-brightGray-50 hover:cursor-pointer inline-flex items-end p-1">
           <img src={@icon_path} class="mr-1" />
           <span class="w-16"><%= level_text(@level) %></span>
@@ -104,7 +113,7 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
   end
 
   @impl true
-  def update(%{current_user: user} = assigns, socket) do
+  def update(%{display_user: user} = assigns, socket) do
     tabs =
       CareerFields.list_career_fields()
       |> Enum.map(&{&1.name_en, &1.name_ja})
@@ -131,7 +140,7 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
   def handle_event(
         "tab_click",
         %{"tab_name" => tab_name},
-        %{assigns: %{current_user: user}} = socket
+        %{assigns: %{display_user: user}} = socket
       ) do
     socket
     |> assign(:selected_tab, tab_name)
@@ -142,7 +151,7 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
   def handle_event(
         "previous_button_click",
         _params,
-        %{assigns: %{page: page, selected_tab: tab_name, current_user: user}} = socket
+        %{assigns: %{page: page, selected_tab: tab_name, display_user: user}} = socket
       ) do
     page = if page - 1 < 1, do: 1, else: page - 1
 
@@ -159,7 +168,7 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
             page: page,
             total_pages: total_pages,
             selected_tab: tab_name,
-            current_user: user
+            display_user: user
           }
         } = socket
       ) do

--- a/lib/bright_web/live/display_user_helper.ex
+++ b/lib/bright_web/live/display_user_helper.ex
@@ -21,15 +21,16 @@ defmodule BrightWeb.DisplayUserHelper do
     |> assign(:display_user, user)
   end
 
-  def assign_display_user(socket, %{"user_name_crypted" => user_name_crypted}) do
+  def assign_display_user(socket, %{"user_name_encrypted" => user_name_encrypted}) do
     user =
-      decrypt_user_name(user_name_crypted)
+      decrypt_user_name(user_name_encrypted)
       |> Accounts.get_user_by_name!()
 
     display_user =
       %User{}
       |> Map.put(:user_profile, %Bright.UserProfiles.UserProfile{})
       |> Map.put(:id, user.id)
+      |> Map.put(:name_encrypted, user_name_encrypted)
 
     socket
     |> assign(:me, false)

--- a/lib/bright_web/live/mypage_live/index.html.heex
+++ b/lib/bright_web/live/mypage_live/index.html.heex
@@ -48,7 +48,9 @@
       <.live_component
         id="skill_card"
         module={BrightWeb.CardLive.SkillCardComponent}
-        current_user={@display_user}
+        display_user={@display_user}
+        me={@me}
+        anonymous={@anonymous}
         root="graphs"
       />
     </div>

--- a/lib/bright_web/live/path_helper.ex
+++ b/lib/bright_web/live/path_helper.ex
@@ -1,0 +1,25 @@
+defmodule BrightWeb.PathHelper do
+  @moduledoc """
+  URL構築用の補助モジュール
+  """
+
+  @doc """
+  指定条件で /graphs, /panels へ遷移するURLを返す
+  """
+  def skill_panel_path(root, skill_panel, display_user, me, anonymous)
+
+  def skill_panel_path(root, skill_panel, _display_user, true, _anonymous) do
+    # 自ユーザー
+    "/#{root}/#{skill_panel.id}"
+  end
+
+  def skill_panel_path(root, skill_panel, display_user, _me, false) do
+    # 対象ユーザーかつ匿名ではない
+    "/#{root}/#{skill_panel.id}/#{display_user.name}"
+  end
+
+  def skill_panel_path(root, skill_panel, display_user, _me, true) do
+    # 対象ユーザーかつ匿名
+    "/#{root}/#{skill_panel.id}/anon/#{display_user.name_encrypted}"
+  end
+end

--- a/lib/bright_web/live/skill_panel_live/graph.html.heex
+++ b/lib/bright_web/live/skill_panel_live/graph.html.heex
@@ -1,44 +1,49 @@
 <!-- feat: スキルパネル更新 861b28d9a8ec541ac03fe716ac0926b4e5575d5e　まで適用 -->
-<div :if={@skill_panel}>
-  <!-- card -->
-  <.navigations current_user={@current_user} display_user={@display_user} root="graphs" />
-  <div class="mx-10">
-    <div class="flex justify-between">
-      <% # TODO: α版後にifと仮divブロックを除去して表示 %>
-      <.toggle_link :if={false} skill_panel={@skill_panel} active="graph" />
-      <div> </div>
-      <.class_tab skill_classes={@skill_classes} skill_class={@skill_class} path={@path} query={@query} />
-    </div>
-    <div class="bg-white shadow pl-7 pr-5 relative z-2 pb-10">
-      <.profile_area display_user={@display_user} anonymous={@anonymous} skill_class_score={@skill_class_score} counter={@counter} num_skills={@num_skills} />
-      <div class="flex">
+
+<.navigations
+  current_user={@current_user}
+  display_user={@display_user}
+  me={@me}
+  anonymous={@anonymous}
+  root="graphs"
+/>
+
+<div class="mx-10">
+  <div class="flex justify-between">
+    <% # TODO: α版後にifと仮divブロックを除去して表示 %>
+    <.toggle_link :if={false} skill_panel={@skill_panel} active="graph" />
+    <div> </div>
+    <.class_tab skill_classes={@skill_classes} skill_class={@skill_class} path={@path} query={@query} />
+  </div>
+  <div class="bg-white shadow pl-7 pr-5 relative z-2 pb-10">
+    <.profile_area display_user={@display_user} anonymous={@anonymous} skill_class_score={@skill_class_score} counter={@counter} num_skills={@num_skills} />
+    <div class="flex">
+      <.live_component
+        id="rowth-graph"
+        module={BrightWeb.ChartLive.GrowthGraphComponent}
+        user_id={@current_user.id}
+        skill_panel_id={@skill_panel.id}
+        class={@skill_class.class}
+      />
+      <div class="w-[700px] pl-28">
         <.live_component
-          id="rowth-graph"
-          module={BrightWeb.ChartLive.GrowthGraphComponent}
+          id="skill-gem"
+          module={BrightWeb.ChartLive.SkillGemComponent}
           user_id={@current_user.id}
           skill_panel_id={@skill_panel.id}
           class={@skill_class.class}
+          select_label={@select_label}
         />
-        <div class="w-[700px] pl-28">
-          <.live_component
-            id="skill-gem"
-            module={BrightWeb.ChartLive.SkillGemComponent}
-            user_id={@current_user.id}
-            skill_panel_id={@skill_panel.id}
-            class={@skill_class.class}
-            select_label={@select_label}
-          />
-          <% # TODO: α版後に:if={false}を除去して表示 %>
-          <div :if={false} class="flex justify-center">
-            <p>
-              あと<span class="text-error !text-2xl font-bold">8</span>%でベテランになれます。
-            </p>
-            <p>
-              次のレベルまでのスキル数<span
-                class="text-error !text-2xl font-bold"
-                >10</span>個
-            </p>
-          </div>
+        <% # TODO: α版後に:if={false}を除去して表示 %>
+        <div :if={false} class="flex justify-center">
+          <p>
+            あと<span class="text-error !text-2xl font-bold">8</span>%でベテランになれます。
+          </p>
+          <p>
+            次のレベルまでのスキル数<span
+              class="text-error !text-2xl font-bold"
+              >10</span>個
+          </p>
         </div>
       </div>
     </div>

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -33,7 +33,12 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
   def navigations(assigns) do
     ~H"""
     <div class="flex gap-x-4 px-10 pt-4 pb-3">
-      <.skill_panel_switch display_user={@display_user} root={@root}/>
+      <.skill_panel_switch
+        display_user={@display_user}
+        me={@me}
+        anonymous={@anonymous}
+        root={@root}
+      />
       <.target_switch current_user={@current_user} />
     </div>
     """
@@ -42,7 +47,13 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
   def skill_panel_switch(assigns) do
     ~H"""
     <p class="leading-tight">対象スキルの<br />切り替え</p>
-    <.skill_panel_menu id="skill_panel_menu" display_user={@display_user} root={@root} />
+    <.skill_panel_menu
+      id="skill_panel_menu"
+      display_user={@display_user}
+      me={@me}
+      anonymous={@anonymous}
+      root={@root}
+    />
     <% # TODO: α版後にifを除去して表示 %>
     <.skill_set_menu :if={false} />
     """
@@ -73,7 +84,9 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
       <.live_component
         id="skill_card"
         module={BrightWeb.CardLive.SkillCardComponent}
-        current_user={@display_user}
+        display_user={@display_user}
+        me={@me}
+        anonymous={@anonymous}
         root={@root}
       />
     </div>

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -12,6 +12,7 @@ defmodule BrightWeb.SkillPanelLive.Skills do
   alias Bright.SkillReferences
   alias Bright.SkillExams
   alias Bright.UserSkillPanels
+  alias BrightWeb.PathHelper
 
   @shortcut_key_score %{
     "1" => :high,

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -1,5 +1,11 @@
-<!-- card -->
-<.navigations current_user={@current_user} display_user={@display_user} root="panels" />
+<.navigations
+  current_user={@current_user}
+  display_user={@display_user}
+  me={@me}
+  anonymous={@anonymous}
+  root="panels"
+/>
+
 <div class="mx-10">
   <div class="flex justify-between">
     <% # TODO: α版後にifと仮divブロックを除去して表示 %>
@@ -34,7 +40,7 @@
   id="skill-evidence-modal"
   show
   style_of_modal_flame_out="w-full max-w-3xl p-4 sm:p-6 lg:py-8"
-  on_cancel={JS.patch(build_path("panels", @skill_panel, @display_user, @me, @anonymous) <> "?class=#{@skill_class.class}")}>
+  on_cancel={JS.patch(PathHelper.skill_panel_path("panels", @skill_panel, @display_user, @me, @anonymous) <> "?class=#{@skill_class.class}")}>
 
   <.live_component
     module={BrightWeb.SkillPanelLive.SkillEvidenceComponent}
@@ -42,7 +48,7 @@
     skill={@skill}
     skill_evidence={@skill_evidence}
     user={@current_user}
-    patch={build_path("panels", @skill_panel, @display_user, @me, @anonymous) <> "?class=#{@skill_class.class}"}
+    patch={PathHelper.skill_panel_path("panels", @skill_panel, @display_user, @me, @anonymous) <> "?class=#{@skill_class.class}"}
   />
 </.bright_modal>
 

--- a/lib/bright_web/router.ex
+++ b/lib/bright_web/router.ex
@@ -166,17 +166,17 @@ defmodule BrightWeb.Router do
       live "/skill_up/jobs/:job_id", OnboardingLive.SkillPanels
       live "/skill_up/jobs/:job_id/skill_panels/:id", OnboardingLive.SkillPanel
       live "/mypage/:user_name", MypageLive.Index, :index
-      live "/mypage/anon/:user_name_crypted", MypageLive.Index, :index
+      live "/mypage/anon/:user_name_encrypted", MypageLive.Index, :index
 
       live "/graphs", SkillPanelLive.Graph, :show
       live "/graphs/:skill_panel_id", SkillPanelLive.Graph, :show
       live "/graphs/:skill_panel_id/:user_name", SkillPanelLive.Graph, :show
-      live "/graphs/:skill_panel_id/anon/:user_name_crypted", SkillPanelLive.Graph, :show
+      live "/graphs/:skill_panel_id/anon/:user_name_encrypted", SkillPanelLive.Graph, :show
 
       live "/panels", SkillPanelLive.Skills, :show
       live "/panels/:skill_panel_id", SkillPanelLive.Skills, :show
       live "/panels/:skill_panel_id/:user_name", SkillPanelLive.Skills, :show
-      live "/panels/:skill_panel_id/anon/:user_name_crypted", SkillPanelLive.Skills, :show
+      live "/panels/:skill_panel_id/anon/:user_name_encrypted", SkillPanelLive.Skills, :show
 
       live "/panels/:skill_panel_id/skills/:skill_id/evidences",
            SkillPanelLive.Skills,


### PR DESCRIPTION
closes #42

## 対応内容

保有スキルのリンク修正です。
対象ユーザー指定時に、リンク先でも対象ユーザーが選択された状態のままになるように対応しました。

## 参考画面

![sample28](https://github.com/bright-org/bright/assets/121112529/8097dfea-e4d7-42b5-a707-b73dabd53ff7)

- マイページでの匿名 => 成長パネルでの匿名
