### PR TITLE
同じスキルパネルのクラス違いを検索した場合に、タブを選択できない不具合修正

### DIFF
--- a/lib/bright_web/live/search_live/search_result_component.ex
+++ b/lib/bright_web/live/search_live/search_result_component.ex
@@ -123,8 +123,7 @@ defmodule BrightWeb.SearchLive.SearchResultComponent do
         %{"tab_name" => tab_name},
         %{assigns: %{skill_params: skill_params}} = socket
       ) do
-    selected_skill_panel =
-      Enum.find(skill_params, &("#{&1.skill_panel}_#{&1.class}" == tab_name))
+    selected_skill_panel = Enum.find(skill_params, &("#{&1.skill_panel}_#{&1.class}" == tab_name))
 
     socket
     |> assign(:selected_tab, tab_name)


### PR DESCRIPTION
選択判定がスキルパネルIDだったので、スキルパネルID + クラスを使用するようにした

before 

![スクリーンショット 2023-09-27 11 33 04](https://github.com/bright-org/bright/assets/91950/4ea716db-103f-4724-be60-b1443dd3ecc9)

after

![スクリーンショット 2023-09-27 11 32 38](https://github.com/bright-org/bright/assets/91950/b798f20a-9289-4896-aa75-54a758d44085)

