### PR TITLE
アップロードボタンのアイコンの色が変わっていないのを修正

### DIFF
--- a/lib/bright_web/components/bright_button_components.ex
+++ b/lib/bright_web/components/bright_button_components.ex
@@ -119,7 +119,7 @@ defmodule BrightWeb.BrightButtonComponents do
       type="button"
       class="text-white bg-planUpgrade-600 px-4 inline-flex rounded-md text-sm items-center font-bold h-9 hover:opacity-70"
     >
-      <span class="bg-white material-icons mr-1 !text-base !text-[#f57f3e] rounded-full h-6 w-6 !font-bold material-icons-outlined">upgrade</span>
+      <span class="bg-white material-icons mr-1 !text-base !text-planUpgrade-600 rounded-full h-6 w-6 !font-bold material-icons-outlined">upgrade</span>
       プランのアップグレード
     </button>
     """


### PR DESCRIPTION
タイトル通り

before
![スクリーンショット 2023-08-24 9 18 49](https://github.com/bright-org/bright/assets/91950/2aace19f-8ec8-4822-8be1-dba9010a94c4)

after
![スクリーンショット 2023-08-24 9 18 56](https://github.com/bright-org/bright/assets/91950/f872d334-421d-4f49-8c41-bb0c1ec68c95)
