### PR TITLE
ドロップダウンのHook化の各所対応

### DIFF
--- a/lib/bright_web/components/mega_menu_components.ex
+++ b/lib/bright_web/components/mega_menu_components.ex
@@ -33,29 +33,30 @@ defmodule BrightWeb.MegaMenuComponents do
 
   def mega_menu_button(assigns) do
     ~H"""
-    <button
-      id={"dropdownOffsetButton#{@id}"}
-      data-dropdown-toggle={"dropdownOffset#{@id}"}
+    <div
+      id={"dropdown-#{@id}"}
+      phx-hook="Dropdown"
       data-dropdown-offset-skidding={@dropdown_offset_skidding}
       data-dropdown-placement="bottom"
-      class="text-white bg-brightGreen-300 rounded-sm py-1.5 pl-3 flex items-center font-bold"
-      type="button"
     >
-      <span class="min-w-[6em]">
-        <%= @label %>
-      </span>
-      <span
-        class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-8px] before:bg-brightGray-50 before:w-[1px] before:h-[42px]">
-        expand_more
-      </span>
-    </button>
+      <button
+        class="dropdownTrigger text-white bg-brightGreen-300 rounded-sm py-1.5 pl-3 flex items-center font-bold"
+        type="button"
+      >
+        <span class="min-w-[6em]">
+          <%= @label %>
+        </span>
+        <span
+          class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-8px] before:bg-brightGray-50 before:w-[1px] before:h-[42px]">
+          expand_more
+        </span>
+      </button>
 
-    <!-- メガメニューの内容 -->
-    <div
-      id={"dropdownOffset#{@id}"}
-      class="z-10 hidden bg-white rounded-sm shadow w-[750px]"
-    >
-      <%= render_slot(@inner_block) %>
+      <div
+        class="dropdownTarget z-10 hidden bg-white rounded-sm shadow w-[750px]"
+      >
+        <%= render_slot(@inner_block) %>
+      </div>
     </div>
     """
   end

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -91,7 +91,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
           >add</span>
       </button>
       <div
-        class="dropdownTarget bg-white rounded-md mt-1 w-[750px] bottom border-brightGray-100 border shadow-md hidden"
+        class="dropdownTarget bg-white rounded-md mt-1 w-[750px] bottom border-brightGray-100 border shadow-md hidden z-10"
       >
         <.live_component
           id="related-user-card-compare"
@@ -124,7 +124,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
           >add</span>
       </button>
       <div
-        class="dropdownTarget bg-white rounded-md mt-1 w-[750px] border border-brightGray-100 shadow-md hidden"
+        class="dropdownTarget bg-white rounded-md mt-1 w-[750px] border border-brightGray-100 shadow-md hidden z-10"
       >
         <.live_component
           id="related_team_card_compare"
@@ -138,6 +138,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
   end
 
   def compare_custom_group(assigns) do
+    # TODO: 実装時、dropdownにHookを使うこと
     ~H"""
     <button
       id="addCustomGroupDropwonButton"


### PR DESCRIPTION
## 対応内容

#811 での対応内容をメガメニューまわりに反映しました。

遷移なしでドロップダウンを閉じると、次回一回で開けないという同様の現象を解消しています。


## 参考画像

**対応前**

flashを出すようなケース（遷移なし）で、次のクリックで開かない。

![sample42](https://github.com/bright-org/bright/assets/121112529/98eb55cb-f94d-4d35-aa5d-09db2b31185d)

**対応後**

![sample41](https://github.com/bright-org/bright/assets/121112529/12a0ad5f-61b3-4ce7-b133-8ebedb872f22)
