### PR TITLE
成長グラフ／スキルパネルで適切ではないリクエストに対して404を返す対応

### DIFF
--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -563,6 +563,18 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       %{skill_panel: skill_panel, skill_class: skill_class}
     end
 
+    test "shows 404 if skill_panel_id is invalid ULID", %{conn: conn} do
+      assert_raise Ecto.NoResultsError, fn ->
+        live(conn, ~p"/panels/abcd")
+      end
+    end
+
+    test "shows 404 if skill_panel not exists", %{conn: conn} do
+      assert_raise Ecto.NoResultsError, fn ->
+        live(conn, ~p"/panels/#{Ecto.ULID.generate()}")
+      end
+    end
+
     test "shows 404 if class not existing", %{
       conn: conn,
       skill_panel: skill_panel


### PR DESCRIPTION
## 対応内容

下記のケースで 404 を返す対応を行いました。

- `?class=abc`などの不正なクラス指定
- `panels/agc` などの不正なスキルパネルid指定
- 保持していないスキルパネルへのURLアクセス指定
  - ただし、me: true(自身)のみのケース
