### PR TITLE
メール・パスワードをαリリース向けにデザイン調整

### DIFF
--- a/lib/bright_web/live/user_settings_live/auth_setting_component.ex
+++ b/lib/bright_web/live/user_settings_live/auth_setting_component.ex
@@ -53,7 +53,7 @@ defmodule BrightWeb.UserSettingsLive.AuthSettingComponent do
           </label>
         </div>
         <div class="mt-1 ml-auto w-fit py-2">
-          <button type="submit" class="bg-brightGray-900 block border border-solid border-brightGray-900 cursor-pointer font-bold px-2 py-1 rounded select-none text-center text-white w-28 hover:opacity-50">追加する</button>
+          <%!-- <button type="submit" class="bg-brightGray-900 block border border-solid border-brightGray-900 cursor-pointer font-bold px-2 py-1 rounded select-none text-center text-white w-28 hover:opacity-50">追加する</button> --%>
           <%!-- <button type="submit" class="mail_delete bg-white block border border-solid border-brightGray-900 cursor-pointer font-bold my-0.5 px-2 py-1 rounded select-none text-center text-brightGray-900 w-28 hover:opacity-50">削除する</button> --%>
         </div>
 


### PR DESCRIPTION
close: #767
表題の通り。

![image](https://github.com/bright-org/bright/assets/18478417/1c22baa6-e425-4828-8e94-e1dc66ca0345)

