### PR TITLE
スキルパネル 求職設定を促すメッセージの表示対応

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -6,3 +6,40 @@
 
 @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700;900&display=swap");
 @import url("https://fonts.googleapis.com/css?family=Material+Icons%7CMaterial+Icons+Outlined%7CMaterial+Icons+Round%7CMaterial+Icons+Sharp%7CMaterial+Icons+Two+Tone%7CMaterial+Symbols+Outlined");
+
+
+/* Skill panels */
+
+#arrow-to-job-searching {
+  position:relative;
+  width:38px;margin:0 auto;
+}
+
+#arrow-to-job-searching::before{
+  animation: arrow-to-job-searching 2.5s infinite;
+  border: solid #FF0000;
+  border-width:4px 4px 0 0;
+  content:"";
+  margin:auto;
+  position:absolute;
+  top:8px;
+  left:25px;
+  transform:rotate(-45deg);
+  width:20px;
+  height:20px;
+}
+
+@keyframes arrow-to-job-searching{
+  0%{
+    transform:rotate(-45deg) translate(0,0);
+  }
+  60%{
+    transform:rotate(-45deg) translate(30px,-30px);
+  }
+  0%,60%,100%{
+    opacity:0;
+  }
+  30%{
+    opacity:1;
+  }
+}

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -12,6 +12,7 @@ defmodule BrightWeb.SkillPanelLive.Skills do
   alias Bright.SkillEvidences
   alias Bright.SkillReferences
   alias Bright.SkillExams
+  alias Bright.UserJobProfiles
   alias BrightWeb.PathHelper
 
   @impl true
@@ -174,5 +175,11 @@ defmodule BrightWeb.SkillPanelLive.Skills do
     else
       socket
     end
+  end
+
+  defp user_job_searching?(user) do
+    user.id
+    |> UserJobProfiles.get_user_job_profile_by_user_id!()
+    |> Map.get(:job_searching)
   end
 end

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -94,8 +94,8 @@
 
   <% # スキル入力後メッセージ（初回のみ） %>
   <div
-    :if={Map.get(@flash, "first_time_submit")}
-    id="first_time_submit_message"
+    :if={Map.get(@flash, "first_submit_in_overall")}
+    id="first_submit_in_overall_message"
     class="absolute bg-designer-dazzle leading-normal px-4 py-2 right-0 rounded text-xs top-32 w-fit z-10">
     <div>
       <p>スキル入力完了おめでとうございます！</p>
@@ -109,13 +109,13 @@
       <button
         type="button"
         class="bg-brightGray-900 border border-brightGray-900 font-bold p-1 rounded text-white w-48"
-        phx-click={JS.push("lv:clear-flash", value: %{key: "first_time_submit"}) |> hide("#first_time_submit_message")}>
+        phx-click={JS.push("lv:clear-flash", value: %{key: "first_submit_in_overall"}) |> hide("#first_submit_in_overall_message")}>
         この説明は分かりやすい
       </button>
       <button
         type="button"
         class="bg-white border border-brightGray-900 font-bold p-1 rounded text-brightGray-900 w-24"
-        phx-click={JS.push("lv:clear-flash", value: %{key: "first_time_submit"}) |> hide("#first_time_submit_message")}>
+        phx-click={JS.push("lv:clear-flash", value: %{key: "first_submit_in_overall"}) |> hide("#first_submit_in_overall_message")}>
         わかりにくい
       </button>
     </div>
@@ -125,7 +125,7 @@
 
     <button
       class="absolute top-2 right-2"
-      phx-click={JS.push("lv:clear-flash", value: %{key: "first_time_submit"}) |> hide("#first_time_submit_message")}>
+      phx-click={JS.push("lv:clear-flash", value: %{key: "first_submit_in_overall"}) |> hide("#first_submit_in_overall_message")}>
       <span class="material-icons text-white bg-brightGray-900 rounded-full !text-sm w-5 h-5 flex justify-center items-center">close</span>
     </button>
   </div>
@@ -161,6 +161,17 @@
       phx-click={JS.push("lv:clear-flash", value: %{key: "next_skill_class_opened"}) |> hide("#next_skill_class_opened_message")}>
       <span class="material-icons text-white bg-brightGray-900 rounded-full !text-sm w-5 h-5 flex justify-center items-center">close</span>
     </button>
+  </div>
+
+  <% # 求職設定を促すメッセージ %>
+  <div
+    :if={Map.get(@flash, "first_submit_in_skill_panel") && !user_job_searching?(@current_user)}
+    id="job_searching_message"
+    class="flex absolute items-center right-4 -top-16 w-fit z-10">
+    <div class="bg-designer-dazzle flex leading-normal px-4 py-2 rounded text-xs w-fit">
+      <p>入力したスキルで就職や転職、副業などをご希望される場合は、上記の求職設定を行うと、スカウト検索であなたのスキルを必要とするプロジェクトから声がかかるようになります。</p>
+    </div>
+    <div id="arrow-to-job-searching" class="arrow ml-1"></div>
   </div>
 </div>
 


### PR DESCRIPTION
## 対応内容

issue close #917 

クラス１の初回スキル入力後、求職未設定のときに求職設定を促すメッセージと矢印を追加しています。

## 参考画像

（アニメーション表示。クリックなどしていません）

![sample45](https://github.com/bright-org/bright/assets/121112529/e52a349e-44c5-4679-affd-bcef42a64e41)
