### PR TITLE
スキルクラス並び順に対応（preload_orderが効く形に修正）

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
@@ -66,9 +66,11 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
     display_user = socket.assigns.display_user
 
     skill_classes =
-      Ecto.assoc(socket.assigns.skill_panel, :skill_classes)
-      |> SkillPanels.list_skill_classes()
-      |> Bright.Repo.preload(skill_class_scores: Ecto.assoc(display_user, :skill_class_scores))
+      socket.assigns.skill_panel
+      |> Bright.Repo.preload(
+        skill_classes: [skill_class_scores: Ecto.assoc(display_user, :skill_class_scores)]
+      )
+      |> Map.get(:skill_classes)
 
     socket
     |> assign(:skill_classes, skill_classes)


### PR DESCRIPTION
## 対応内容

`Ecto.assoc` を使っているところ(preload_orderが効かない)があったので対応を行いました。

（現状、対応するテストはありません）