### PR TITLE
スキル保有者検索 スキルパネル側処理変更に伴う表示不具合対応

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
@@ -158,8 +158,8 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
   end
 
   def assign_skill_score_dict(socket) do
-    %{skill_class: skill_class, skill_class_score: skill_class_score} = socket.assigns
-    skills = SkillUnits.list_skills_on_skill_class(skill_class)
+    %{skill_class_score: skill_class_score} = socket.assigns
+    skills = SkillUnits.list_skills_on_skill_class(%{id: skill_class_score.skill_class_id})
 
     # skillからskill_scoreを引く辞書を生成
     # skillに対して未作成のときは、フォームの都合でStructで初期化


### PR DESCRIPTION
## 対応内容

スキル保有者の検索結果が表示されない不具合（他所PRの影響）対応です。

下記の傷害対応になります。
https://docs.google.com/spreadsheets/d/1OuTi-4y8Qk9RTscOl01UTHXkCNigxsa_OzykQhG8ctw/edit#gid=0&range=17:17

同じ処理を別のところで使っている処理（同件類似）はありませんでした。
（対応する自動テストを書くとなると最初からになりそうだったため含めていません）