### PR TITLE
エビデンス 入力内容に空行が入るとflexされる現象対応

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
@@ -34,7 +34,9 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
             </div>
 
             <div class="w-[370px] flex justify-between gap-x-4 pb-4">
-              <%= Phoenix.HTML.Format.text_to_html post.content, attributes: [class: "break-all grow"] %>
+              <div class="grow">
+                <%= Phoenix.HTML.Format.text_to_html post.content, attributes: [class: "break-all first:mt-0 mt-3"] %>
+              </div>
               <div class="cursor-pointer flex-none" phx-click="delete" phx-target={@myself} phx-value-id={post.id}>
                 <.icon name="hero-x-mark-solid" />
               </div>


### PR DESCRIPTION
## 対応内容

入力内容に改行が入るとflexされる現象があったため対応しました。
複数のpタグが生成されるためです。

## 参考画像

発生していた不具合です。

![image](https://github.com/bright-org/bright/assets/121112529/9686f8cc-ede9-44aa-b34a-fb6a87eb1057)

修正後のイメージです。

![スクリーンショット 2023-09-28 130233](https://github.com/bright-org/bright/assets/121112529/18fdbda4-042f-4771-930a-b821cbc38368)
