### PR TITLE
TwitterシェアボタンがXアプリインストール済みのAndroid端末でも動作するように修正

### DIFF
--- a/lib/bright_web/components/sns_components.ex
+++ b/lib/bright_web/components/sns_components.ex
@@ -61,7 +61,7 @@ defmodule BrightWeb.SnsComponents do
           <img class="h-6" src="/images/share_button/share_facebook.png" />
         </a>
         <a
-          href={"https://twitter.com/share?#{URI.encode_query(%{text: @text, url: @url})}"}
+          href={"https://twitter.com/intent/tweet?#{URI.encode_query(%{text: @text, url: @url})}"}
           target="_blank"
           rel="nofollow noopener noreferrer"
         >


### PR DESCRIPTION
https://digi-dock.slack.com/archives/C0550EENU86/p1697034731305729?thread_ts=1697033735.192019&cid=C0550EENU86

↓記事の通りに対応
https://foxism.jp/2023/05/twitter-share-button/