### PR TITLE
スキルパネル&成長グラフ 「自分に戻す」ボタンを自分がみているときに非表示

### DIFF
--- a/lib/bright_web/live/graph_live/graphs.html.heex
+++ b/lib/bright_web/live/graph_live/graphs.html.heex
@@ -23,6 +23,7 @@
       counter={@counter}
       num_skills={@num_skills}
       display_skill_edit_button={false}
+      me={@me}
     />
     <div class="flex flex-col-reverse lg:flex-row">
       <.live_component

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -224,14 +224,6 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
     """
   end
 
-  def return_myself_button(assigns) do
-    ~H"""
-    <button phx-click="clear_display_user" class="text-brightGreen-300 border bg-white border-brightGreen-300 rounded px-3 font-bold">
-      自分に戻す
-    </button>
-    """
-  end
-
   def toggle_link(assigns) do
     ~H"""
       <div class="bg-white text-brightGray-500 rounded-full inline-flex text-sm font-bold h-10">
@@ -358,7 +350,6 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
   end
 
   def profile_area(assigns) do
-    # TODO: 自分に戻す、に対応が必要
     ~H"""
       <div class="flex flex-col lg:justify-between lg:flex-row">
         <div class="pt-2 w-full lg:pt-6 lg:w-[850px]">
@@ -370,7 +361,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
             icon_file_path={Bright.UserProfiles.icon_url(@display_user.user_profile.icon_file_path)}
             display_excellent_person={false}
             display_anxious_person={false}
-            display_return_to_yourself={true}
+            display_return_to_yourself={!@me}
             display_sns={true}
             twitter_url={@display_user.user_profile.twitter_url}
             github_url={@display_user.user_profile.github_url}

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -25,6 +25,7 @@
         display_skill_edit_button={@me}
         skill_panel={@skill_panel}
         query={@query}
+        me={@me}
       />
 
       <.help_messages_area flash={@flash} />


### PR DESCRIPTION
## 対応内容

「自分に戻す」ボタンを対象者切り替えのときのみ表示するように変更しました。

## 参考画像

![sample46](https://github.com/bright-org/bright/assets/121112529/1816e259-53fe-443b-8999-f92e3750916c)

