### PR TITLE
mailboxをdev serverで使う設定を revert

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -116,13 +116,9 @@ if config_env() == :prod do
   #     config :swoosh, :api_client, Swoosh.ApiClient.Hackney
   #
   # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.
-  if System.get_env("DEV_SERVER") do
-    config :bright, Bright.Mailer, adapter: Swoosh.Adapters.Local
-  else
-    config :bright, Bright.Mailer,
-      adapter: Swoosh.Adapters.Sendgrid,
-      api_key: System.get_env("SENDGRID_API_KEY")
-  end
+  config :bright, Bright.Mailer,
+    adapter: Swoosh.Adapters.Sendgrid,
+    api_key: System.get_env("SENDGRID_API_KEY")
 
   # Sentry
   config :sentry,

--- a/lib/bright_web/router.ex
+++ b/lib/bright_web/router.ex
@@ -98,15 +98,6 @@ defmodule BrightWeb.Router do
     end
   end
 
-  # dev server 自動テスト用
-  if System.get_env("DEV_SERVER") do
-    scope "/dev" do
-      pipe_through [:browser, :admin]
-
-      forward "/mailbox", Plug.Swoosh.MailboxPreview
-    end
-  end
-
   # ローカル開発用
   if Application.compile_env(:bright, :dev_routes) do
     # If you want to use the LiveDashboard in production, you should put


### PR DESCRIPTION
aliceさんから依頼があり、使えるか検証をしてみたがlocalをprodモードでは動作したがdev serverではうまく動かない
この改修のあとログインと登録のdevサーバーの動作が安定しないので一旦revert


以下からyamlを編集して環境変数を追加したが、Swooshのアダプターがlocalに切り替わったようでメールは送信されなくなったが、dev/milboxにアクセスしても 404としか表示されず、ログは404だけで内部的な別のエラーは出ていなかった
```
env:
    - name: DEV_SERVER
        value: 'true' 
```
https://console.cloud.google.com/run/detail/asia-northeast1/bright/yaml/view?hl=ja&project=bright-dev-392003