### PR TITLE
Bright.UserProfiles.icon_url対応

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -256,7 +256,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
             user_name={@display_user.name}
             title={@display_user.user_profile.title}
             detail={@display_user.user_profile.detail}
-            icon_file_path={@display_user.user_profile.icon_file_path}
+            icon_file_path={Bright.UserProfiles.icon_url(@display_user.user_profile.icon_file_path)}
             display_excellent_person={false}
             display_anxious_person={false}
             display_return_to_yourself={true}


### PR DESCRIPTION
プロフィールのアイコン対応（GCS）

![image](https://github.com/bright-org/bright/assets/13599847/377b12bf-86aa-4989-a2a0-31d49d683c7f)

![image](https://github.com/bright-org/bright/assets/13599847/a2224a83-681c-451a-b5f9-e082cab53608)
