### PR TITLE
スキルパネル 対象者 切り替えメニュー対応

### DIFF
--- a/lib/bright_web/components/profile_components.ex
+++ b/lib/bright_web/components/profile_components.ex
@@ -96,20 +96,47 @@ defmodule BrightWeb.ProfileComponents do
   """
   attr :user_name, :string, default: ""
   attr :title, :string, default: ""
-  attr :detail, :string, default: ""
   attr :icon_file_path, :string, default: ""
+  attr :click_event, :string, default: ""
+  attr :click_target, :string, default: nil
 
   def profile_small(assigns) do
     ~H"""
     <li class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded w-1/2">
-      <a class="inline-flex items-center gap-x-6">
+      <.profile_small_link click_event={@click_event} click_target={@click_target} user_name={@user_name}>
         <img class="inline-block h-10 w-10 rounded-full" src={@icon_file_path} />
         <div>
           <p><%= @user_name %></p>
           <p class="text-brightGray-300"><%= @title %></p>
         </div>
-      </a>
+      </.profile_small_link>
     </li>
+    """
+  end
+
+  defp profile_small_link(%{click_event: nil} = assigns) do
+    ~H"""
+    <a class="cursor-pointer inline-flex items-center gap-x-6" href={"/mypage/#{@user_name}"}>
+      <span class="inline-flex items-center gap-x-6">
+        <%= render_slot(@inner_block) %>
+      </span>
+    </a>
+    """
+  end
+
+  defp profile_small_link(%{click_event: _, click_target: nil} = assigns) do
+    ~H"""
+    <a class="cursor-pointer inline-flex items-center gap-x-6" phx-click={@click_event} phx-value-name={@user_name}>
+      <%= render_slot(@inner_block) %>
+    </a>
+    """
+  end
+
+  defp profile_small_link(assigns) do
+    ~H"""
+    <a class="cursor-pointer inline-flex items-center gap-x-6" phx-click={@click_event} phx-target={@click_target} phx-value-name={@user_name}>
+      <%= render_slot(@inner_block) %>
+    </a>
     """
   end
 end

--- a/lib/bright_web/live/card_live/related_user_card_component.ex
+++ b/lib/bright_web/live/card_live/related_user_card_component.ex
@@ -36,6 +36,8 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
       |> assign(:page, 1)
       |> assign(:total_pages, 0)
       |> assign(:page_size, @page_size)
+      |> assign(:card_row_click_target, nil)
+      |> assign(:purpose, nil)
 
     {:ok, socket}
   end
@@ -46,7 +48,7 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
     ~H"""
     <div>
       <.tab
-        id="intriguing_card#{@id}"
+        id={"related-user-card-#{@id}"}
         tabs={@tabs}
         selected_tab={@selected_tab}
         menu_items={@menu_items}
@@ -71,7 +73,7 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
           </ul>
           <ul :if={Enum.count(@user_profiles) > 0} class="flex flex-wrap gap-y-1">
             <%= for user_profile <- @user_profiles do %>
-              <.profile_small user_name={user_profile.user_name} title={user_profile.title} icon_file_path={user_profile.icon_file_path} />
+              <.profile_small user_name={user_profile.user_name} title={user_profile.title} icon_file_path={user_profile.icon_file_path} click_event={click_event(@purpose)} click_target={@card_row_click_target} />
             <% end %>
           </ul>
         </div>
@@ -82,9 +84,7 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
 
   @impl true
   def update(assigns, socket) do
-    socket =
-      socket
-      |> assign(:current_user, assigns.current_user)
+    socket = socket |> assign(assigns)
 
     # 初期表示データの取得 mount時に設定したselected_tabの選択処理を実行
     {:noreply, socket} =
@@ -299,4 +299,8 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
 
     %{user_smalls: member_and_users, total_pages: page.total_pages}
   end
+
+  defp click_event(nil), do: nil
+
+  defp click_event(purpose), do: "click_on_related_user_card_#{purpose}"
 end

--- a/lib/bright_web/live/skill_panel_live/graph.ex
+++ b/lib/bright_web/live/skill_panel_live/graph.ex
@@ -30,31 +30,14 @@ defmodule BrightWeb.SkillPanelLive.Graph do
   end
 
   @impl true
