### PR TITLE
#84 RelatedTeamCardのバグ修正

### DIFF
--- a/lib/bright_web/live/card_live/related_team_card_component.ex
+++ b/lib/bright_web/live/card_live/related_team_card_component.ex
@@ -147,7 +147,6 @@ defmodule BrightWeb.CardLive.RelatedTeamCardComponent do
         %{"id" => _id},
         %{assigns: %{card: card}} = socket
       ) do
-
     page = card.page_params.page - 1
     page = if page < 1, do: 1, else: page
 
@@ -159,14 +158,12 @@ defmodule BrightWeb.CardLive.RelatedTeamCardComponent do
         %{"id" => _id},
         %{assigns: %{card: card}} = socket
       ) do
-
     page = card.page_params.page + 1
 
     page =
       if page > card.total_pages,
         do: card.total_pages,
         else: page
-
 
     card_view(socket, card.selected_tab, page)
   end


### PR DESCRIPTION
# やったこと

RelatedTeamCardComponentのバグを修正
- ID指定のバグで一意に指定できていなかった為、<>ボタンの往復で行が増え続けるバグがあったので修正
- 表示行が少ない場合の対応として縦幅をスタイルで固定指定

![image](https://github.com/bright-org/bright/assets/45676464/e3dbf563-1646-47a8-abce-0b23e8e1f2cf)
