### PR TITLE
スキルパネル 過去スキル一覧でスキルユニット表示順が指定順になっていない不具合対応

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skills_field_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_field_component.ex
@@ -188,9 +188,11 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
     # 過去分のため存在しない可能性がある
     if historical_skill_class do
       skill_units =
-        Ecto.assoc(historical_skill_class, :historical_skill_units)
-        |> HistoricalSkillUnits.list_historical_skill_units()
-        |> Bright.Repo.preload(historical_skill_categories: [:historical_skills])
+        historical_skill_class
+        |> Bright.Repo.preload(
+          historical_skill_units: [historical_skill_categories: [:historical_skills]]
+        )
+        |> Map.get(:historical_skill_units)
 
       skills =
         skill_units


### PR DESCRIPTION
## 対応内容

障害対応です。
タイムラインで切り替えた過去スキルの表示順が正しくなっていなかったため対応しました。

障害表：https://docs.google.com/spreadsheets/d/11gDi3bzbaqlj7csk_4Gbmmn4LziW64V93JqJEw__JSQ/edit#gid=0&range=41:41
