### PR TITLE
SPログイン、ヘッダー周り修正

### DIFF
--- a/lib/bright_web/components/layouts/auth.html.heex
+++ b/lib/bright_web/components/layouts/auth.html.heex
@@ -1,6 +1,6 @@
 <.root_layout page_title={assigns[:page_title]} csrf_token={get_csrf_token()}>
   <body class="bg-background font-notosans">
-    <main class="flex h-screen items-center justify-center p-10 w-screen" role="main">
+    <main class="flex lg:h-screen items-center justify-center lg:p-10 w-screen" role="main">
       <section class="bg-white lg:-mt-10 p-10 rounded-lg w-full max-w-[390px] lg:max-w-[800px]">
         <%= @inner_content %>
       </section>


### PR DESCRIPTION
ヘッダーが見切れていたのを修正、paddingが２重に合ったので１つは削除
![スクリーンショット 2023-09-18 14 03 27](https://github.com/bright-org/bright/assets/91950/5c68a0d7-9916-4ccb-bb4a-c1b1023baa25)
![スクリーンショット 2023-09-18 14 03 33](https://github.com/bright-org/bright/assets/91950/a1d06c31-f0b3-4a01-b1d0-a1d760a3fa53)
