### PR TITLE
スキルパネル画面 開放済みクラスの過去（解放前）をみるとエラーになる現象対応

### DIFF
--- a/lib/bright/historical_skill_scores.ex
+++ b/lib/bright/historical_skill_scores.ex
@@ -26,6 +26,8 @@ defmodule Bright.HistoricalSkillScores do
   @doc """
   Returns the list of historical_skill_scores from historical_skill_class_score
   """
+  def list_historical_skill_scores_from_historical_skill_class_score(nil), do: []
+
   def list_historical_skill_scores_from_historical_skill_class_score(%{
         historical_skill_class_id: historical_skill_class_id,
         user_id: user_id

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -272,7 +272,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
 
         <%= for {[col1, col2, col3], row} <- @table_structure |> Enum.with_index(1) do %>
           <% focus = @focus_row == row %>
-          <% skill_score = @skill_score_dict[col3.skill.id] %>
+          <% skill_score = @skill_score_dict[col3.skill.id] || %{score: :low} %>
           <% current_skill = Map.get(@current_skill_dict, col3.skill.trace_id) %>
           <% current_skill_score = Map.get(@current_skill_score_dict, Map.get(current_skill, :id)) %>
 


### PR DESCRIPTION
## 対応内容

スキルパネル画面で、開放済みクラスを選択中に、過去（解放前）をみるとエラーになる現象があったので対応しました。

修正対象となる自動テストはありません。