### PR TITLE
スキルパネル：右上SNSシェアボタン追加

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -52,6 +52,12 @@
 </div>
 
 
+<BrightWeb.SnsComponents.floating_share_buttons
+  text="スキルパネル"
+  path={@path}
+/>
+
+
 <% # スコア入力用モーダル %>
 <.bright_modal
   :if={:edit == @live_action && @me}


### PR DESCRIPTION
Closes #931 

コンポーネントは #953 で作成済み

## やったこと

- スキルパネルの画面右上にSNSシェアボタンを追加

| PC | SP |
| --- | --- |
| ![image](https://github.com/bright-org/bright/assets/1233315/219e9e1f-8d38-448a-a007-d310972e3d25) | ![image](https://github.com/bright-org/bright/assets/1233315/df6405b1-ed5f-4066-a405-e8e53d6782ee) |

## やってないこと

- 初期入力されるテキストを正式なものにする（Twitterのみ）