### PR TITLE
#871 チーム作成時にEnterをおすとメンバーの削除も発火するバグの修正

### DIFF
--- a/lib/bright_web/components/profile_components.ex
+++ b/lib/bright_web/components/profile_components.ex
@@ -153,7 +153,7 @@ defmodule BrightWeb.ProfileComponents do
         <div
           phx-click={JS.push("remove_user", value: %{id: @user_id})}
           phx-target={@remove_user_target}
-          class="mx-4"
+          class="mx-4 cursor-pointer"
         >
           <span
             class="material-icons !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center"


### PR DESCRIPTION
### フォーム内に配置したメンバーの削除ボタンが同時に発火指定していた

![image](https://github.com/bright-org/bright/assets/45676464/666bb5ec-ac25-4fa7-9a4e-f41110df85f3)

bottun -> カーソルポインターしていのdivに変更
