### PR TITLE
ドロップダウンのHook化

### DIFF
--- a/assets/js/hooks/Dropdown.js
+++ b/assets/js/hooks/Dropdown.js
@@ -1,0 +1,44 @@
+// ドロップダウンのJS実行。下記を改善するためにHookとして用意
+// Flowbiteはdata属性に基づいて自動実行されるが、
+// phx-updateでドロップダウンが閉じるとその後のクリック操作が意図と反する。
+//
+// refs:
+// https://flowbite.com/docs/components/dropdowns/#more-examples
+
+import {Dropdown as FlowbiteDropdown} from 'flowbite';
+
+const Dropdown = {
+  // 画面状態とdropdownの内部状態を合わせる処理
+  displayDropdown(dropdown, targetEl){
+    if(targetEl.classList.contains("hidden")){
+      dropdown.hide()
+    }
+    if(targetEl.classList.contains("block")){
+      dropdown.show()
+    }
+  },
+
+  mounted() {
+    this.triggerEl = this.el.querySelector(".dropdownTrigger")
+    this.targetEl = this.el.querySelector(".dropdownTarget")
+    const offset = this.el.dataset.dropdownOffsetSkidding
+    const placement = this.el.dataset.dropdownPlacement
+
+    this.options = {
+      triigerType: 'click',
+      placement: placement,
+      offsetSkidding: parseInt(offset),
+      delay: 300,
+      ignoreClickOutsideClass: false
+    }
+
+    this.dropdown = new FlowbiteDropdown(this.targetEl, this.triggerEl, this.options)
+    this.displayDropdown(this.dropdown, this.targetEl)
+  },
+
+  updated() {
+    this.displayDropdown(this.dropdown, this.targetEl)
+  }
+}
+
+export default Dropdown

--- a/assets/js/hooks/index.js
+++ b/assets/js/hooks/index.js
@@ -3,6 +3,7 @@ import {GrowthGraph} from './GrowthGraph.js'
 import {DoughnutGraph} from './DoughnutGraph.js'
 import IframeSizeFitting from './IframeSizeFitting.js'
 import TabSlideScroll from './TabSlideScroll.js'
+import Dropdown from './Dropdown.js'
 
 export const Hooks = {
   SkillGem: SkillGem,
@@ -10,4 +11,5 @@ export const Hooks = {
   DoughnutGraph: DoughnutGraph,
   IframeSizeFitting: IframeSizeFitting,
   TabSlideScroll: TabSlideScroll,
+  Dropdown: Dropdown
 }

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -75,62 +75,64 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
 
   def compare_individual(assigns) do
     ~H"""
-    <button
-      id="addCompareDropdownButton-related-user"
-      data-dropdown-toggle="addCompareDropdown-related-user"
-      data-dropdown-offset-skidding="300"
-      data-dropdown-placement="bottom"
-      class="border border-brightGray-200 rounded-md py-1.5 pl-3 flex items-center"
-      type="button"
-    >
-      <span class="min-w-[6em]">個人と比較</span>
-      <span
-        class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-7px] before:bg-brightGray-200 before:w-[1px] before:h-[38px]"
-        >add</span>
-    </button>
-    <!-- 個人と比較Donwdrop -->
     <div
-      class="bg-white rounded-md mt-1 w-[750px] bottom border-brightGray-100 border shadow-md hidden"
-      id="addCompareDropdown-related-user"
+      id="compare-indivividual-dropdown"
+      phx-hook="Dropdown"
+      data-dropdown-offset-skidding="307"
+      data-dropdown-placement="bottom"
     >
-      <.live_component
-        id="related-user-card-compare"
-        module={BrightWeb.CardLive.RelatedUserCardComponent}
-        current_user={@current_user}
-        display_menu={false}
-        purpose="compare"
-        card_row_click_target={@myself}
-      />
+      <button
+        class="dropdownTrigger border border-brightGray-200 rounded-md py-1.5 pl-3 flex items-center"
+        type="button"
+      >
+        <span class="min-w-[6em]">個人と比較</span>
+        <span
+          class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-7px] before:bg-brightGray-200 before:w-[1px] before:h-[38px]"
+          >add</span>
+      </button>
+      <div
+        class="dropdownTarget bg-white rounded-md mt-1 w-[750px] bottom border-brightGray-100 border shadow-md hidden"
+      >
+        <.live_component
+          id="related-user-card-compare"
+          module={BrightWeb.CardLive.RelatedUserCardComponent}
+          current_user={@current_user}
+          display_menu={false}
+          purpose="compare"
+          card_row_click_target={@myself}
+        />
+      </div>
     </div>
     """
   end
 
   def compare_team(assigns) do
     ~H"""
-    <button
-      id="compareAllDropdownButton"
-      data-dropdown-toggle="compareAllDropdown"
-      data-dropdown-offset-skidding="300"
-      data-dropdown-placement="bottom"
-      class="border border-brightGray-200 rounded-md py-1.5 pl-3 flex items-center"
-      type="button"
-    >
-      <span class="min-w-[6em]">チーム全員と比較</span>
-      <span
-        class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-7px] before:bg-brightGray-200 before:w-[1px] before:h-[38px]"
-        >add</span>
-    </button>
-    <!-- チーム全員と比較Downdrop -->
     <div
-      class="bg-white rounded-md mt-1 w-[750px] border border-brightGray-100 shadow-md hidden"
-      id="compareAllDropdown"
+      id="compare-team-dropdown"
+      phx-hook="Dropdown"
+      data-dropdown-offset-skidding="307"
+      data-dropdown-placement="bottom"
     >
-      <.live_component
-        id="related_team_card_compare"
-        module={BrightWeb.CardLive.RelatedTeamCardComponent}
-        current_user={@current_user}
-        show_menu={false}
-      />
+      <button
+        class="dropdownTrigger border border-brightGray-200 rounded-md py-1.5 pl-3 flex items-center"
+        type="button"
+      >
+        <span class="min-w-[6em]">チーム全員と比較</span>
+        <span
+          class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-7px] before:bg-brightGray-200 before:w-[1px] before:h-[38px]"
+          >add</span>
+      </button>
+      <div
+        class="dropdownTarget bg-white rounded-md mt-1 w-[750px] border border-brightGray-100 shadow-md hidden"
+      >
+        <.live_component
+          id="related_team_card_compare"
+          module={BrightWeb.CardLive.RelatedTeamCardComponent}
+          current_user={@current_user}
+          show_menu={false}
+        />
+      </div>
     </div>
     """
   end


### PR DESCRIPTION
## 対応内容

LiveViewによる更新時に二回押さないと開かなくなる現象への対応になります。
Hookに移して `updated()` で適当な処理をいれるようにしました。
その他使用箇所については、本PRで練ってマージされた後に対応します。

## 参考画面

**変更前**

「個人と比較」でユーザー追加後に、再度クリックしてもドロップダウンが開かない。

![sample38](https://github.com/bright-org/bright/assets/121112529/42578162-998b-4f20-827c-ca923e172f50)


**変更後**

=> 開く。

![sample39](https://github.com/bright-org/bright/assets/121112529/d51d685e-974c-49ca-9d8d-173ff60c8d2d)
