### PR TITLE
ボタンの有効範囲を指定

### DIFF
--- a/lib/bright_web/components/sns_components.ex
+++ b/lib/bright_web/components/sns_components.ex
@@ -20,7 +20,7 @@ defmodule BrightWeb.SnsComponents do
 
   def sns(assigns) do
     ~H"""
-    <div class="flex gap-x-6 mr-2">
+    <div class="flex gap-x-6 mr-2 mt-1">
       <.icon_button sns_type="twitter" url={@twitter_url} />
       <.icon_button sns_type="github" url={@github_url} />
       <.icon_button sns_type="facebook" url={@facebook_url} />
@@ -43,7 +43,7 @@ defmodule BrightWeb.SnsComponents do
       |> assign(:url, "window.open('#{assigns.url}')")
 
     ~H"""
-    <button type="button" onclick={@url} class="flex">
+    <button type="button" onclick={@url} class="flex h-[26px]">
       <.icon sns_type={@sns_type} disable={false} />
     </button>
     """
@@ -58,7 +58,7 @@ defmodule BrightWeb.SnsComponents do
       |> assign(src: "/images/common/#{assigns.sns_type}#{disable_icon_suffix(assigns.disable)}")
 
     ~H"""
-    <img src={@src} class="w-[26px] h-[26px] mt-1" />
+    <img src={@src} class="w-[26px] h-[26px]" />
     """
   end
 


### PR DESCRIPTION
タイトル通り
修正前は、ボタンの有効範囲が「称号」の高さと同じであった

修正後

https://github.com/bright-org/bright/assets/13599847/6332ef2f-63bb-4b2c-a4f6-02c966d92f79

