### PR TITLE
window幅を1920固定に戻す

### DIFF
--- a/lib/bright_web/components/layouts/root.html.heex
+++ b/lib/bright_web/components/layouts/root.html.heex
@@ -1,5 +1,5 @@
 <.root_layout page_title={assigns[:page_title]} csrf_token={get_csrf_token()}>
-  <body class="max-w-[1920px]">
+  <body class="w-[1920px]">
     <div class="flex">
       <.side_menu  href={@conn.request_path} />
       <main class="bg-background flex flex-col flex-1">


### PR DESCRIPTION
経緯
https://digi-dock.slack.com/archives/C0550EENU86/p1694329294276699

![スクリーンショット 2023-09-11 11 51 26](https://github.com/bright-org/bright/assets/91950/0f4c7a5f-950e-4688-bdad-3e1b59f10f94)


ページ幅を小さくしても崩れないのを確認
![スクリーンショット 2023-09-11 11 50 23](https://github.com/bright-org/bright/assets/91950/63496baf-107d-4825-8806-501096da5fec)
