### PR TITLE
スキルパネル クラスレベル変化時の保有スキルカード更新に対応

### DIFF
--- a/lib/bright_web/live/card_live/skill_card_component.ex
+++ b/lib/bright_web/live/card_live/skill_card_component.ex
@@ -224,7 +224,7 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
     |> then(&{:ok, &1})
   end
 
-  def update(%{status: "level_up"}, socket) do
+  def update(%{status: "level_changed"}, socket) do
     # 新しいスキルクラスを開放時のupdateを実施
     %{
       selected_tab: career_field,

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -66,18 +66,16 @@ defmodule BrightWeb.SkillPanelLive.Skills do
       |> Map.values()
       |> Enum.filter(& &1.changed)
 
-    {:ok, updated_result} =
-      SkillScores.update_skill_scores(socket.assigns.current_user, target_skill_scores)
+    {:ok, _} = SkillScores.update_skill_scores(socket.assigns.current_user, target_skill_scores)
 
     skill_class_score = SkillScores.get_skill_class_score!(socket.assigns.skill_class_score.id)
 
-    # スキルクラス解放時に保有スキルカードの更新を通知
-    if get_in(updated_result, [
-         :skill_class_scores,
-         :"skill_class_score_#{skill_class_score.id}",
-         :level_up_skill_class_score
-       ]) do
-      send_update(SkillCardComponent, id: "skill_card", status: "level_up")
+    # スキルクラスのレベル変更時に保有スキルカードの表示変更を通知
+    prev_level = socket.assigns.skill_class_score.level
+    new_level = skill_class_score.level
+
+    if prev_level != new_level do
+      send_update(SkillCardComponent, id: "skill_card", status: "level_changed")
     end
 
     {:noreply,


### PR DESCRIPTION
## 対応内容

スキルクラスのレベルが変化した際に、保有スキルカード（メガメニュー）が更新されていない現象に対応しました。

レベルアップ時は下記のPRで対応済みでしたが、レベルで表記が変わるのを失念していました。
https://github.com/bright-org/bright/pull/789

## 参考画像

下記は、「平均」から「ベテラン」にレベル変化した際に、メガメニューがかわる、シナリオです。

![sample40](https://github.com/bright-org/bright/assets/121112529/58e2370d-c691-4cfd-bb07-32fa20ba33e8)
