### PR TITLE
スキルを選択のリンクを more_skillsに変更

### DIFF
--- a/lib/bright_web/components/layout_components.ex
+++ b/lib/bright_web/components/layout_components.ex
@@ -106,7 +106,7 @@ defmodule BrightWeb.LayoutComponents do
 
   def links() do
     [
-      {"スキルを選ぶ", "/onboardings"},
+      {"スキルを選ぶ", "/more_skills"},
       {"成長を見る・比較する", "/graphs"},
       {"スキルパネルを入力", "/panels"},
       # TODO α版はskill_upを表示しない

--- a/lib/bright_web/live/onboarding_live/index.ex
+++ b/lib/bright_web/live/onboarding_live/index.ex
@@ -85,5 +85,5 @@ defmodule BrightWeb.OnboardingLive.Index do
 
   defp page_title("/onboardings"), do: "オンボーディング"
   # αはスキルを選ぶにしておく
-  defp page_title("/skill_up"), do: "スキルを選ぶ"
+  defp page_title("/more_skills"), do: "スキルを選ぶ"
 end

--- a/lib/bright_web/router.ex
+++ b/lib/bright_web/router.ex
@@ -171,11 +171,11 @@ defmodule BrightWeb.Router do
            :notification_detail
 
       live "/searches", MypageLive.Index, :search
-      live "/skill_up", OnboardingLive.Index, :index
-      live "/skill_up/wants/:want_id", OnboardingLive.SkillPanels
-      live "/skill_up/wants/:want_id/skill_panels/:id", OnboardingLive.SkillPanel
-      live "/skill_up/jobs/:job_id", OnboardingLive.SkillPanels
-      live "/skill_up/jobs/:job_id/skill_panels/:id", OnboardingLive.SkillPanel
+      live "/more_skills", OnboardingLive.Index, :index
+      live "/more_skills/wants/:want_id", OnboardingLive.SkillPanels
+      live "/more_skills/wants/:want_id/skill_panels/:id", OnboardingLive.SkillPanel
+      live "/more_skills/jobs/:job_id", OnboardingLive.SkillPanels
+      live "/more_skills/jobs/:job_id/skill_panels/:id", OnboardingLive.SkillPanel
       live "/graphs", SkillPanelLive.Graph, :show
       live "/graphs/:skill_panel_id", SkillPanelLive.Graph, :show
       live "/graphs/:skill_panel_id/:user_name", SkillPanelLive.Graph, :show

--- a/lib/bright_web/user_auth.ex
+++ b/lib/bright_web/user_auth.ex
@@ -222,7 +222,7 @@ defmodule BrightWeb.UserAuth do
   def on_mount(:redirect_if_onboarding_finished, _params, _session, socket) do
     if socket.assigns.current_user.user_onboardings do
       socket
-      |> Phoenix.LiveView.redirect(to: ~p"/skill_up")
+      |> Phoenix.LiveView.redirect(to: ~p"/more_skills")
       |> then(&{:halt, &1})
     else
       {:cont, socket}
@@ -285,7 +285,7 @@ defmodule BrightWeb.UserAuth do
   def redirect_if_onboarding_finished(conn, _ops) do
     if Accounts.onboarding_finished?(conn.assigns[:current_user]) do
       conn
-      |> redirect(to: ~p"/skill_up")
+      |> redirect(to: ~p"/more_skills")
       |> halt()
     else
       conn

--- a/test/bright_web/user_auth_test.exs
+++ b/test/bright_web/user_auth_test.exs
@@ -368,7 +368,7 @@ defmodule BrightWeb.UserAuthTest do
       insert(:user_onboarding, user: user)
       conn = conn |> assign(:current_user, user) |> UserAuth.redirect_if_onboarding_finished([])
       assert conn.halted
-      assert redirected_to(conn) == ~p"/skill_up"
+      assert redirected_to(conn) == ~p"/more_skills"
     end
 
     test "does not redirect if user is not authenticated", %{conn: conn, user: user} do


### PR DESCRIPTION
スキルを選択のリンクを more_skillsに変更・統一しました
サイドメニューのスキルを選ぶ  onboarding -> more_skills
ルーティングの skill_up -> more_skills

skill_upはβで別機能として実装されます

これに伴いサイドメニューの選択状態にならない不具合が解消されました
![スクリーンショット 2023-09-04 17 01 09](https://github.com/bright-org/bright/assets/91950/3d69ee2a-f1be-4eaf-9f3b-bf1b23db33e3)
