### PR TITLE
成長グラフ グラフ描画用データ取得時の日付参照先の変更

### DIFF
--- a/lib/bright/skill_scores.ex
+++ b/lib/bright/skill_scores.ex
@@ -458,7 +458,14 @@ defmodule Bright.SkillScores do
         %{locked_date: ~D[2022-10-01], percentage: 15.555555555555555}
       ]
   """
+  # TODO: リファクタリング HistoricalSkillScoresコンテキストに移動
   def get_historical_skill_class_scores(skill_panel_id, class, user_id, from_date, to_date) do
+    # skill_classから引くため該当する日付に変更
+    # TODO: リファクタリング TimelineHelperを適当な場所に移動後に修正
+    alias BrightWeb.SkillPanelLive.TimelineHelper
+    locked_date_from = TimelineHelper.get_shift_date_from_date(from_date, -1)
+    locked_date_to = TimelineHelper.get_shift_date_from_date(to_date, -1)
+
     from(
       historical_skill_class in HistoricalSkillClass,
       join:
@@ -466,19 +473,22 @@ defmodule Bright.SkillScores do
           historical_skill_class,
           :historical_skill_class_scores
         ),
-      on:
-        historical_skill_class_scores.user_id == ^user_id and
-          historical_skill_class_scores.locked_date >= ^from_date and
-          historical_skill_class_scores.locked_date <= ^to_date,
+      on: historical_skill_class_scores.user_id == ^user_id,
       where:
         historical_skill_class.skill_panel_id == ^skill_panel_id and
-          historical_skill_class.class == ^class,
+          historical_skill_class.class == ^class and
+          historical_skill_class.locked_date >= ^locked_date_from and
+          historical_skill_class.locked_date <= ^locked_date_to,
       select: {
-        historical_skill_class_scores.locked_date,
+        historical_skill_class.locked_date,
         historical_skill_class_scores.percentage
       }
     )
     |> Repo.all()
+    |> Enum.map(fn {date, percentage} ->
+      # skill_class_scoreにあたる日付に戻す
+      {TimelineHelper.get_shift_date_from_date(date, 1), percentage}
+    end)
   end
 
   @doc """


### PR DESCRIPTION
## 対応内容

成長グラフのグラフ描画用データの取得方法を微調整しました。
historical_skill_class_score の日付からhistorical_skill_class の日付に変更しています。
（取得参照先の違いからジェムやスキルパネルと矛盾が生じるため）

[障害表](https://docs.google.com/spreadsheets/d/1KaMXZXd1YXszUBpJ58lQthpU6_zrAvqhPIEGl61bH34/edit#gid=0&range=48:49)

## 参考画像

（ジェムと矛盾していたのを解消しています）

![スクリーンショット 2023-10-05 133440](https://github.com/bright-org/bright/assets/121112529/8717d52c-91a1-4f02-9b7a-9fa1a06554fb)

![スクリーンショット 2023-10-05 133505](https://github.com/bright-org/bright/assets/121112529/4b4b37c1-67ed-4fe5-8227-1c35b8627a22)
