### PR TITLE
ガイドメッセージ わかりやすい、わかりにくいに共通classを付加

### DIFF
--- a/lib/bright_web/live/help_message_component.ex
+++ b/lib/bright_web/live/help_message_component.ex
@@ -21,14 +21,14 @@ defmodule BrightWeb.HelpMessageComponent do
         <button
           id={good_button_id(@id)}
           type="button"
-          class="bg-brightGray-900 border border-brightGray-900 font-bold p-1 rounded text-white w-48"
+          class="btn-help-good bg-brightGray-900 border border-brightGray-900 font-bold p-1 rounded text-white w-48"
           phx-click={JS.push("good", target: @myself) |> hide("##{@id}")}>
           この説明は分かりやすい
         </button>
         <button
           id={bad_button_id(@id)}
           type="button"
-          class="bg-white border border-brightGray-900 font-bold p-1 rounded text-brightGray-900 w-24"
+          class="btn-help-bad bg-white border border-brightGray-900 font-bold p-1 rounded text-brightGray-900 w-24"
           phx-click={JS.push("bad", target: @myself) |> hide("##{@id}")}>
           わかりにくい
         </button>


### PR DESCRIPTION
## 対応内容

ガイドメッセージについて、

わかりやすい：btn-help-good
わかりにく：btn-help-bad 
をそれぞれ共通クラスとして追加しました。
（GAトラッキング依頼がありました）


## 参考画像

![スクリーンショット 2023-10-11 092408](https://github.com/bright-org/bright/assets/121112529/ed5ee1aa-66ef-4846-ad48-16588ebe748f)
![スクリーンショット 2023-10-11 092419](https://github.com/bright-org/bright/assets/121112529/745c180b-9d83-4bee-ab3e-1814056e51c6)

