### PR TITLE
tailwind.config.css更新

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -96,6 +96,9 @@ module.exports = {
         amethyst600: "#C04CD0",
         amethyst300: "#DD6DED",
       },
+      planUpgrade: {
+        600: "#f57f3e",
+      },
     },
     extend: {
       backgroundImage: (theme) => ({


### PR DESCRIPTION
「プランのアップグレード」ボタンのオレンジを定義しました。「bg-planUpgrade-600」で利用できます。