### PR TITLE
RelatedUserCard 採用候補者クリック時の動作を各画面に対応

### DIFF
--- a/lib/bright_web/components/profile_components.ex
+++ b/lib/bright_web/components/profile_components.ex
@@ -184,14 +184,13 @@ defmodule BrightWeb.ProfileComponents do
   attr :skill_panel, :string, required: true
   attr :desired_income, :string, default: ""
   attr :encrypt_user_name, :string, required: true
+  attr :click_event, :string, default: ""
+  attr :click_target, :string, default: nil
 
   def profile_stock_small_with_remove_button(assigns) do
     ~H"""
     <li class="relative text-left flex items-center text-base p-1  bg-white w-1/2">
-      <.link
-        class="inline-flex items-center gap-x-6 w-full hover:bg-brightGray-50"
-        href={"/mypage/anon/#{@encrypt_user_name}"}
-      >
+      <.profile_stock_small_link click_event={@click_event} click_target={@click_target} encrypt_user_name={@encrypt_user_name}>
         <img
           class="inline-block h-10 w-10 rounded-full"
           src="/images/avatar.png"
@@ -200,32 +199,29 @@ defmodule BrightWeb.ProfileComponents do
           <p>検索：<%= @skill_panel %></p>
           <span class="text-brightGray-300">(<%= @stock_date %>)</span>
           <span class="text-brightGray-300">希望年収：<%= @desired_income %></span>
-
         </div>
-      </.link>
+      </.profile_stock_small_link>
       <button
-          phx-click={JS.push("remove_user", value: %{stock_id: @stock_id})}
-          phx-target={@remove_user_target}
-          class="absolute top-1 right-4"
-        >
-          <span class="material-icons bg-brightGray-900 !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center text-white">
-            close
-          </span>
-        </button>
-
+        phx-click={JS.push("remove_user", value: %{stock_id: @stock_id})}
+        phx-target={@remove_user_target}
+        class="absolute top-1 right-4"
+      >
+        <span class="material-icons bg-brightGray-900 !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center text-white">
+          close
+        </span>
+      </button>
     </li>
     """
   end
 
+  # 基本プロフィール マイページ遷移用リンク
   defp profile_small_link(%{click_event: nil} = assigns) do
     user_name =
       if assigns.encrypt_user_name == "",
         do: assigns.user_name,
         else: "anon/#{assigns.encrypt_user_name}"
 
-    assigns =
-      assigns
-      |> assign(:user_name, user_name)
+    assigns = assign(assigns, :user_name, user_name)
 
     ~H"""
     <a class="cursor-pointer inline-flex items-center gap-x-6" href={"/mypage/#{@user_name}"}>
@@ -236,6 +232,7 @@ defmodule BrightWeb.ProfileComponents do
     """
   end
 
+  # 基本プロフィール root LiveView用イベント
   defp profile_small_link(%{click_event: _, click_target: nil} = assigns) do
     ~H"""
     <a class="cursor-pointer inline-flex items-center gap-x-6" phx-click={@click_event} phx-value-name={@user_name} phx-value-encrypt_user_name={@encrypt_user_name}>
@@ -244,11 +241,53 @@ defmodule BrightWeb.ProfileComponents do
     """
   end
 
+  # 基本プロフィール LiveComponent用イベント
   defp profile_small_link(assigns) do
     ~H"""
     <a class="cursor-pointer inline-flex items-center gap-x-6" phx-click={@click_event} phx-target={@click_target} phx-value-name={@user_name} phx-value-encrypt_user_name={@encrypt_user_name}>
       <%= render_slot(@inner_block) %>
     </a>
+    """
+  end
+
+  # 採用候補者 マイページ遷移用リンク
+  defp profile_stock_small_link(%{click_event: nil} = assigns) do
+    ~H"""
+    <.link
+      class="inline-flex items-center gap-x-6 w-full hover:bg-brightGray-50"
+      href={"/mypage/anon/#{@encrypt_user_name}"}
+    >
+      <%= render_slot(@inner_block) %>
+    </.link>
+    """
+  end
+
+  # 採用候補者 root LiveView用イベント
+  # 成長グラフ／スキルパネルのメガメニューで利用
+  defp profile_stock_small_link(%{click_event: _, click_target: nil} = assigns) do
+    ~H"""
+    <.link
+      class="inline-flex items-center gap-x-6 w-full hover:bg-brightGray-50"
+      phx-click={@click_event}
+      phx-value-encrypt_user_name={@encrypt_user_name}
+    >
+      <%= render_slot(@inner_block) %>
+    </.link>
+    """
+  end
+
+  # 採用候補者 LiveComponent用イベント
+  # スキルパネル「個人と比較」で利用
+  defp profile_stock_small_link(assigns) do
+    ~H"""
+    <.link
+      class="inline-flex items-center gap-x-6 w-full hover:bg-brightGray-50"
+      phx-click={@click_event}
+      phx-target={@click_target}
+      phx-value-encrypt_user_name={@encrypt_user_name}
+    >
+      <%= render_slot(@inner_block) %>
+    </.link>
     """
   end
 end

--- a/lib/bright_web/live/card_live/related_user_card_component.ex
+++ b/lib/bright_web/live/card_live/related_user_card_component.ex
@@ -104,6 +104,8 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
                   desired_income={if user_profile.desired_income == 0, do: "-" ,else: user_profile.desired_income}
                   encrypt_user_name={encrypt_user_name(user_profile.user)}
                   remove_user_target={@myself}
+                  click_event={click_event(@purpose)}
+                  click_target={@card_row_click_target}
                 />
               <% end %>
             <% end %>


### PR DESCRIPTION
## 対応内容

採用候補者の表示を別コンポーネントにされた際に、すべてがリンクになってマイページへ飛ぶようになったようでしたので、改めて対応しました。

１．成長グラフ／スキルパネル画面の「個人」から採用候補者選択時
=> 成長グラフ／スキルパネル画面で該当ユーザーに切り替わること

２．スキルパネル画面の「個人と比較」から採用候補者選択時
=> スキル一覧で該当ユーザーが追加されること
