### PR TITLE
#844 スキル保有がない場合の表示追加

### DIFF
--- a/lib/bright_web/live/team_live/my_team_live.ex
+++ b/lib/bright_web/live/team_live/my_team_live.ex
@@ -205,11 +205,6 @@ defmodule BrightWeb.MyTeamLive do
     # スキルが取得できていない場合、ダミーデータを設定
     map
     |> Map.put(:user_skill_class_score, nil)
-
-    # %{
-    #  skill_class: nil,
-    #  skill_class_score: 0
-    # })
   end
 
   defp add_user_skill_class_score(map, display_skill_classes, filterd_member_skill_classes) do

--- a/lib/bright_web/live/team_live/team_member_skill_card_component.ex
+++ b/lib/bright_web/live/team_live/team_member_skill_card_component.ex
@@ -15,7 +15,7 @@ defmodule BrightWeb.TeamMemberSkillCardComponent do
       <!-- メンバーデータ -->
         <div
           :if={is_nil(@display_skill_card.user_skill_class_score)}
-          class="h-[56px] bg-brightGreen-50"
+          class="h-[56px] bg-pureGray-600"
         >
         </div>
 


### PR DESCRIPTION
## スキル保有がないメンバーの文言表示追加

※ POにはSlackにてデザイン確認済

![image](https://github.com/bright-org/bright/assets/45676464/ace2956c-fc74-4213-b993-324d0d9f1a6e)

