### PR TITLE
スキルパネル、成長グラフ タブ内にスキルクラス名を表示

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -333,22 +333,21 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
       <%= for {skill_class, skill_class_score} <- pair_skill_class_score(@skill_classes) do %>
         <%= if skill_class_score do %>
           <% current = @skill_class.class == skill_class.class %>
-          <li class={current && "bg-white text-base"}>
+          <li id={"class_tab_#{skill_class.class}"} class={current && "bg-white text-base"}>
             <.link
-              id={"class_tab_#{skill_class.class}"}
               patch={"#{@path}?#{build_query(@query, %{"class" => skill_class.class})}"}
-              class="flex justify-start items-center p-4 pt-2 lg:inline-block lg:pt-3 text-xs"
+              class="flex justify-start items-center p-4 pt-2 lg:inline-block lg:pt-3 text-xs lg:text-base"
               aria-current={current && "page"}
             >
-              クラス<%= skill_class.class %> <%= if(current, do: skill_class.name, else: "") %>
+              クラス<%= skill_class.class %> <%= skill_class.name %>
               <span class="text-xl ml-2 lg:ml-4"><%= floor skill_class_score.percentage %></span>％
               <span class="material-symbols-outlined ml-auto lg:hidden">stat_minus_1</span>
             </.link>
           </li>
         <% else %>
-          <li class="bg-pureGray-600 text-pureGray-100">
-            <span href="#" class="select-none inline-block p-4 pt-3">
-              クラス<%= skill_class.class %>
+          <li id={"class_tab_#{skill_class.class}"} class="bg-pureGray-600 text-pureGray-100">
+            <span href="#" class="select-none inline-block p-4 pt-3 text-xs lg:text-base">
+              クラス<%= skill_class.class %> <%= skill_class.name %>
               <span class="text-xl ml-4">0</span>％
             </span>
           </li>

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -62,21 +62,22 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       skill_panel = insert(:skill_panel)
       insert(:user_skill_panel, user: user, skill_panel: skill_panel)
       skill_class = insert(:skill_class, skill_panel: skill_panel, class: 1)
+      skill_class_2 = insert(:skill_class, skill_panel: skill_panel, class: 2)
 
-      %{skill_panel: skill_panel, skill_class: skill_class}
+      %{skill_panel: skill_panel, skill_class: skill_class, skill_class_2: skill_class_2}
     end
 
     test "shows content", %{
       conn: conn,
       skill_panel: skill_panel,
-      skill_class: skill_class
+      skill_class: skill_class,
+      skill_class_2: skill_class_2
     } do
       {:ok, show_live, html} = live(conn, ~p"/panels/#{skill_panel}")
 
       assert html =~ "スキルパネル"
-
-      assert show_live
-             |> has_element?("#class_tab_1", skill_class.name)
+      assert has_element?(show_live, "#class_tab_1", skill_class.name)
+      assert has_element?(show_live, "#class_tab_2", skill_class_2.name)
     end
 
     test "shows content without parameters", %{
@@ -87,9 +88,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       {:ok, show_live, html} = live(conn, ~p"/panels")
 
       assert html =~ skill_panel.name
-
-      assert show_live
-             |> has_element?("#class_tab_1", skill_class.name)
+      assert has_element?(show_live, "#class_tab_1", skill_class.name)
     end
 
     test "shows skills table", %{
@@ -175,15 +174,13 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
     test "shows the skill class by query string parameter", %{
       conn: conn,
       user: user,
-      skill_panel: skill_panel
+      skill_panel: skill_panel,
+      skill_class_2: skill_class_2
     } do
-      skill_class_2 = insert(:skill_class, skill_panel: skill_panel, class: 2)
       insert(:init_skill_class_score, user: user, skill_class: skill_class_2)
-
       {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=2")
 
-      assert show_live
-             |> has_element?("#class_tab_2", skill_class_2.name)
+      assert has_element?(show_live, "#class_tab_2", skill_class_2.name)
     end
   end
 


### PR DESCRIPTION
## 対応内容

参考画像のように、タブ内にスキルクラス名を表示するようにしました。
（PO依頼より）

合わせて文字サイズに違和感があったので対応しています（コメント参照）。


## 参考画像

本PRで以下のようになります。

![image](https://github.com/bright-org/bright/assets/121112529/77d14270-c500-42b0-a473-42bd97781b48)

![image](https://github.com/bright-org/bright/assets/121112529/9893cd36-fd30-4163-a8f0-742515adeab4)
