### PR TITLE
#854 チーム未所属の場合のスキルカードのダミー追加

### DIFF
--- a/lib/bright_web/components/mega_menu_components.ex
+++ b/lib/bright_web/components/mega_menu_components.ex
@@ -9,18 +9,16 @@ defmodule BrightWeb.MegaMenuComponents do
   以下のattrを指定可能
 
   - id 画面内でメガメニューボタンを一意に識別できるID
-  - card_component 　一覧表示に使用するカードコンポーネント
   - label ボタンに表示する名称
-  - display_user  カードの取得に使用するユーザー
   - dropdown_offset_skidding ドロップダウンの描画オフセット(labelの文字数に応じて調整する必要がある)
-  - card_component liveComponentによるカード実装
-  - over_ride_on_card_row_click_target カードコンポーネント内の行クリック時のハンドラを呼び出し元のハンドラで実装するか否か falseの場合、本実装デフォルトの挙動(チームIDのみ指定してのチームスキル分析への遷移)を実行する
+  - menu_width ドロップダウンメニューの幅指定（デフォルトは750px）
 
   ## Examples
     <.mega_menu_button
       id="mega_menu_team"
       label="ボタンに表示する文言"
       dropdown_offset_skidding="307"
+      menu_width="w-[750px]"
     />
   """
 
@@ -29,6 +27,7 @@ defmodule BrightWeb.MegaMenuComponents do
   attr :id, :string, required: true
   attr :label, :string, required: true
   attr :dropdown_offset_skidding, :string, required: true
+  attr :menu_width, :string, required: false, default: "w-[750px]"
   slot :inner_block
 
   def mega_menu_button(assigns) do
@@ -53,7 +52,7 @@ defmodule BrightWeb.MegaMenuComponents do
       </button>
 
       <div
-        class="dropdownTarget z-10 hidden bg-white rounded-sm shadow w-[750px]"
+        class={"dropdownTarget z-10 hidden bg-white rounded-sm shadow #{@menu_width}"}
       >
         <%= render_slot(@inner_block) %>
       </div>

--- a/lib/bright_web/live/team_live/my_team_live.ex
+++ b/lib/bright_web/live/team_live/my_team_live.ex
@@ -403,10 +403,17 @@ defmodule BrightWeb.MyTeamLive do
 
     display_team = Teams.get_team_with_member_users!(team_id)
 
+    display_skill_panel_id =
+      if is_nil(socket.assigns.display_skill_panel) do
+        nil
+      else
+        socket.assigns.display_skill_panel.id
+      end
+
     socket =
       socket
       |> assign(:display_team, display_team)
-      |> deside_redirect(display_team, socket.assigns.display_skill_panel.id, nil)
+      |> deside_redirect(display_team, display_skill_panel_id, nil)
 
     {:noreply, socket}
   end

--- a/lib/bright_web/live/team_live/my_team_live.html.heex
+++ b/lib/bright_web/live/team_live/my_team_live.html.heex
@@ -19,6 +19,23 @@
     <p class="leading-tight">対象スキルの<br />切り替え</p>
     <!-- スキルパネル menu -->
     <.mega_menu_button
+      :if={is_nil(@display_team)}
+      id="mega_menu_skill_panel"
+      label="スキル"
+      dropdown_offset_skidding="156"
+      menu_width="w-[450px]"
+    >
+      <div
+        class="w-[440px] flex items-center text-base rounded"
+        >
+        <div class="text-left flex items-center text-base px-1 py-1 flex-1 m-2">所属しているチームはありません</div>
+          <a href="/teams/new" class="text-sm font-bold px-5 py-3 rounded text-white bg-base m-2">
+             チームを作る
+           </a>
+      </div>
+    </.mega_menu_button>
+    <.mega_menu_button
+      :if={!is_nil(@display_team)}
       id="mega_menu_skill_panel"
       label="スキル"
       dropdown_offset_skidding="307"
@@ -41,7 +58,7 @@
     <button
       data-modal-target="defaultModal"
       data-modal-toggle="defaultModal"
-      class="text-brightGreen-300 border bg-white border-brightGreen-300 rounded px-3 font-bold ml-auto"
+      class="text-sm font-bold px-5 py-3 rounded text-white bg-base ml-auto"
       phx-click={show_modal("create-team-modal")}
     >
       チームを作る


### PR DESCRIPTION
# チームに所属していない場合、専用のカードを表示する

![image](https://github.com/bright-org/bright/assets/45676464/0f7a7650-ec73-4270-9fa3-0888e771e8a7)

### 文言同線はチームのカードと同様

![image](https://github.com/bright-org/bright/assets/45676464/b1224546-9416-4503-8e06-2d63cf2fd509)

# ついでに右上固定のチームを作るボタンのデザイン変更も対応

![image](https://github.com/bright-org/bright/assets/45676464/601ab853-af5d-4719-85be-8acb69234899)




