### PR TITLE
スキルパネル スコアクリックでフォーカス行が変わらない現象対応

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -78,14 +78,15 @@ defmodule BrightWeb.SkillPanelLive.Skills do
      |> assign_edit_off()}
   end
 
-  def handle_event("change", %{"score" => score, "skill_id" => skill_id}, socket) do
+  def handle_event("change", %{"score" => score, "skill_id" => skill_id, "row" => row}, socket) do
     score = String.to_atom(score)
     skill_score = Map.get(socket.assigns.skill_score_dict, skill_id)
+    row = String.to_integer(row)
 
     {:noreply,
      socket
      |> update_by_score_change(skill_score, score)
-     |> update(:focus_row, &Enum.min([&1 + 1, socket.assigns.num_skills]))}
+     |> assign(:focus_row, row)}
   end
 
   def handle_event("shortcut", %{"key" => key, "skill_id" => skill_id}, socket)

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -334,6 +334,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
                     phx-click="change"
                     phx-value-score="high"
                     phx-value-skill_id={col3.skill.id}
+                    phx-value-row={row}
                   >
                     <input
                       type="radio"
@@ -348,6 +349,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
                     phx-click="change"
                     phx-value-score="middle"
                     phx-value-skill_id={col3.skill.id}
+                    phx-value-row={row}
                   >
                     <input
                       type="radio"
@@ -362,6 +364,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
                     phx-click="change"
                     phx-value-score="low"
                     phx-value-skill_id={col3.skill.id}
+                    phx-value-row={row}
                   >
                     <input
                       type="radio"


### PR DESCRIPTION
## 対応内容

一度ショートカットキーで下にいくと、クリックしてもフォーカスが戻らなかったため対応しました。

## 参考画像

![sample30](https://github.com/bright-org/bright/assets/121112529/f675814f-18b7-4821-bf3a-5c0b18443d64)

- 下にいったあとに上にクリックで戻して、またショートカットキー操作をしています。

