### PR TITLE
エビデンス デザイン適用（現機能までの対応）

### DIFF
--- a/lib/bright/skill_evidences.ex
+++ b/lib/bright/skill_evidences.ex
@@ -123,6 +123,17 @@ defmodule Bright.SkillEvidences do
     |> Repo.all()
   end
 
+  def list_skill_evidence_posts_from_skill_evidence(skill_evidence) do
+    from(
+      sep in Ecto.assoc(skill_evidence, :skill_evidence_posts),
+      order_by: sep.inserted_at,
+      join: u in assoc(sep, :user),
+      join: up in assoc(u, :user_profile),
+      preload: [user: {u, [user_profile: up]}]
+    )
+    |> list_skill_evidence_posts()
+  end
+
   @doc """
   Gets a single skill_evidence_post.
 

--- a/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
@@ -4,43 +4,94 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
   alias Bright.SkillEvidences
   alias Bright.SkillScores
 
+  @unkown_icon "/images/avatar.png"
+
   @impl true
   def render(assigns) do
     ~H"""
-    <div id={@id}>
-      <.header> <%= @skill.name %> </.header>
+    <div id={@id} class="flex justify-center items-center">
+      <div class="w-full lg:w-[450px]">
+        <p class="pb-2 text-base font-bold">
+          <%= @skill.name %>
+        </p>
 
-      <div
-        id="skill_evidence_posts"
-        phx-update="stream"
-      >
         <div
-          :for={{id, post} <- @streams.skill_evidence_posts}
-          id={id}
+          id="skill_evidence_posts"
+          class="h-[356px] lg:h-[600px] overflow-y-auto"
+          phx-hook="ScrollOccupancy"
+          phx-update="stream"
         >
