### PR TITLE
保有スキルの文字の色を修正 （タブコンポーネントのtext-brightGray-500の位置を変更）

### DIFF
--- a/lib/bright_web/components/tab_components.ex
+++ b/lib/bright_web/components/tab_components.ex
@@ -33,7 +33,7 @@ defmodule BrightWeb.TabComponents do
   def tab(assigns) do
     ~H"""
     <div id={@id} class="bg-white rounded-md mt-1">
-      <div class="text-sm font-medium text-center text-brightGray-500">
+      <div class="text-sm font-medium text-center">
         <.tab_header
           id={@id}
           tabs={@tabs}
@@ -62,7 +62,7 @@ defmodule BrightWeb.TabComponents do
 
   defp tab_header(assigns) do
     ~H"""
-    <ul class="flex content-between border-b border-brightGray-200">
+    <ul class="flex content-between border-b border-brightGray-200 text-brightGray-500">
       <%= for {key, value} <- @tabs do %>
         <.tab_header_item
           id={@id}


### PR DESCRIPTION
修正前
タブコンポーネントの中が薄い緑になっている
![マイページ1](https://github.com/bright-org/bright/assets/13599847/f63cc457-a8e1-470a-9719-45e1b1ae0e63)

修正後
タブコンポーネントの中はフォントの色を影響を与えないようにする
代わりにタブを薄い緑にする
![image](https://github.com/bright-org/bright/assets/13599847/b0b656f3-aea6-4868-8e3f-189d6dade048)

