### PR TITLE
エビデンス登録 表示領域の整形

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
@@ -18,9 +18,9 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
           :for={{id, post} <- @streams.skill_evidence_posts}
           id={id}
         >
-          <div class="flex justify-between my-2">
-            <%= Phoenix.HTML.Format.text_to_html post.content %>
-            <div class="cursor-pointer" phx-click="delete" phx-target={@myself} phx-value-id={post.id}>
+          <div class="flex justify-between items-center my-2 gap-x-4">
+            <%= Phoenix.HTML.Format.text_to_html post.content, attributes: [class: "break-all grow"] %>
+            <div class="cursor-pointer flex-none" phx-click="delete" phx-target={@myself} phx-value-id={post.id}>
               Ｘ削除
             </div>
           </div>


### PR DESCRIPTION
障害報告への対応です。

## 対応内容

下記を修正しました。

- 英数字で枠をはみ出す
- 「削除」ボタンを圧迫する

デザイン当てそのものがβなので仮にクラスを付けて対応しています。

## 画面

修正前：
![スクリーンショット 2023-08-22 144008](https://github.com/bright-org/bright/assets/121112529/984fbb20-7f4c-4c5c-a2f0-5f3a81d4728f)

修正後：
![スクリーンショット 2023-08-22 143954](https://github.com/bright-org/bright/assets/121112529/d5091547-3442-449c-90b1-3492057ae808)
