### PR TITLE
スキルパネル メガメニューコンポーネントの適用およびinner_block対応

### DIFF
--- a/lib/bright_web/components/mega_menu_components.ex
+++ b/lib/bright_web/components/mega_menu_components.ex
@@ -20,10 +20,7 @@ defmodule BrightWeb.MegaMenuComponents do
     <.mega_menu_button
       id="mega_menu_team"
       label="ボタンに表示する文言"
-      current_user={@current_user}
       dropdown_offset_skidding="307"
-      card_component={BrightWeb.CardLive.RelatedTeamCardComponent}
-      over_ride_on_card_row_click_target={:true}
     />
   """
 
@@ -32,15 +29,13 @@ defmodule BrightWeb.MegaMenuComponents do
   attr :id, :string, required: true
   attr :label, :string, required: true
   attr :dropdown_offset_skidding, :string, required: true
-  attr :current_user, Bright.Accounts.User, required: true
-  attr :card_component, :any, required: true
-  attr :over_ride_on_card_row_click_target, :boolean, required: false, default: false
+  slot :inner_block
 
   def mega_menu_button(assigns) do
     ~H"""
     <button
-      id="dropdownOffsetButton#{@id}"
-      data-dropdown-toggle="dropdownOffset#{@id}"
+      id={"dropdownOffsetButton#{@id}"}
+      data-dropdown-toggle={"dropdownOffset#{@id}"}
       data-dropdown-offset-skidding={@dropdown_offset_skidding}
       data-dropdown-placement="bottom"
       class="text-white bg-brightGreen-300 rounded-sm py-1.5 pl-3 flex items-center font-bold"
@@ -54,18 +49,14 @@ defmodule BrightWeb.MegaMenuComponents do
         expand_more
       </span>
     </button>
+
     <!-- メガメニューの内容 -->
-      <div
-        id="dropdownOffset#{@id}"
-        class="z-10 hidden bg-white rounded-sm shadow w-[750px]"
-      >
-        <.live_component
-          id={@id}
-          module={@card_component}
-          current_user={@current_user}
-          over_ride_on_card_row_click_target={@over_ride_on_card_row_click_target}
-        />
-      </div>
+    <div
+      id={"dropdownOffset#{@id}"}
+      class="z-10 hidden bg-white rounded-sm shadow w-[750px]"
+    >
+      <%= render_slot(@inner_block) %>
+    </div>
     """
   end
 end

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -2,6 +2,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
   use Phoenix.Component
   import BrightWeb.ChartComponents
   import BrightWeb.ProfileComponents
+  import BrightWeb.MegaMenuComponents
   import BrightWeb.SkillPanelLive.SkillPanelHelper, only: [calc_percentage: 2]
 
   # スコア（〇 △ー） 各スタイルと色の定義
@@ -47,39 +48,10 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
   def skill_panel_switch(assigns) do
     ~H"""
     <p class="leading-tight">対象スキルの<br />切り替え</p>
-    <.skill_panel_menu
+    <.mega_menu_button
       id="skill_panel_menu"
-      display_user={@display_user}
-      me={@me}
-      anonymous={@anonymous}
-      root={@root}
-    />
-    <% # TODO: α版後にifを除去して表示 %>
-    <.skill_set_menu :if={false} />
-    """
-  end
-
-  def skill_panel_menu(assigns) do
-    # TODO: 使えるならばMegaMenuComponentsに差し替え
-    ~H"""
-    <button
-      id={"dropdownOffsetButton-#{@id}"}
-      data-dropdown-toggle={"dropdownOffset-#{@id}"}
-      data-dropdown-offset-skidding="256"
-      data-dropdown-placement="bottom"
-      class="text-white bg-brightGreen-300 rounded pl-3 flex items-center font-bold h-[35px]"
-      type="button"
-    >
-      <span class="min-w-[6em]">スキル</span>
-      <span class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-8px] before:bg-brightGray-50 before:w-[1px] before:h-[42px]">
-        expand_more
-      </span>
-    </button>
-
-    <!-- スキルパネル menu -->
-    <div
-      id={"dropdownOffset-#{@id}"}
-      class="z-10 hidden bg-white rounded-sm shadow"
+      label="スキル"
+      dropdown_offset_skidding="307"
     >
       <.live_component
         id="skill_card"
@@ -89,7 +61,10 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
         anonymous={@anonymous}
         root={@root}
       />
-    </div>
+    </.mega_menu_button>
+
+    <% # TODO: α版後にifを除去して表示 %>
+    <.skill_set_menu :if={false} />
     """
   end
 
@@ -163,32 +138,19 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
 
   def related_user_menu(assigns) do
     ~H"""