-          <div class="flex justify-between items-center my-2 gap-x-4">
-            <%= Phoenix.HTML.Format.text_to_html post.content, attributes: [class: "break-all grow"] %>
-            <div class="cursor-pointer flex-none" phx-click="delete" phx-target={@myself} phx-value-id={post.id}>
-              Ｘ削除
+          <div
+            :for={{id, post} <- @streams.skill_evidence_posts}
+            id={id}
+            class="flex flex-wrap my-2"
+          >
+            <div class="w-[50px] flex justify-center flex-col items-center">
+              <img class="inline-block h-10 w-10 rounded-full" src={icon_file_path(post.user, @anonymous)} />
+              <hr class="w-[1px] bg-brightGray-200 h-full" />
+            </div>
+
+            <div class="w-[370px] flex justify-between gap-x-4 pb-4">
+              <%= Phoenix.HTML.Format.text_to_html post.content, attributes: [class: "break-all grow"] %>
+              <div class="cursor-pointer flex-none" phx-click="delete" phx-target={@myself} phx-value-id={post.id}>
+                <.icon name="hero-x-mark-solid" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <.simple_form
-        for={@form}
-        id="skill_evidence_post-form"
-        phx-target={@myself}
-        phx-submit="save"
-      >
-        <.input
-          field={@form[:content]}
-          type="textarea"
-          label="エビデンスを入力" />
-        <:actions>
-          <.button phx-disable-with="送信中...">メモを書き込む</.button>
-        </:actions>
-      </.simple_form>
+        <.simple_form
+          for={@form}
+          id="skill_evidence_post-form"
+          phx-target={@myself}
+          phx-submit="save"
+        >
+          <div>
+            <% # コメント入力 %>
+            <div class="flex flex-wrap pb-2">
+              <div class="w-[50px] flex justify-center flex-col items-center">
+                <img class="inline-block h-10 w-10 rounded-full" src={icon_file_path(@user, @anonymous)} />
+              </div>
+              <div class="w-[370px]">
+                <.input_textarea field={@form[:content]} />
+              </div>
+            </div>
+            <hr class="pb-1 mt-0 border-brightGray-100" />
+            <% # TODO: α後に実装して有効化 %>
+            <div :if={false} class="flex justify-end py-2 items-center">
+              <label>
+                <input
+                  type="checkbox"
+                  value=""
+                  class="w-4 h-4 mr-3"
+                />学習を完了する
+              </label>
+            </div>
+            <div class="flex justify-end gap-x-4 py-2">
+              <% # TODO: α後に実装して有効化 %>
+              <button :if={false} class="mr-auto">
+                <span class="material-icons-outlined !text-4xl">
+                  add_photo_alternate
+                </span>
+              </button>
+              <button
+                class="text-sm font-bold px-5 py-2 rounded border bg-base text-white"
+                type="submit"
+                phx-disable-with="送信中..."
+              >
+                メモを書き込む
+              </button>
+              <% # TODO: α後に実装して有効化 %>
+              <button
+                :if={false}
+                class="text-sm font-bold px-5 py-2 rounded border bg-base text-white"
+              >
+                このメモでヘルプを出す
+              </button>
+            </div>
+          </div>
+        </.simple_form>
+      </div>
     </div>
     """
   end
@@ -48,14 +99,13 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
   @impl true
   def update(assigns, socket) do
     skill_evidence_posts =
-      assigns.skill_evidence
-      |> Ecto.assoc(:skill_evidence_posts)
-      |> SkillEvidences.list_skill_evidence_posts()
+      SkillEvidences.list_skill_evidence_posts_from_skill_evidence(assigns.skill_evidence)
 
     {:ok,
      socket
      |> assign(assigns)
      |> stream(:skill_evidence_posts, skill_evidence_posts)
+     |> update(:user, &Bright.Repo.preload(&1, :user_profile))
      |> assign_form()}
   end
 
@@ -68,6 +118,8 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
     )
     |> case do
       {:ok, skill_evidence_post} ->
+        skill_evidence_post = Bright.Repo.preload(skill_evidence_post, user: [:user_profile])
+
         if post_by_myself(socket.assigns.user, socket.assigns.skill_evidence) do
           SkillScores.make_skill_score_evidence_filled(
             socket.assigns.user,
@@ -111,5 +163,38 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
 
   defp post_by_myself(user, skill_evidence) do
     user.id == skill_evidence.user_id
+  end
+
+  defp icon_file_path(_user, true), do: @unkown_icon
+
+  defp icon_file_path(user, _anonymous) do
+    Bright.UserProfiles.icon_url(user.user_profile.icon_file_path)
+  end
+
+  # TODO: CoreComponentとの統合検討
+  attr :id, :any, default: nil
+  attr :field, Phoenix.HTML.FormField
+
+  defp input_textarea(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
+    assigns =
+      assigns
+      |> assign(field: nil, id: assigns.id || field.id)
+      |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
+      |> assign_new(:name, fn -> field.name end)
+      |> assign_new(:value, fn -> field.value end)
+
+    ~H"""
+    <div phx-feedback-for={@name}>
+      <textarea
+        id={@id}
+        name={@name}
+        placeholder="コメントを入力"
+        class="w-full min-h-1 outline-none border-none focus:ring-0 p-2"
+      ><%= Phoenix.HTML.Form.normalize_value("textarea", @value) %></textarea>
+      <div>
+        <.error :for={msg <- @errors}><%= msg %></.error>
+      </div>
+    </div>
+    """
   end
 end

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -126,6 +126,7 @@
     skill={@skill}
     skill_evidence={@skill_evidence}
     user={@current_user}
+    anonymous={@anonymous}
     patch={PathHelper.skill_panel_path("panels", @skill_panel, @display_user, @me, @anonymous) <> "?class=#{@skill_class.class}"}
   />
 </.bright_modal>


### PR DESCRIPTION
## 対応内容

#944
close #945

エビデンス入力モーダルのデザイン適用です。
現機能までのところが対象です。

留意点

- 投稿削除ボタンは、デザインがないため仮で xマークにしています。
- モーダル内スクロールは、スキル入力用モーダルを踏襲しています。
  - 投稿部分のみのスクロールにしています。
 - 見出しスキル名の位置などの調整を実施中です。

## 参考画像

（デザインHTML）
![image](https://github.com/bright-org/bright/assets/121112529/91f9d43c-b982-4e88-aa3c-02b0c7823fdd)


（本PR後）
![image](https://github.com/bright-org/bright/assets/121112529/bf653707-767b-4684-94cf-aa936ba340ec)
