### PR TITLE
成長グラフ/スキルパネル 「スキルを選ぶ」リンクを追加

### DIFF
--- a/lib/bright_web/live/skill_panel_live/graph.html.heex
+++ b/lib/bright_web/live/skill_panel_live/graph.html.heex
@@ -51,9 +51,9 @@
     </div>
   </div>
 </div>
+
 <% else %>
-<div class="h-screen w-full flex flex-col justify-center items-center gap-y-2">
-  <p class="text-4xl">スキルパネルがありません</p>
-  <p class="text-xl">スキルを選ぶからスキルパネルを取得しましょう</p>
-</div>
+
+<.no_skill_panel />
+
 <% end %>

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -1,5 +1,5 @@
 defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
-  use Phoenix.Component
+  use BrightWeb, :component
   import BrightWeb.ChartComponents
   import BrightWeb.ProfileComponents
   import BrightWeb.MegaMenuComponents
@@ -300,6 +300,18 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
           </button>
         </div>
       </div>
+    """
+  end
+
+  def no_skill_panel(assigns) do
+    ~H"""
+    <div class="h-screen w-full flex flex-col justify-center items-center gap-y-2">
+      <p class="text-4xl">スキルパネルがありません</p>
+      <p class="text-xl">スキルを選ぶからスキルパネルを取得しましょう</p>
+      <a href={~p"/onboardings"} class="text-xl cursor-pointer bg-brightGray-900 !text-white font-bold px-6 py-4 rounded mt-10 hover:opacity-50">
+      スキルを選ぶ
+      </a>
+    </div>
     """
   end
 

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -78,9 +78,9 @@
     <iframe id="iframe-skill-exam" src={@skill_exam.url} phx-hook="IframeSizeFitting" />
   </div>
 </.bright_modal>
+
 <% else %>
-<div class="h-screen w-full flex flex-col justify-center items-center gap-y-2">
-  <p class="text-4xl">スキルパネルがありません</p>
-  <p class="text-xl">スキルを選ぶからスキルパネルを取得しましょう</p>
-</div>
+
+<.no_skill_panel />
+
 <% end %>

--- a/test/bright_web/live/skill_panel_live/graph_test.exs
+++ b/test/bright_web/live/skill_panel_live/graph_test.exs
@@ -46,9 +46,16 @@ defmodule BrightWeb.SkillPanelLive.GraphTest do
     setup [:register_and_log_in_user]
 
     test "show content with no skill panel message", %{conn: conn} do
-      {:ok, _show_live, html} = live(conn, ~p"/graphs")
+      {:ok, show_live, html} = live(conn, ~p"/graphs")
 
       assert html =~ "スキルパネルがありません"
+
+      show_live
+      |> element("a", "スキルを選ぶ")
+      |> render_click()
+
+      {path, _} = assert_redirect(show_live)
+      assert path == "/onboardings"
     end
   end
 end

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -142,9 +142,16 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
     setup [:register_and_log_in_user]
 
     test "show content with no skill panel message", %{conn: conn} do
-      {:ok, _show_live, html} = live(conn, ~p"/panels")
+      {:ok, show_live, html} = live(conn, ~p"/panels")
 
       assert html =~ "スキルパネルがありません"
+
+      show_live
+      |> element("a", "スキルを選ぶ")
+      |> render_click()
+
+      {path, _} = assert_redirect(show_live)
+      assert path == "/onboardings"
     end
   end
 


### PR DESCRIPTION
## 対応内容

表題の通りです。参考画像のようにリンクボタンを追加しました。

## 参考画像

![image](https://github.com/bright-org/bright/assets/121112529/92179171-0098-4e45-a128-3d1012e8a123)

- メッセージサイズに合わせて、[Figma](https://www.figma.com/file/q9SVY4YWjijOrgsQtJjlD6/Bright?type=design&node-id=605-2531&mode=design&t=el3sz1bVvKwCc9P0-4)よりボタンを大きくしました。