### PR TITLE
成長グラフ 「スキル入力する」案内メッセージ用？アイコン 非表示

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -401,6 +401,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
               スキル入力する
             </.link>
             <div
+              :if={@display_skill_edit_button}
               id="btn-help-enter-skills-button"
               class="flex-none cursor-pointer"
               phx-click={JS.push("open", target: "#help-enter-skills-button") |> show("#help-enter-skills-button")}>


### PR DESCRIPTION
## 対応内容

成長グラフ画面に、「スキル入力する」案内メッセージ用？アイコンがでていたので消しました。

下記、赤枠のところを削除しています。

![image](https://github.com/bright-org/bright/assets/121112529/00449f29-ffb5-4050-90cc-0fbe25044ab6)

