### PR TITLE
#962 チーム作成モーダルの名称変更

### DIFF
--- a/lib/bright_web/live/team_live/team_create_live_component.html.heex
+++ b/lib/bright_web/live/team_live/team_create_live_component.html.heex
@@ -3,7 +3,7 @@
           <div id="create-team-modal" class="relative rounded-sm px-16 py-8">
 
               <!-- Modal header -->
-              <h3>チームを作る</h3> 
+              <h3>友人やチームメンバーを招待する（チームが作られます）</h3> 
               <!-- Modal body -->
               <div class="flex pt-8">
                 <!-- modal left -->


### PR DESCRIPTION
# チーム作成画面の名称変更

それだけ

![image](https://github.com/bright-org/bright/assets/45676464/8d07ab7b-5765-462b-b094-c63e62ee3337)
