### PR TITLE
成長グラフ/スキルパネル スキルパネルを１つも保有していない対象者切り替え時のエラー対応

### DIFF
--- a/lib/bright_web/live/skill_panel_live/graph.ex
+++ b/lib/bright_web/live/skill_panel_live/graph.ex
@@ -48,11 +48,21 @@ defmodule BrightWeb.SkillPanelLive.Graph do
 
   @impl true
   def handle_event("click_on_related_user_card_menu", params, socket) do
+    skill_panel = socket.assigns.skill_panel
     # TODO: チームメンバー以外の対応時に匿名に注意すること
+    # TODO: 参照可能なユーザーかどうかの判定を行うこと
     user = Bright.Accounts.get_user_by_name(params["name"])
 
-    # 参照可能なユーザーかどうかの判定は遷移先で行うので必要ない
-    {:noreply, push_redirect(socket, to: ~p"/graphs/#{socket.assigns.skill_panel}/#{user.name}")}
+    get_path_to_switch_display_user("graphs", user, skill_panel, false)
+    |> case do
+      {:ok, path} ->
+        {:noreply, push_redirect(socket, to: path)}
+
+      :error ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "選択された対象者がスキルパネルを保有していないため、対象者を表示できません")}
+    end
   end
 
   def handle_event("clear_display_user", _params, socket) do

--- a/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
@@ -50,6 +50,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
       socket
       |> assign(:skill_panel, skill_panel)
     else
+      # TODO: この正規の導線はなくなった見込み。自動テストを補充後に削除して、`raise_if_not_exists_my_skill_panel`と統合し、404を返すこと
       # 指定されているスキルパネルがない場合は、
       # 直近のスキルパネルを取得して、
       # URLと矛盾した表示にならないようにリダイレクト
@@ -237,6 +238,22 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
     |> case do
       nil -> "/#{root}"
       _ -> "/#{root}/#{skill_panel.id}"
+    end
+  end
+
+  def get_path_to_switch_display_user(root, user, skill_panel, anonymous) do
+    display_user_skill_panel =
+      SkillPanels.get_user_skill_panel(user, skill_panel.id) ||
+        SkillPanels.get_user_latest_skill_panel(user)
+
+    display_user_skill_panel
+    |> case do
+      nil ->
+        # 保有スキルパネルが1つもない場合は表示不可のためpathを返さない
+        :error
+
+      _ ->
+        {:ok, build_path(root, skill_panel, user, false, anonymous)}
     end
   end
 

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -127,11 +127,22 @@ defmodule BrightWeb.SkillPanelLive.Skills do
   end
 
   def handle_event("click_on_related_user_card_menu", params, socket) do
+    skill_panel = socket.assigns.skill_panel
     # TODO: チームメンバー以外の対応時に匿名に注意すること
+    # TODO: 参照可能なユーザーかどうかの判定を行うこと
     user = Bright.Accounts.get_user_by_name(params["name"])
 
-    # 参照可能なユーザーかどうかの判定は遷移先で行うので必要ない
-    {:noreply, push_redirect(socket, to: ~p"/panels/#{socket.assigns.skill_panel}/#{user.name}")}
+    get_path_to_switch_display_user("panels", user, skill_panel, false)
+    |> case do
+      {:ok, path} ->
+        # 参照可能なユーザーかどうかの判定は遷移先で行う
+        {:noreply, push_redirect(socket, to: path)}
+
+      :error ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "選択された対象者がスキルパネルを保有していないため、対象者を表示できません")}
+    end
   end
 
   def handle_event("clear_display_user", _params, socket) do


### PR DESCRIPTION
## 対応内容

対象者切り替えで保有スキルパネルがないユーザーを指定するとエラーになるため対応しました。
flashを出しています。

ケースとしてはレアだろうと思いますが、登録したてのユーザー（オンボーディングが終わっていないなど）を指定した際などに発生します。

## 参考画像

![sample34](https://github.com/bright-org/bright/assets/121112529/c2e53f62-4c7c-449f-9b44-d8b61149aef5)

