### PR TITLE
スキルパネル タイムライン データ未登録区間の表示を追加

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -315,6 +315,13 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
           </tr>
         <% end %>
       </table>
+
+      <%= if @num_skills == 0 do %>
+        <div class="mt-28 w-full flex flex-col justify-center items-center gap-y-2">
+          <p class="text-2xl lg:text-4xl">データ未登録の区間です。</p>
+          <p class="text-md lg:text-xl">スキル入力された以降の区間を選択するとスキル一覧／習得状況が表示されます。</p>
+        </div>
+      <% end %>
     </div>
     """
   end


### PR DESCRIPTION
## 対応内容

タイムラインで過去を表示した際、データが登録されていない日付での表示を追加しました。

## 参考画像

![image](https://github.com/bright-org/bright/assets/121112529/33336bd3-b862-4a3f-b18c-6a105feace91)
