### PR TITLE
スキルパネル 入力用モーダルにドーナツグラフと％を表示

### DIFF
--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -389,6 +389,15 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
 
       start_edit(show_live)
 
+      assert has_element?(show_live, "#doughnut_area_in_skills_form", "見習い")
+      assert has_element?(show_live, "#doughnut_area_in_skills_form .score-high-percentage", "0％")
+
+      assert has_element?(
+               show_live,
+               "#doughnut_area_in_skills_form .score-middle-percentage",
+               "0％"
+             )
+
       show_live
       |> element(~s{#skill-1-form [phx-window-keydown="shortcut"]})
       |> render_keydown(%{"key" => "1"})
@@ -400,6 +409,20 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       show_live
       |> element(~s{#skill-3-form [phx-window-keydown="shortcut"]})
       |> render_keydown(%{"key" => "2"})
+
+      assert has_element?(show_live, "#doughnut_area_in_skills_form", "ベテラン")
+
+      assert has_element?(
+               show_live,
+               "#doughnut_area_in_skills_form .score-high-percentage",
+               "66％"
+             )
+
+      assert has_element?(
+               show_live,
+               "#doughnut_area_in_skills_form .score-middle-percentage",
+               "33％"
+             )
 
       submit_form(show_live)
 
@@ -422,6 +445,15 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       show_live
       |> element(~s{#skill-3-form [phx-window-keydown="shortcut"]})
       |> render_keydown(%{"key" => "3"})
+
+      assert has_element?(show_live, "#doughnut_area_in_skills_form", "見習い")
+      assert has_element?(show_live, "#doughnut_area_in_skills_form .score-high-percentage", "0％")
+
+      assert has_element?(
+               show_live,
+               "#doughnut_area_in_skills_form .score-middle-percentage",
+               "0％"
+             )
 
       submit_form(show_live)
 


### PR DESCRIPTION
## 対応内容

スキルパネルのスコア入力用モーダルにドーナツグラフとレベルなどを表示するように対応しました。

![スクリーンショット 2023-09-27 102552](https://github.com/bright-org/bright/assets/121112529/febd790e-e98a-47b8-9bd7-9e1c37434bd1)
