### PR TITLE
オンボーディングページでpage_titleが設定されていない箇所があったのを修正

### DIFF
--- a/lib/bright_web/live/onboarding_live/index.ex
+++ b/lib/bright_web/live/onboarding_live/index.ex
@@ -84,5 +84,6 @@ defmodule BrightWeb.OnboardingLive.Index do
     do: "rounded-bl-none rounded-br-none before:-mt-0.5 before:rotate-45"
 
   defp page_title("/onboardings"), do: "オンボーディング"
-  defp page_title("/skill_up"), do: "スキルアップ"
+  # αはスキルを選ぶにしておく
+  defp page_title("/skill_up"), do: "スキルを選ぶ"
 end

--- a/lib/bright_web/live/onboarding_live/skill_panel.ex
+++ b/lib/bright_web/live/onboarding_live/skill_panel.ex
@@ -77,6 +77,7 @@ defmodule BrightWeb.OnboardingLive.SkillPanel do
     skill_class = SkillPanels.get_skill_class_by_skill_panel_id(id)
 
     socket
+    |> assign(:page_title, "スキルを選ぶ")
     |> assign(:skill_panel, skill_panel)
     |> assign(:career_field, List.first(career_fields))
     |> assign(:skill_units, skill_class.skill_units)

--- a/lib/bright_web/live/onboarding_live/skill_panels.ex
+++ b/lib/bright_web/live/onboarding_live/skill_panels.ex
@@ -79,6 +79,7 @@ defmodule BrightWeb.OnboardingLive.SkillPanels do
     |> assign(:route, "wants")
     |> assign(:return_to, "/#{current_path}?open=want_todo_panel")
     |> assign(:id, id)
+    |> assign(:page_title, "スキルを選ぶ")
     |> assign(:career_fields, career_fields)
     |> then(&{:noreply, &1})
   end


### PR DESCRIPTION
タイトルママ
αはスキルを選ぶのリンクから飛ぶのでスキルアップではなく、タイトルをスキルを選ぶとしている