### PR TITLE
スキルパネル名のリンクを削除する

### DIFF
--- a/lib/bright_web/live/card_live/skill_card_component.ex
+++ b/lib/bright_web/live/card_live/skill_card_component.ex
@@ -119,9 +119,7 @@ defmodule BrightWeb.CardLive.SkillCardComponent do
     ~H"""
     <div class="flex">
       <div class="flex-1 text-left font-bold">
-        <.link href={PathHelper.skill_panel_path(@root, @skill_panel, @display_user, @me, @anonymous)}>
-          <%= @skill_panel.name %>
-        </.link>
+        <%= @skill_panel.name %>
       </div>
       <%= for skill_class <- @skill_classes do %>
         <.skill_gem


### PR DESCRIPTION
タイトル通り
![a](https://github.com/bright-org/bright/assets/13599847/89bd40ac-660e-49cc-8152-8782484f2326)
