### PR TITLE
スキルパネル バルーンメッセージのサイズ変更，語句変更

### DIFF
--- a/lib/bright_web/live/help_message_component.ex
+++ b/lib/bright_web/live/help_message_component.ex
@@ -19,7 +19,7 @@ defmodule BrightWeb.HelpMessageComponent do
 
   def render(assigns) do
     ~H"""
-    <div id={@id} class="relative px-4 py-2 my-1 rounded w-fit text-xs bg-designer-dazzle leading-normal">
+    <div id={@id} class="relative px-4 py-2 my-1 rounded w-fit text-sm bg-designer-dazzle leading-normal">
       <%= render_slot(@inner_block) %>
 
       <div class="flex gap-4 justify-center pt-2">

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -545,7 +545,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
     ~H"""
     <div id="job_searching_message" class="flex fixed lg:absolute items-center right-4 top-12 lg:-top-16 w-fit px-5 lg:px-0 z-10">
       <div class="bg-designer-dazzle flex leading-normal px-4 py-2 rounded text-xs w-fit">
-        <p>上記の求職設定を行うと、スカウト検索であなたのスキルを必要とするプロジェクト（副業含む）から声がかかるようになります。</p>
+        <p>上記の求職設定を行うと、スキル検索であなたのスキルを必要とするプロジェクト（副業含む）から声がかかるようになります。</p>
       </div>
       <div id="arrow-to-job-searching" class="arrow ml-1"></div>
     </div>


### PR DESCRIPTION
## 対応内容

https://github.com/bright-org/bright/issues/966#issuecomment-1745911891
より、

> ・バルーンの字が全体的に小さい
に対応しています。

text-xs -> text-sm

## 参考画像

![スクリーンショット 2023-10-04 113745](https://github.com/bright-org/bright/assets/121112529/f91590f8-3bb4-4154-9b7e-b7b6e3c2f72e)

![スクリーンショット 2023-10-04 113711](https://github.com/bright-org/bright/assets/121112529/85c44eff-f148-4a00-a8b7-30993a7e08a8)

