### PR TITLE
チームスキル分析画面のバグ修正

### DIFF
--- a/lib/bright_web/live/team_live/my_team_live.ex
+++ b/lib/bright_web/live/team_live/my_team_live.ex
@@ -67,7 +67,7 @@ defmodule BrightWeb.MyTeamLive do
     %{page_number: _page, total_pages: _total_pages, entries: skill_panels} =
       SkillPanels.list_team_member_users_skill_panels(display_team.id, 1)
 
-      List.first(skill_panels)
+    List.first(skill_panels)
   end
 
   defp get_display_skill_panel(_params, _display_team) do


### PR DESCRIPTION
チーム作成済、かつ、メンバーが一人もスキルパネルを取得していない場合のパターンマッチバグを修正