### PR TITLE
「個人」メガメニューから他者を押下したとき、成長グラフの対象が選択した個人に切り替わる対応

### DIFF
--- a/lib/bright_web/live/skill_panel_live/graph.html.heex
+++ b/lib/bright_web/live/skill_panel_live/graph.html.heex
@@ -21,7 +21,7 @@
       <.live_component
         id="rowth-graph"
         module={BrightWeb.ChartLive.GrowthGraphComponent}
-        user_id={@current_user.id}
+        user_id={@display_user.id}
         skill_panel_id={@skill_panel.id}
         class={@skill_class.class}
       />


### PR DESCRIPTION
タイトル通り

https://github.com/bright-org/bright/assets/13599847/1cf4e47f-9bbd-4053-8042-dee0d5d35060