-  # TODO: デモ用実装のため対象ユーザー実装後に削除
-  # TODO: 匿名に注意すること
-  def handle_event("demo_change_user", _params, socket) do
-    users =
-      Bright.Accounts.User
-      |> Bright.Repo.all()
-      |> Enum.reject(fn user ->
-        user.id == socket.assigns.current_user.id ||
-          Ecto.assoc(user, :user_skill_panels)
-          |> Bright.Repo.all()
-          |> Enum.empty?()
-      end)
+  def handle_event("click_on_related_user_card_menu", params, socket) do
+    # TODO: チームメンバー以外の対応時に匿名に注意すること
+    user = Bright.Accounts.get_user_by_name(params["name"])
 
-    if users != [] do
-      user = Enum.random(users)
-
-      {:noreply,
-       socket
-       |> push_redirect(to: ~p"/graphs/#{socket.assigns.skill_panel}/#{user.name}")}
-    else
-      {:noreply,
-       socket
-       |> put_flash(:info, "demo: ユーザーがいません")
-       |> push_redirect(to: ~p"/graphs/#{socket.assigns.skill_panel}")}
-    end
+    # 参照可能なユーザーかどうかの判定は遷移先で行うので必要ない
+    {:noreply,
+     socket
+     |> push_redirect(to: ~p"/graphs/#{socket.assigns.skill_panel}/#{user.name}")}
   end
 
   # TODO: 検討：本実装で同じ処理をまるっと共通化するのはimportではできそうにない

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -155,30 +155,17 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
   def target_switch(assigns) do
     ~H"""
     <p class="leading-tight ml-4">対象者の<br />切り替え</p>
-    <% # TODO: 共通コンポーネント完成後に表示 %>
-    <.individual_menu :if={false} current_user={@current_user} />
+    <.related_user_menu current_user={@current_user} />
     <% # TODO: α版後にifを除去して表示 %>
     <.team_menu :if={false} current_user={@current_user} />
-
-    <% # TODO: 仮実装のため実装後に削除 %>
-    <button
-      class="text-white bg-brightGreen-300 rounded py-1.5 pl-3 flex items-center font-bold"
-      type="button"
-      phx-click="demo_change_user"
-    >
-      <span class="min-w-[6em]">個人</span>
-      <span class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-8px] before:bg-brightGray-50 before:w-[1px] before:h-[42px]">
-        expand_more
-      </span>
-    </button>
     """
   end
 
-  def individual_menu(assigns) do
+  def related_user_menu(assigns) do
     ~H"""
       <button
-        id="dropdownDefaultButton"
-        data-dropdown-toggle="dropdown2"
+        id="dropdownDefaultButton-related-user"
+        data-dropdown-toggle="dropdown-related-user"
         data-dropdown-offset-skidding="302"
         data-dropdown-placement="bottom"
         class="text-white bg-brightGreen-300 rounded-sm py-1.5 pl-3 flex items-center font-bold"
@@ -191,14 +178,15 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
       </button>
       <!-- 個人 menu -->
       <div
-        id="dropdown2"
+        id="dropdown-related-user"
         class="z-10 hidden bg-whiterounded-lg shadow w-[750px]"
       >
         <.live_component
-          id="intriguing_card"
+          id="related-user-card-menu"
           module={BrightWeb.CardLive.RelatedUserCardComponent}
           current_user={@current_user}
           display_menu={false}
+          purpose="menu"
         />
       </div>
     """

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -115,31 +115,14 @@ defmodule BrightWeb.SkillPanelLive.Skills do
     {:noreply, socket}
   end
 
-  # TODO: デモ用実装のため対象ユーザー実装後に削除
-  # TODO: 匿名に注意すること
-  def handle_event("demo_change_user", _params, socket) do
-    users =
-      Bright.Accounts.User
-      |> Bright.Repo.all()
-      |> Enum.reject(fn user ->
-        user.id == socket.assigns.current_user.id ||
-          Ecto.assoc(user, :user_skill_panels)
-          |> Bright.Repo.all()
-          |> Enum.empty?()
-      end)
+  def handle_event("click_on_related_user_card_menu", params, socket) do
+    # TODO: チームメンバー以外の対応時に匿名に注意すること
+    user = Bright.Accounts.get_user_by_name(params["name"])
 
