### PR TITLE
スキルパネル タイムライン, パーセンテージの誤表記対応

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -231,7 +231,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
             <th class="bg-base text-white text-center">
               合計
             </th>
-            <td>
+            <td id="my-percentages">
               <div class="flex justify-center flex-wrap gap-x-2">
                 <div class="min-w-[3em] flex items-center">
                   <span class={[score_mark_class(:high, :green), "inline-block mr-1"]} />
@@ -260,7 +260,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
         </thead>
 
         <%= for {[col1, col2, col3], row} <- @table_structure |> Enum.with_index(1) do %>
-          <% skill_score = @skill_score_dict[col3.skill.id] || %{score: :low} %>
+          <% skill_score = @skill_score_dict[col3.skill.id] %>
           <% current_skill = Map.get(@current_skill_dict, col3.skill.trace_id, %{}) %>
           <% current_skill_score = Map.get(@current_skill_score_dict, Map.get(current_skill, :id)) %>
 

--- a/lib/bright_web/live/skill_panel_live/skills_field_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_field_component.ex
@@ -284,6 +284,18 @@ defmodule BrightWeb.SkillPanelLive.SkillsFieldComponent do
       |> HistoricalSkillScores.list_historical_skill_scores_from_historical_skill_class_score()
       |> Map.new(&{&1.historical_skill_id, &1})
 
+    skill_score_dict =
+      Map.new(socket.assigns.skills, fn skill ->
+        skill_score =
+          Map.get(skill_score_dict, skill.id)
+          |> Kernel.||(%HistoricalSkillScores.HistoricalSkillScore{
+            historical_skill_id: skill.id,
+            score: :low
+          })
+
+        {skill.id, skill_score}
+      end)
+
     socket
     |> assign(skill_class_score: skill_class_score)
     |> assign(skill_score_dict: skill_score_dict)

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -773,6 +773,9 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       h_skill_x =
         insert(:historical_skill, historical_skill_category: h_skill_category, position: 2)
 
+      # スキルスコアがないスキルとして用意
+      insert(:historical_skill, historical_skill_category: h_skill_category, position: 3)
+
       # ユーザーのスコアの用意
       insert(:historical_skill_class_score,
         historical_skill_class: h_skill_class,
@@ -803,6 +806,10 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       |> render_click()
 
       assert has_element?(show_live, "#skill-1 .score-mark-middle")
+      assert has_element?(show_live, "#skill-2 .score-mark-high")
+      assert has_element?(show_live, "#skill-3 .score-mark-low")
+      assert has_element?(show_live, "#my-percentages .score-high-percentage", "33％")
+      assert has_element?(show_live, "#my-percentages .score-middle-percentage", "33％")
     end
 
     @tag score: nil


### PR DESCRIPTION
## 対応内容

スキルスコア数を参照する以前仕様ままだったため、スキル数参照に変更しました。

[障害表](https://docs.google.com/spreadsheets/d/11gDi3bzbaqlj7csk_4Gbmmn4LziW64V93JqJEw__JSQ/edit#gid=0&range=47:50)

## 参考画像

（障害対応の記録としてなのでレビューは無視してください）

![スクリーンショット 2023-10-05 110614](https://github.com/bright-org/bright/assets/121112529/a468dcb8-1bfd-4cd2-94b7-c56312ffa06c)
