### PR TITLE
スキルパネル 他者との比較, パーセンテージの誤表記対応

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -190,7 +190,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
 
   def skills_table(assigns) do
     ~H"""
-    <div class="skills-table-field h-[70vh] w-full overflow-auto scroll-pt-[76px] mt-4 lg:h-[50vh]">
+    <div id="skills-table-field" class="h-[70vh] w-full overflow-auto scroll-pt-[76px] mt-4 lg:h-[50vh]">
       <table class="skill-panel-table min-w-full border-t border-l border-brightGray-200">
         <thead class="sticky top-0 bg-white">
           <tr>
@@ -243,14 +243,16 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
                 </div>
               </div>
             </td>
-            <td :for={user <- @compared_users}>
+            <td id={"user-#{index}-percentages"} :for={{user, index} <- Enum.with_index(@compared_users, 1)}>
               <% user_data = Map.get(@compared_user_dict, user.name) %>
               <div class="flex justify-center gap-x-2">
                 <div class="min-w-[3em] flex items-center">
-                  <span class={[score_mark_class(:high, :amethyst), "inline-block mr-1"]}></span><%= user_data.high_skills_percentage %>％
+                  <span class={[score_mark_class(:high, :amethyst), "inline-block mr-1"]}></span>
+                  <span class="score-high-percentage"><%= user_data.high_skills_percentage %>％</span>
                 </div>
                 <div class="min-w-[3em] flex items-center">
-                  <span class={[score_mark_class(:middle, :amethyst), "inline-block mr-1"]}></span><%= user_data.middle_skills_percentage %>％
+                  <span class={[score_mark_class(:middle, :amethyst), "inline-block mr-1"]}></span>
+                  <span class="score-middle-percentage"><%= user_data.middle_skills_percentage %>％</span>
                 </div>
               </div>
             </td>

--- a/lib/bright_web/live/skill_panel_live/skills_field_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_field_component.ex
@@ -306,15 +306,16 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
       skill_scores
       |> Enum.reduce({%{}, 0, 0}, fn skill_score, {dict, high_c, middle_c} ->
         score = skill_score.score
+        skill_id = skill_scores_skill_id(skill_score)
 
         {
-          dict |> Map.put(skill_scores_skill_id(skill_score), score),
+          Map.put(dict, skill_id, score),
           high_c + if(score == :high, do: 1, else: 0),
           middle_c + if(score == :middle, do: 1, else: 0)
         }
       end)
 
-    size = Enum.count(skill_scores)
+    size = Enum.count(skill_ids)
     high_skills_percentage = calc_percentage(high_skills_count, size)
     middle_skills_percentage = calc_percentage(middle_skills_count, size)
 

--- a/test/factories/team_member_user_factory.ex
+++ b/test/factories/team_member_user_factory.ex
@@ -1,0 +1,15 @@
+defmodule Bright.TeamMemberUsersFactory do
+  @moduledoc """
+  Factory for Bright.Teams.TeamMemberUsers
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      def team_member_users_factory do
+        %Bright.Teams.TeamMemberUsers{
+          invitation_confirmed_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+        }
+      end
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -85,6 +85,10 @@ defmodule Bright.Factory do
   use Bright.HistoricalSkillScoreFactory
   use Bright.HistoricalSkillClassScoreFactory
 
+  # Teams context
+  use Bright.TeamFactory
+  use Bright.TeamMemberUsersFactory
+
   # NotificationsFactory context
   use Bright.NotificationOperationFactory
   use Bright.NotificationCommunityFactory


### PR DESCRIPTION
## 対応内容

スキルスコア数を参照する以前仕様ままだったため、スキル数参照に変更しました。

障害表：[err-44~47](https://docs.google.com/spreadsheets/d/11gDi3bzbaqlj7csk_4Gbmmn4LziW64V93JqJEw__JSQ/edit#gid=0&range=47:50
)

## 参考画像

err-44 について修正後
（batch_7のパーセンテージが20%/15%であること）

![スクリーンショット 2023-10-03 100442](https://github.com/bright-org/bright/assets/121112529/195edec0-72cd-45ab-a89a-3b573fb12820)
