### PR TITLE
最新のスキルパネル扱いにするタイミングをアクセス時に変更

### DIFF
--- a/lib/bright_web/live/skill_panel_live/graph.ex
+++ b/lib/bright_web/live/skill_panel_live/graph.ex
@@ -28,7 +28,8 @@ defmodule BrightWeb.SkillPanelLive.Graph do
      |> assign_skill_class_and_score(params["class"])
      |> create_skill_class_score_if_not_existing()
      |> assign_skill_score_dict()
-     |> assign_counter()}
+     |> assign_counter()
+     |> touch_user_skill_panel()}
   end
 
   def handle_params(_params, _url, %{assigns: %{skill_panel: nil}} = socket),

--- a/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
@@ -6,6 +6,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
   import Phoenix.LiveView, only: [push_redirect: 2]
 
   alias BrightWeb.DisplayUserHelper
+  alias Bright.UserSkillPanels
 
   @counter %{
     low: 0,
@@ -32,7 +33,6 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
 
   def assign_skill_panel(socket, nil, _root) do
     display_user = socket.assigns.display_user
-
     skill_panel = SkillPanels.get_user_latest_skill_panel(display_user)
 
     socket
@@ -41,7 +41,6 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
 
   def assign_skill_panel(socket, skill_panel_id, root) do
     display_user = socket.assigns.display_user
-
     skill_panel = SkillPanels.get_user_skill_panel(display_user, skill_panel_id)
 
     if skill_panel do
@@ -179,6 +178,17 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
       |> Map.update!(:evidence_filled, &if(skill_score.evidence_filled, do: &1 + 1, else: &1))
     end)
   end
+
+  def touch_user_skill_panel(%{assigns: %{me: true}} = socket) do
+    UserSkillPanels.touch_user_skill_panel_updated(
+      socket.assigns.current_user,
+      socket.assigns.skill_panel
+    )
+
+    socket
+  end
+
+  def touch_user_skill_panel(socket), do: socket
 
   def assign_page_sub_title(%{assigns: %{skill_panel: nil}} = socket) do
     socket

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -12,7 +12,6 @@ defmodule BrightWeb.SkillPanelLive.Skills do
   alias Bright.SkillEvidences
   alias Bright.SkillReferences
   alias Bright.SkillExams
-  alias Bright.UserSkillPanels
   alias BrightWeb.PathHelper
 
   @shortcut_key_score %{
@@ -43,7 +42,8 @@ defmodule BrightWeb.SkillPanelLive.Skills do
      |> create_skill_class_score_if_not_existing()
      |> assign_skill_score_dict()
      |> assign_counter()
-     |> apply_action(socket.assigns.live_action, params)}
+     |> apply_action(socket.assigns.live_action, params)
+     |> touch_user_skill_panel()}
   end
 
   def handle_params(_params, _url, %{assigns: %{skill_panel: nil}} = socket),
@@ -67,11 +67,6 @@ defmodule BrightWeb.SkillPanelLive.Skills do
 
     {:ok, _} = SkillScores.update_skill_scores(socket.assigns.current_user, target_skill_scores)
     skill_class_score = SkillScores.get_skill_class_score!(socket.assigns.skill_class_score.id)
-
-    UserSkillPanels.touch_user_skill_panel_updated(
-      socket.assigns.current_user,
-      socket.assigns.skill_panel
-    )
 
     {:noreply,
      socket

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -148,6 +148,40 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
     end
   end
 
+  # # TODO: 時間操作の対応
+  # describe "Show latest skill panel" do
+  #   setup [:register_and_log_in_user]
+  #
+  #   setup %{user: user} do
+  #     [skill_panel_1, skill_panel_2] =
+  #       insert_pair(:skill_panel)
+  #       |> Enum.map(fn skill_panel ->
+  #         insert(:user_skill_panel, user: user, skill_panel: skill_panel)
+  #         insert(:skill_class, skill_panel: skill_panel, class: 1)
+  #         skill_panel
+  #       end)
+  #
+  #     %{skill_panel_1: skill_panel_1, skill_panel_2: skill_panel_2}
+  #   end
+  #
+  #   test "switches latest skill panel by access", %{
+  #     skill_panel_1: skill_panel_1,
+  #     skill_panel_2: skill_panel_2,
+  #     conn: conn
+  #   } do
+  #     {:ok, _show_live, html} = live(conn, ~p"/panels/#{skill_panel_1}")
+  #     assert html =~ "スキルパネル / #{skill_panel_1.name}"
+  #     {:ok, _show_live, html} = live(conn, ~p"/panels")
+  #     assert html =~ "スキルパネル / #{skill_panel_1.name}"
+  #
+  #     :timer.sleep(1000)
+  #     {:ok, _show_live, html} = live(conn, ~p"/panels/#{skill_panel_2}")
+  #     assert html =~ "スキルパネル / #{skill_panel_2.name}"
+  #     {:ok, _show_live, html} = live(conn, ~p"/panels")
+  #     assert html =~ "スキルパネル / #{skill_panel_2.name}"
+  #   end
+  # end
+
   describe "Show skill scores" do
     setup [:register_and_log_in_user, :setup_skills]
 


### PR DESCRIPTION
refs: https://github.com/orgs/bright-org/projects/3/views/1?pane=issue&itemId=36699210

## 対応内容

下記の仕様変更対応を行いました。

変更前：
スキルスコアを編集して保存した際に最新

変更後：
成長グラフやスキルパネルを表示した際に最新
