### PR TITLE
スキルパネル スキルスコアが存在しないケースのテスト追加

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -372,7 +372,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
     [Map.get(@score_mark, mark), get_in(@score_mark_color, [color, mark])]
   end
 
-  def profile_score_stats(assigns) do
+  defp profile_score_stats(assigns) do
     ~H"""
     <div id="profile_score_stats" class="h-20 mt-5 ml-2 flex flex-wrap">
       <p class="text-brightGreen-300 font-bold w-full flex mt-2 mb-1">

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -134,7 +134,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
 
       # ２つのスキルのうち、１つのみスキルスコアを生成
       [%{skills: [skill_1, _skill_2]}] = insert_skill_categories_and_skills(skill_unit, [2])
-      build(:skill_score, user: user, skill: skill_1) |> make_fullmark() |> insert()
+      insert(:full_mark_skill_score, user: user, skill: skill_1)
 
       {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}")
 

--- a/test/factories/skill_score_factory.ex
+++ b/test/factories/skill_score_factory.ex
@@ -25,8 +25,8 @@ defmodule Bright.SkillScoreFactory do
         }
       end
 
-      def make_fullmark(%SkillScore{} = skill_score) do
-        skill_score
+      def full_mark_skill_score_factory do
+        init_skill_score_factory()
         |> Map.merge(%{
           score: :high,
           exam_progress: :done,


### PR DESCRIPTION
refs #619 

## 対応内容

スキルスコアの初期化タイミングが変わるので、その事前準備となります。
大きくなりそうなので、ひとまず分けれるところで分けました。

（テストを作ってそれが落ちると思ったら落ちなかったというオチで、現状確認みたいなテストになりましたが追加しています）