### PR TITLE
#876 ULIDのバリデータとparams処理時のハンドリング追加

### DIFF
--- a/lib/bright/teams.ex
+++ b/lib/bright/teams.ex
@@ -487,4 +487,12 @@ defmodule Bright.Teams do
 
     if Repo.exists?(query), do: true, else: raise(Ecto.NoResultsError, queryable: query)
   end
+
+  def raise_if_not_ulid(team_id) do
+    Ecto.ULID.cast(team_id)
+    |> case do
+      {:ok, _} -> nil
+      _ -> raise Ecto.NoResultsError, queryable: "Bright.Teams.Team"
+    end
+  end
 end

--- a/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
@@ -263,7 +263,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
     raise Ecto.NoResultsError, queryable: "Bright.SkillPanels.SkillClass"
   end
 
-  defp raise_if_not_ulid(ulid) do
+  def raise_if_not_ulid(ulid) do
     # スキルパネルの指定が不正だった場合は404で返す。
     # 導線はなく、URLで指定される可能性がある。
     Ecto.ULID.cast(ulid)


### PR DESCRIPTION
チームスキル分析は
1. パラメータなし -> 優先度の高いチーム、スキルパネルで自動選択
/teams
2. チームIDのみ指定 -> 指定されたチームと優先度の高いスキルパネルで自動選択
/teams/:team_id
3.  チームID、スキルパネルID指定 -> 指定された内容で表示
/teams/:team_id/skill_panels/:skill_panel_id
とパターンが多く、かつ、自動選択の概念があるので、都合の悪いケースはすべて1と同じ挙動におとしている

URLパラメータについてもULIDチェックを追加したうえで不正な場合はすべて１に落とす実装とした
(そもそもAPIではないので直URL入力の不正に対して細かいハンドリングを実装したくない為)