### PR TITLE
GoogleApi.Storage.V1.Connection.new() 漏れ

### DIFF
--- a/lib/bright/utils/google_cloud/storage.ex
+++ b/lib/bright/utils/google_cloud/storage.ex
@@ -95,6 +95,7 @@ defmodule Bright.Utils.GoogleCloud.Storage do
 
       _ ->
         Goth.fetch!(Bright.Goth)
+        |> GoogleApi.Storage.V1.Connection.new()
     end
   end
 


### PR DESCRIPTION
表題の通り。
dev 環境でアップロードした時にエラーになっていた。