### PR TITLE
チームカードにチームを作るボタンを追加

### DIFF
--- a/lib/bright_web/live/card_live/related_team_card_component.ex
+++ b/lib/bright_web/live/card_live/related_team_card_component.ex
@@ -197,7 +197,7 @@ defmodule BrightWeb.CardLive.RelatedTeamCardComponent do
       socket
       |> assign(:display_team, display_team)
       |> assign(:display_user, socket.assigns.display_user)
-      |> push_navigate(to: "/teams/#{display_team.id}")
+      |> redirect(to: "/teams/#{display_team.id}")
 
     {:noreply, socket}
   end

--- a/lib/bright_web/live/team_live/my_team_live.html.heex
+++ b/lib/bright_web/live/team_live/my_team_live.html.heex
@@ -105,7 +105,7 @@
   <.bright_modal
     id="create-team-modal"
     show={if @live_action in [:new, :edit] do true else false end}
-    on_cancel={JS.patch(~p"/teams")}
+    on_cancel={JS.push("cancel_team_create")}
   >
     <.live_component
       module={BrightWeb.TeamCreateLiveComponent}


### PR DESCRIPTION
## チームを作るボタンを追加

### チームに所属していない場合にのみボタン表示

![image](https://github.com/bright-org/bright/assets/45676464/ee4905bf-00f9-41a8-9ae1-0003d85fdf1c)

### メガメニュー時も同一の仕様

![image](https://github.com/bright-org/bright/assets/45676464/b887da69-db44-4ad4-810d-bf4a062b2bd2)


### クリック時はチームを作る(/teams/new)に遷移

![image](https://github.com/bright-org/bright/assets/45676464/8d393fc2-02ba-459a-bdb9-1024727e14b1)

## チーム作成モーダルの×ボタンの挙動を変更

チームの有無にかかわらずチームスキル分析(/teams)へ遷移(挙動のバリエーションを無くすため)
チーム作成時は作成したチームを指定してチームスキル分析(/teams/:team_id)に遷移(仕様変更なし)

![image](https://github.com/bright-org/bright/assets/45676464/a5dffc70-e373-4255-a714-dc73bbc9e3f3)

![image](https://github.com/bright-org/bright/assets/45676464/01b5f896-9f85-47ee-8732-3a997ad0cdba)



