### PR TITLE
エビデンス入力 デザイン適用 ゴミ箱アイコンとフォントサイズ調整

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
@@ -33,12 +33,17 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
               <hr class="w-[1px] bg-brightGray-200 h-full mt-2" />
             </div>
 
-            <div class="w-[370px] flex justify-between gap-x-4 pb-4">
-              <div class="grow">
+            <div class="w-[370px] pb-4">
+              <div class="text-base">
                 <%= Phoenix.HTML.Format.text_to_html post.content, attributes: [class: "break-all first:mt-0 mt-3"] %>
               </div>
-              <div class="cursor-pointer flex-none" phx-click="delete" phx-target={@myself} phx-value-id={post.id}>
-                <.icon name="hero-x-mark-solid" />
+              <div
+                class="h-6 w-6 py-2 ml-auto cursor-pointer"
+                phx-click="delete"
+                phx-target={@myself}
+                phx-value-id={post.id}
+              >
+                <span class="material-symbols-outlined text-brightGray-500 font-xs hover:opacity-50">delete</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## 対応内容

issue closes #944 
（現機能で当てていないところの対応が完了するので閉じます）

投稿削除処理用のアイコンがなかったのでいただいて、対応しました。
その設置と、改めてみるとフォントサイズが違ったので直しました。

## 参考画像

変更前：
![image](https://github.com/bright-org/bright/assets/121112529/980f5c39-b3a5-482f-abd3-17c2b3709988)


変更後：
![image](https://github.com/bright-org/bright/assets/121112529/e6d44136-c0bd-490c-910c-f5ab4e4eebe4)


