### PR TITLE
スキルパネル 「個人と比較」で同一ユーザーを一覧に追加不可とする対応

### DIFF
--- a/lib/bright_web/components/bright_core_components.ex
+++ b/lib/bright_web/components/bright_core_components.ex
@@ -10,8 +10,6 @@ defmodule BrightWeb.BrightCoreComponents do
   import BrightWeb.CoreComponents,
     only: [
       icon: 1,
-      show: 1,
-      hide: 1,
       hide: 2,
       translate_error: 1,
       error: 1
@@ -73,16 +71,6 @@ defmodule BrightWeb.BrightCoreComponents do
     ~H"""
     <.flash kind={:info} title="Success!" flash={@flash} />
     <.flash kind={:error} title="Error!" flash={@flash} />
-    <.flash
-      id="disconnected"
-      kind={:error}
-      title="We can't find the internet"
-      phx-disconnected={show("#disconnected")}
-      phx-connected={hide("#disconnected")}
-      hidden
-    >
-      Attempting to reconnect <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
-    </.flash>
     """
   end
 


### PR DESCRIPTION
## 対応内容

refs: https://github.com/orgs/bright-org/projects/3/views/2?filterQuery=tato&pane=issue&itemId=37302070

選択一覧にはでるが、選択しても追加されないこと

## 参考画面

![sample35](https://github.com/bright-org/bright/assets/121112529/72bf591a-e756-455d-ab5f-38eab71297bc)

（「個人と比較」を連続でクリックすると反応しない現象は、別途対応します）