-    if users != [] do
-      user = Enum.random(users)
-
-      {:noreply,
-       socket
-       |> push_redirect(to: ~p"/panels/#{socket.assigns.skill_panel}/#{user.name}")}
-    else
-      {:noreply,
-       socket
-       |> put_flash(:info, "demo: ユーザーがいません")
-       |> push_redirect(to: ~p"/panels/#{socket.assigns.skill_panel}")}
-    end
+    # 参照可能なユーザーかどうかの判定は遷移先で行うので必要ない
+    {:noreply,
+     socket
+     |> push_redirect(to: ~p"/panels/#{socket.assigns.skill_panel}/#{user.name}")}
   end
 
   def handle_event("clear_target_user", _params, socket) do

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -8,20 +8,8 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
     ~H"""
     <div class="flex mt-4 items-center">
       <.compare_timeline myself={@myself} timeline={@timeline} />
-      <% # TODO: 仮UI コンポーネント完成後に削除 %>
       <div class="flex gap-x-4">
-        <button
-          class="border border-brightGray-200 rounded-md py-1.5 pl-3 flex items-center"
-          type="button"
-          phx-click="demo_compare_user"
-          phx-target={@myself}
-        >
-          <span class="min-w-[6em]">個人と比較</span>
-          <span
-            class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-7px] before:bg-brightGray-200 before:w-[1px] before:h-[38px]">add</span>
-        </button>
-        <% # TODO: コンポーネント完成後にifを除去して表示 %>
-        <.compare_individual :if={false} current_user={@current_user} />
+        <.compare_individual current_user={@current_user} myself={@myself} />
         <% # TODO: α版後にifを除去して表示 %>
         <.compare_team :if={false} current_user={@current_user} />
         <% # TODO: α版後にifを除去して表示 %>
@@ -88,8 +76,8 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
   def compare_individual(assigns) do
     ~H"""
     <button
-      id="addCompareDropdownButton"
-      data-dropdown-toggle="addCompareDropdown"
+      id="addCompareDropdownButton-related-user"
+      data-dropdown-toggle="addCompareDropdown-related-user"
       data-dropdown-offset-skidding="300"
       data-dropdown-placement="bottom"
       class="border border-brightGray-200 rounded-md py-1.5 pl-3 flex items-center"
@@ -103,13 +91,15 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
     <!-- 個人と比較Donwdrop -->
     <div
       class="bg-white rounded-md mt-1 w-[750px] bottom border-brightGray-100 border shadow-md hidden"
-      id="addCompareDropdown"
+      id="addCompareDropdown-related-user"
     >
       <.live_component
-        id="intriguing_card_compare"
+        id="related-user-card-compare"
         module={BrightWeb.CardLive.RelatedUserCardComponent}
         current_user={@current_user}
         display_menu={false}
+        purpose="compare"
+        card_row_click_target={@myself}
       />
     </div>
     """

--- a/lib/bright_web/live/skill_panel_live/skills_field_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_field_component.ex
@@ -61,29 +61,16 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
      |> assign_compared_users_info()}
   end
 
-  # TODO: デモ用実装のため対象ユーザー実装後に削除
-  def handle_event("demo_compare_user", _params, socket) do
-    users =
-      Bright.Accounts.User
-      |> Bright.Repo.all()
-      |> Enum.reject(fn user ->
-        user.id == socket.assigns.display_user.id ||
-          Ecto.assoc(user, :user_skill_panels)
-          |> Bright.Repo.all()
-          |> Enum.empty?()
-      end)
+  def handle_event("click_on_related_user_card_compare", params, socket) do
+    # TODO: チームメンバー以外の対応時に匿名に注意すること
+    # TODO: 本当に参照可能かのチェックをいれること
+    user = Bright.Accounts.get_user_by_name(params["name"])
 
-    if users != [] do
-      user = Enum.random(users)
-
-      {:noreply,
-       socket
-       |> update(:compared_users, &((&1 ++ [user]) |> Enum.uniq()))
-       |> assign_compared_user_dict(user)
-       |> assign_compared_users_info()}
-    else
-      {:noreply, socket}
-    end
+    {:noreply,
+     socket
+     |> update(:compared_users, &((&1 ++ [user]) |> Enum.uniq()))
+     |> assign_compared_user_dict(user)
+     |> assign_compared_users_info()}
   end
 
   def handle_event("reject_compared_user", %{"name" => name}, socket) do


### PR DESCRIPTION
closes #549 

## 対応内容

- メガメニューの対象者の切り替えに対応しました。
- スキルパネルの対象個人と比較のメニューに対応しました。


## 参考画面

![sample29](https://github.com/bright-org/bright/assets/121112529/4bcab4af-dc03-45ca-af7c-d8e20859c187)
