### PR TITLE
エビデンス フォーム位置と横長アバター画像の表示崩れ対応

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
@@ -17,7 +17,7 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
 
         <div
           id="skill_evidence_posts"
-          class="h-[356px] lg:h-[600px] overflow-y-auto"
+          class="max-h-[356px] lg:max-h-[600px] overflow-y-auto"
           phx-hook="ScrollOccupancy"
           phx-update="stream"
         >
@@ -27,8 +27,10 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
             class="flex flex-wrap my-2"
           >
             <div class="w-[50px] flex justify-center flex-col items-center">
-              <img class="inline-block h-10 w-10 rounded-full" src={icon_file_path(post.user, @anonymous)} />
-              <hr class="w-[1px] bg-brightGray-200 h-full" />
+              <div class="min-h-content">
+                <img class="h-10 w-10 rounded-full" src={icon_file_path(post.user, @anonymous)} />
+              </div>
+              <hr class="w-[1px] bg-brightGray-200 h-full mt-2" />
             </div>
 
             <div class="w-[370px] flex justify-between gap-x-4 pb-4">


### PR DESCRIPTION
## 対応内容

issue #944

#943 の追加対応です。下記の点を直しました。

- 投稿がない、少ない状態でもフォームが下に表示される（投稿部分と目が離れすぎて見づらい）
- 横長のアバター画像のときに、投稿内容が小さいとつぶれて表示される

## 参考画像

（対応前）
![スクリーンショット 2023-09-28 083010](https://github.com/bright-org/bright/assets/121112529/8ca9a6d6-79cb-4e55-90cc-a66845070d7b)

（対応後）
![image](https://github.com/bright-org/bright/assets/121112529/baf81f31-fa53-49d9-b8ea-35b3fa69eab7)

