### PR TITLE
検索スキルを追加するとデザインが崩れるのを修正

### DIFF
--- a/lib/bright_web/live/search_live/user_search_component.html.heex
+++ b/lib/bright_web/live/search_live/user_search_component.html.heex
@@ -116,6 +116,7 @@
 
   <div class="flex mt-4" id="skill_section">
     <span class="mt-2 w-32 text-start">スキルで絞り込む</span>
+    <div>
     <.inputs_for :let={sk} field={@form[:skills]} >
       <input type="hidden" name="user_search[skills_sort][]" value={sk.index}>
       <div class="flex items-center mb-4">
@@ -171,6 +172,7 @@
         --->
       </div>
     </.inputs_for>
+    </div>
   </div>
   <label class="block cursor-pointer" :if={Enum.count(@form[:skills].value) < 3}>
     <input type="checkbox" name="user_search[skills_sort][]" class="hidden" />


### PR DESCRIPTION
タイトルママ
inputs_forの前にdivがないと縦方向ではなく、横方向に要素が追加されてしまった

before

![スクリーンショット 2023-09-21 21 07 26](https://github.com/bright-org/bright/assets/91950/1b3d7f44-6805-433a-8ba5-3330d4ea6846)

after
![スクリーンショット 2023-09-21 21 19 40](https://github.com/bright-org/bright/assets/91950/2853269c-b2cc-4cc3-b8d4-400095ee3aaf)

