### PR TITLE
SkillGemが未定義に描画更新処理をさせない

### DIFF
--- a/assets/js/hooks/SkillGem.js
+++ b/assets/js/hooks/SkillGem.js
@@ -278,6 +278,7 @@ export const SkillGem = {
     this.drawRaderGraph(this.el)
   },
   updated() {
+    if (window.myRadar[this.el.id] == undefined) return
     window.myRadar[this.el.id].destroy()
     this.ctx.removeEventListener('click', this.clickEvent)
     this.drawRaderGraph(this.el)


### PR DESCRIPTION
タイトル通り

この修正はjsレベルでの回避であります
なので、必要に応じてelixir側で回避も必要ですがこのプルリクではelixir側は実施しません