### PR TITLE
スキルパネル クラスタブ箇所のデザイン調整

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -119,6 +119,10 @@ module.exports = {
         planUpgrade: {
           600: "#f57f3e",
         },
+        pureGray: {
+          100: "#e0e0e0",
+          600: "#acacac",
+        },
       },
       backgroundImage: (theme) => ({
         bgGem: "url('/images/bg_gem_title.png')",

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -272,7 +272,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
             </.link>
           </li>
         <% else %>
-          <li class="bg-brightGray-100 text-white">
+          <li class="bg-pureGray-600 text-pureGray-100">
             <span href="#" class="select-none inline-block p-4 pt-3">
               クラス<%= skill_class.class %>
               <span class="text-xl ml-4">0</span>％


### PR DESCRIPTION
## 対応内容

デザイン調整があり、未開放クラスのタブのデザインを対応しました。

## 参考画像

**変更前**

![image](https://github.com/bright-org/bright/assets/121112529/48815f36-ddf7-4c8a-adb1-673d5f3a9eac)


**変更後**

![image](https://github.com/bright-org/bright/assets/121112529/d8fd28bd-6761-44a4-b7a4-a0c49c3ccb7a)
