### PR TITLE
スキルパネル&成長グラフ シェアボタンを一時非表示

### DIFF
--- a/lib/bright_web/live/graph_live/graphs.html.heex
+++ b/lib/bright_web/live/graph_live/graphs.html.heex
@@ -77,6 +77,7 @@
 </div>
 
 <BrightWeb.SnsComponents.floating_share_buttons
+  :if={false}
   text="成長グラフ"
   path={@path}
 />

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -53,6 +53,7 @@
 </div>
 
 <BrightWeb.SnsComponents.floating_share_buttons
+  :if={false}
   text="スキルパネル"
   path={@path}
 />


### PR DESCRIPTION
## 対応内容

スキルパネル&成長グラフ シェアボタンを一時非表示にしています。

