### PR TITLE
「対象者の切り替え」と「スキル」メガメニューの位置を入れ替え

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -34,13 +34,13 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
   def navigations(assigns) do
     ~H"""
     <div class="flex gap-x-4 px-10 pt-4 pb-3">
+      <.target_switch current_user={@current_user} />
       <.skill_panel_switch
         display_user={@display_user}
         me={@me}
         anonymous={@anonymous}
         root={@root}
       />
-      <.target_switch current_user={@current_user} />
     </div>
     """
   end


### PR DESCRIPTION
## 対応内容

表題の通りです。

**背景**

対象者を切り替えると、「対象スキル」で表示されるのはその対象者の保有スキルパネルになります。
つまり、メガメニュー内容が「対象者の切り替え」 > 「対象スキル」の依存関係のため、位置を変更しています。


## 画面

**前**

![image](https://github.com/bright-org/bright/assets/121112529/4f754032-c637-409b-a631-8b434f7d3849)


**後**

![image](https://github.com/bright-org/bright/assets/121112529/713150cb-81b8-4a50-b8ca-945f90cac54d)
