### PR TITLE
 タイトルを「スキルパネル」から「成長グラフ」に修正

### DIFF
--- a/lib/bright_web/live/graph_live/graphs.ex
+++ b/lib/bright_web/live/graph_live/graphs.ex
@@ -14,7 +14,7 @@ defmodule BrightWeb.GraphLive.Graphs do
      |> assign_display_user(params)
      |> assign_skill_panel(params["skill_panel_id"], "graphs")
      |> assign(:select_label, "now")
-     |> assign(:page_title, "スキルパネル")
+     |> assign(:page_title, "成長グラフ")
      |> assign_page_sub_title()}
   end
 


### PR DESCRIPTION
タイトル通り
![image](https://github.com/bright-org/bright/assets/13599847/8a52e6b9-c0ff-462c-b0fd-718f9d9a8a16)
