### PR TITLE
スキルパネル 以前の編集ボタン除去と表示制御の追加

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -354,6 +354,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
           <.link
             :if={@display_skill_edit_button}
             patch={~p"/panels/#{@skill_panel}/edit?#{@query}"}
+            id="link-skills-form"
             class="flex items-center text-sm font-bold justify-center pl-6 py-3 relative rounded !text-white bg-brightGray-900 w-48 hover:opacity-50">
             <span class="absolute material-icons-outlined left-4 top-1/2 text-white !text-xl -translate-y-1/2">edit</span>
             スキル入力する

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -21,7 +21,7 @@
       skill_class_score={@skill_class_score}
       counter={@counter}
       num_skills={@num_skills}
-      display_skill_edit_button={true}
+      display_skill_edit_button={@me}
       skill_panel={@skill_panel}
       query={@query}
     />

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -200,19 +200,6 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
                 <p class="inline-flex flex-1 justify-center">
                   <%= if(@anonymous, do: "非表示", else: @display_user.name) %>
                 </p>
-
-                <.link
-                  :if={@editable}
-                  id="link-skills-form"
-                  patch={~p"/panels/#{@skill_panel}/edit?#{@query}"}
-                >
-                  <button
-                    type="button"
-                    class="bg-brightGreen-300 hover:bg-brightGray-100 rounded-full w-5 h-5 inline-flex items-center justify-center"
-                  >
-                    <span class="material-icons-outlined text-white hover:text-brightGray-900 !text-sm">edit</span>
-                  </button>
-                </.link>
               </div>
             </td>
             <td :for={user <- @compared_users} class="!border-l !border-brightGray-200">

--- a/lib/bright_web/live/skill_panel_live/skills_field_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_field_component.ex
@@ -35,7 +35,6 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
          path={@path}
          query={@query}
          display_user={@display_user}
-         editable={@editable}
          current_skill_dict={@current_skill_dict}
          current_skill_score_dict={@current_skill_score_dict}
          myself={@myself}
@@ -220,7 +219,6 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
     |> assign(num_skills: [])
     |> assign(compared_users_stats: %{})
     |> assign(compared_user_dict: %{})
-    |> assign(editable: false)
   end
 
   defp assign_on_timeline(socket, :now) do
@@ -234,7 +232,6 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
     |> assign_counter()
     |> assign_compared_user_dict_from_users()
     |> assign_compared_users_info()
-    |> assign(:editable, socket.assigns.me)
   end
 
   defp assign_on_timeline(socket, :future) do
@@ -242,7 +239,6 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
     socket
     |> assign(:tense, :future)
     |> assign_on_timeline(:now)
-    |> assign(editable: false)
   end
 
   defp assign_on_timeline(socket, :past) do
@@ -254,7 +250,6 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
     |> assign_counter()
     |> assign_compared_user_dict_from_users()
     |> assign_compared_users_info()
-    |> assign(:editable, false)
   end
 
   defp assign_skill_score_dict(%{assigns: %{historical_skill_class: nil}} = socket, _past) do


### PR DESCRIPTION
## 対応内容

#914 の漏れの対応です。

- 以前の編集ボタンの削除が必要だったので削除
- 新しい編集ボタンに表示ユーザーが自分のときだけ、表示という条件が抜けていたので追加