-      <button
-        id="dropdownDefaultButton-related-user"
-        data-dropdown-toggle="dropdown-related-user"
-        data-dropdown-offset-skidding="302"
-        data-dropdown-placement="bottom"
-        class="text-white bg-brightGreen-300 rounded-sm py-1.5 pl-3 flex items-center font-bold"
-        type="button"
-      >
-        <span class="min-w-[6em]">個人</span>
-        <span class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-8px] before:bg-brightGray-50 before:w-[1px] before:h-[42px]">
-          expand_more
-        </span>
-      </button>
-      <!-- 個人 menu -->
-      <div
-        id="dropdown-related-user"
-        class="z-10 hidden bg-whiterounded-lg shadow w-[750px]"
-      >
-        <.live_component
-          id="related-user-card-menu"
-          module={BrightWeb.CardLive.RelatedUserCardComponent}
-          current_user={@current_user}
-          display_menu={false}
-          purpose="menu"
-        />
-      </div>
+    <.mega_menu_button
+      id="related_user_card_menu"
+      label="個人"
+      dropdown_offset_skidding="307"
+    >
+      <.live_component
+        id="related_user"
+        module={BrightWeb.CardLive.RelatedUserCardComponent}
+        current_user={@current_user}
+        display_menu={false}
+        purpose="menu"
+      />
+    </.mega_menu_button>
     """
   end
 

--- a/lib/bright_web/live/team_live/my_team_live.html.heex
+++ b/lib/bright_web/live/team_live/my_team_live.html.heex
@@ -3,15 +3,22 @@
   <!-- スキルと対象の切り替え -->
   <div class="flex gap-x-4">
     <p class="leading-tight">対象スキルの<br />切り替え</p>
-    <!-- スキルパネル menu --> 
+    <!-- スキルパネル menu -->
     <.mega_menu_button
       id="mega_menu_skill_panel"
-      label="スキルパネル"
+      label="スキル"
       dropdown_offset_skidding="307"
-      current_user={@current_user}
-      card_component={BrightWeb.CardLive.RelatedTeamCardComponent}
-      over_ride_on_card_row_click_target={:true}
-    />
+    >
+      <% # TODO: 仮置き要対応 %>
+      <.live_component
+        id="skill_card"
+        module={BrightWeb.CardLive.SkillCardComponent}
+        display_user={@current_user}
+        me={true}
+        anonymous={false}
+        root={"graphs"}
+      />
+    </.mega_menu_button>
 
     <!-- TODO αリリースではスキルセットは対応しない -->
     <!-- スキルセット menu -->
@@ -19,22 +26,26 @@
     <p class="leading-tight ml-4">対象者の<br />切り替え</p>
     <!-- チーム menu -->
     <.mega_menu_button
-      id="mega_menu_team" 
+      id="mega_menu_team"
       label="チーム"
-      current_user={@current_user}
       dropdown_offset_skidding="307"
-      card_component={BrightWeb.CardLive.RelatedTeamCardComponent}
-      over_ride_on_card_row_click_target={:true}
-    />
+    >
+      <.live_component
+        id="team_card"
+        module={BrightWeb.CardLive.RelatedTeamCardComponent}
+        current_user={@current_user}
+        over_ride_on_card_row_click_target={:true}
+      />
+    </.mega_menu_button>
 
-      <button
-       data-modal-target="defaultModal"
-       data-modal-toggle="defaultModal"
-       class="text-brightGreen-300 border bg-white border-brightGreen-300 rounded px-3 font-bold ml-auto"
-       phx-click={show_modal("create-team-modal")}
-      >
-        チームを作る
-      </button>
+    <button
+      data-modal-target="defaultModal"
+      data-modal-toggle="defaultModal"
+      class="text-brightGreen-300 border bg-white border-brightGreen-300 rounded px-3 font-bold ml-auto"
+      phx-click={show_modal("create-team-modal")}
+    >
+      チームを作る
+    </button>
   </div>
   <!-- プロフィール -->
   <div class="flex justify-between py-6 px-10 bg-white">
@@ -63,7 +74,7 @@
     team_type={:general_team}
   />
   -->
-  
+
 
   <!-- チームメンバー -->
 


### PR DESCRIPTION
## 対応内容

スキルパネル側でメガメニューのコンポーネントを使っていなかったため、使う形に対応しました。
これによって、障害報告のあった枠崩れを解消しました。

また、合わせてコンポーネントのインターフェースを調整しています。

## 画面

**修正前**
![スクリーンショット 2023-08-24 092749](https://github.com/bright-org/bright/assets/121112529/a670cc5e-ee7a-4699-93fe-4e4287a91bd3)

**修正後**
![スクリーンショット 2023-08-24 092738](https://github.com/bright-org/bright/assets/121112529/e731ce56-a6ea-4f16-9dc7-5d798bfe09fc)
