### PR TITLE
チーム分析のアイコンを丸くする

### DIFF
--- a/lib/bright_web/live/team_live/team_member_skill_card_component.ex
+++ b/lib/bright_web/live/team_live/team_member_skill_card_component.ex
@@ -26,7 +26,7 @@ defmodule BrightWeb.TeamMemberSkillCardComponent do
           <div class="text-2xl font-bold">
             <%= assigns.display_skill_card.user.name %>
           </div>
-            <div class="bg-test bg-contain h-20 w-20 mt-4"
+            <div class="bg-test bg-contain h-20 w-20 mt-4 rounded-full"
             style={"background-image: url('#{icon_url(assigns.display_skill_card.user.user_profile.icon_file_path)}');"}
             >
             </div>


### PR DESCRIPTION
修正後
![a](https://github.com/bright-org/bright/assets/13599847/7084c378-7ef5-4917-88e7-cf4e58c5f0d1)

修正前
![b](https://github.com/bright-org/bright/assets/13599847/da9aed4e-6425-48dc-b024-eb220a69bd88)
