### PR TITLE
スキルパネル SPサイズでスキルユニットへのアンカーリンク対応

### DIFF
--- a/assets/js/hooks/SkillUnitScrolling.js
+++ b/assets/js/hooks/SkillUnitScrolling.js
@@ -1,0 +1,27 @@
+// スキルパネル画面 SPサイズのスキルテーブル中のスキルユニットにアンカーリンクで移動するためのHook
+// スキルジェムからは`#unit-x`で遷移があり、本Hookで`#unit-sp-x`位置にスクロールしている
+
+const SkillUnitScrolling = {
+  mounted() {
+    const spEl = document.getElementById("sp-size")
+    const isSP = getComputedStyle(spEl).display !== 'none'
+    const anchor = location.hash || ''
+    const spAnchor = anchor + '-sp'
+
+    if(isSP) {
+      const targetEl = document.querySelector(spAnchor)
+
+      if(targetEl) {
+        // 固定されたheaderに隠れないように調整
+        const headerSize = document.querySelector('#user-header').offsetHeight
+        const targetTop = targetEl.getBoundingClientRect().top - headerSize
+
+        // スクロール
+        // そのままだとピッタリのため、5ほど余白を取っている
+        window.scroll({top: targetTop - 5, behavior: 'smooth'})
+      }
+    }
+  }
+}
+
+export default SkillUnitScrolling

--- a/assets/js/hooks/index.js
+++ b/assets/js/hooks/index.js
@@ -5,6 +5,7 @@ import IframeSizeFitting from './IframeSizeFitting.js'
 import TabSlideScroll from './TabSlideScroll.js'
 import Dropdown from './Dropdown.js'
 import ScrollOccupancy from './ScrollOccupancy.js'
+import SkillUnitScrolling from './SkillUnitScrolling.js'
 
 export const Hooks = {
   SkillGem: SkillGem,
@@ -13,5 +14,6 @@ export const Hooks = {
   IframeSizeFitting: IframeSizeFitting,
   TabSlideScroll: TabSlideScroll,
   Dropdown: Dropdown,
-  ScrollOccupancy: ScrollOccupancy
+  ScrollOccupancy: ScrollOccupancy,
+  SkillUnitScrolling: SkillUnitScrolling
 }

--- a/lib/bright_web/components/layout_components.ex
+++ b/lib/bright_web/components/layout_components.ex
@@ -87,7 +87,7 @@ defmodule BrightWeb.LayoutComponents do
       |> assign(:page_sub_title, page_sub_title)
 
     ~H"""
-    <div class="sticky top-0 z-10 flex flex-col-reverse justify-between px-4 py-2 border-brightGray-100 border-b bg-white w-full lg:flex-row lg:items-center lg:px-10 lg:relative">
+    <div id="user-header" class="sticky top-0 z-10 flex flex-col-reverse justify-between px-4 py-2 border-brightGray-100 border-b bg-white w-full lg:flex-row lg:items-center lg:px-10 lg:relative">
       <h4 class="lg:hidden font-bold mt-2 text-sm before:bg-bgGem before:bg-6 before:bg-left before:bg-no-repeat before:content-[''] before:h-6 before:inline-block before:align-[-5px] before:w-6">
         <%= @page_title %><%= @page_sub_title %>
       </h4>

--- a/lib/bright_web/components/layouts/root.html.heex
+++ b/lib/bright_web/components/layouts/root.html.heex
@@ -7,5 +7,7 @@
         <%= @inner_content %>
       </main>
     </div>
+    <% # sp/pc 表示サイズ判定利用 %>
+    <div id="sp-size" class="h-0 w-0 lg:hidden" />
   </body>
 </.root_layout>

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -321,11 +321,14 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
 
   def skills_table_sp(assigns) do
     ~H"""
-    <div class="flex justify-center items-center mb-20">
+    <div
+    id="skills-table-field-sp"
+    class="flex justify-center items-center mb-20"
+    phx-hook="SkillUnitScrolling">
       <section class="text-sm w-full">
         <div>
-          <%= for skill_unit <- @skill_units do %>
-            <b class="block font-bold mt-6 text-xl">
+          <%= for {skill_unit, position} <- Enum.with_index(@skill_units, 1) do %>
+            <b id={"unit-#{position}-sp"} class="block font-bold mt-6 text-xl">
               <%= skill_unit.name %>
             </b>
             <%= for skill_category <- get_children(skill_unit, "skill_categories") do %>


### PR DESCRIPTION
## 対応内容

スマホでスキルジェムからスキルパネルのスキルユニットに遷移できない現象に対応しました。

[障害表](https://docs.google.com/spreadsheets/d/1KaMXZXd1YXszUBpJ58lQthpU6_zrAvqhPIEGl61bH34/edit#gid=0&range=50:50)

## 参考画像

（gifです）

![sample49](https://github.com/bright-org/bright/assets/121112529/e7fa337c-8105-433e-9c73-6e326c506989)

