### PR TITLE
SNSシェアボタンがクラスを切り替えると消えてしまうバグを修正

### DIFF
--- a/assets/js/hooks/SnsFloatingShareButtons.js
+++ b/assets/js/hooks/SnsFloatingShareButtons.js
@@ -1,7 +1,10 @@
 export const SnsFloatingShareButtons = {
   mounted() {
-    this.adjustShareButtonPosition()
     window.addEventListener('resize', this.adjustShareButtonPosition.bind(this))
+    this.updated()
+  },
+  updated() {
+    this.adjustShareButtonPosition()
     this.el.classList.remove('hidden')
   },
   destroyed() {

--- a/lib/bright_web/components/sns_components.ex
+++ b/lib/bright_web/components/sns_components.ex
@@ -51,7 +51,6 @@ defmodule BrightWeb.SnsComponents do
         id={@id}
         class="hidden fixed gap-2 flex flex-col lg:flex-row p-2 top-24 lg:top-16"
         phx-hook="SnsFloatingShareButtons"
-        phx-update="ignore"
       >
         <a
           href={"https://www.facebook.com/share.php?#{URI.encode_query(%{u: @url})}"}


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1KaMXZXd1YXszUBpJ58lQthpU6_zrAvqhPIEGl61bH34/edit#gid=0&range=51:51
https://docs.google.com/spreadsheets/d/11gDi3bzbaqlj7csk_4Gbmmn4LziW64V93JqJEw__JSQ/edit#gid=0&range=62:62

patchによる画面遷移だと `mounted` は呼ばれないが、コンポーネントは再レンダリングされるため `hidden` クラスが付いてしまいボタンが表示されなくなっていた