### PR TITLE
スキルパネル 「スキル入力する」用メッセージの位置調整

### DIFF
--- a/lib/bright_web/components/guide_message_components.ex
+++ b/lib/bright_web/components/guide_message_components.ex
@@ -1,0 +1,141 @@
+defmodule BrightWeb.GuideMessageComponents do
+  @moduledoc """
+  ガイドメッセージを集めたコンポーネント
+  """
+
+  use BrightWeb, :component
+
+  @doc """
+  スキル入力解説メッセージ
+  """
+  def enter_skills_help_message(%{reference_from: "button"} = assigns) do
+    # 現状はスキル入力前メッセージと同様
+    ~H"""
+    <.first_skills_edit_message />
+    """
+  end
+
+  def enter_skills_help_message(%{reference_from: "modal"} = assigns) do
+    ~H"""
+    <p>スキル入力は、途中保存可能でいつでも変更できます。</p>
+    <.score_mark_description />
+    <.shortcut_key_description />
+    """
+  end
+
+  @doc """
+  スキル入力前メッセージ
+  """
+  def first_skills_edit_message(assigns) do
+    ~H"""
+    <p>
+      <span class="font-bold">まずは「スキル入力する」ボタンをクリック</span>してスキル入力を始めてください。
+    </p>
+    <p>スキル入力は、途中保存可能でいつでも変更できます。</p>
+    <.score_mark_description />
+    <.shortcut_key_description />
+    <.evidence_introduction_description />
+    """
+  end
+
+  @doc """
+  スキル入力後メッセージ（初回のみ）
+  """
+  def first_submit_in_overall_message(assigns) do
+    ~H"""
+    <div>
+      <p>スキル入力完了おめでとうございます！</p>
+      <p class="mt-4">
+        <span class={[score_mark_class(:high, :green), "inline-block align-middle mr-1"]} /><span class="align-middle">が40％より下は「見習い」、40％以上で「平均」、60％以上で「ベテラン」となります。</span>
+      </p>
+      <p class="mt-2">
+        スキル入力後は「成長を見る・比較する」メニューで現在のスキルレベルを確認できます。
+      </p>
+      <p>
+        また、3ヶ月区切りでスキルレベルを集計するので、スキルの成長も体感できます。
+      </p>
+      <div class="mt-2 max-w-[400px]">
+        <img src="/images/sample_groth_graph.png" alt="成長グラフ" />
+      </div>
+      <.evidence_introduction_description />
+    </div>
+    """
+  end
+
+  @doc """
+  クラス開放メッセージ
+  """
+  def next_skill_class_opened_message(assigns) do
+    ~H"""
+    <div>
+      <p>クラス開放おめでとうございます！</p>
+      <p class="mt-2">クラス開放後は「成長を見る・比較する」メニューでスキルレベルを確認できます。</p>
+    </div>
+    <div class="mt-4 max-w-[400px]">
+      <img src="/images/sample_groth_graph.png" alt="成長グラフ" />
+    </div>
+    """
+  end
+
+  @doc """
+  求職案内メッセージ
+  """
+  def prompt_job_searching_message(assigns) do
+    ~H"""
+    <div id="job_searching_message" class="flex fixed lg:absolute items-center right-4 top-12 lg:-top-16 w-fit px-5 lg:px-0 z-10">
+      <div class="bg-designer-dazzle flex leading-normal px-4 py-2 rounded text-xs w-fit">
+        <p>上記の求職設定を行うと、スキル検索であなたのスキルを必要とするプロジェクト（副業含む）から声がかかるようになります。</p>
+      </div>
+      <div id="arrow-to-job-searching" class="arrow ml-1"></div>
+    </div>
+    """
+  end
+
+  defp score_mark_description(assigns) do
+    ~H"""
+    <ul class="my-2">
+      <li class="flex items-center">
+        <span class={[score_mark_class(:high, :green), "inline-block mr-1"]} />
+        実務経験がある、もしくは依頼されたら短期間で実行できる
+      </li>
+      <li class="flex items-center">
+        <span class={[score_mark_class(:middle, :green), "inline-block mr-1"]} />
+        知識はあるが、実務経験が浅く、自信が無い（調査が必要）
+      </li>
+      <li class="flex items-center">
+        <span class={[score_mark_class(:low, :green), "inline-block mr-1"]} />
+        知識や実務経験が無い
+      </li>
+    </ul>
+    """
+  end
+
+  defp shortcut_key_description(assigns) do
+    ~H"""
+    <div class="hidden lg:block">
+      <p class="flex flex-wrap items-center">
+        1キーを押すと
+        <span class={[score_mark_class(:high, :green), "inline-block mx-1"]} />
+        が付き、2キーを押すと
+        <span class={[score_mark_class(:middle, :green), "inline-block mx-1"]} />
+        、3キーで
+        <span class={[score_mark_class(:low, :green), "inline-block mx-1"]} />
+        が付くので、
+      </p>
+      <p>マウス無しのキーボード操作だけで快適にスキル入力できます。</p>
+    </div>
+    """
+  end
+
+  defp evidence_introduction_description(assigns) do
+    ~H"""
+    <p class="mt-4">
+      なお、各スキルを学んだ記録やメモを残したい場合は、<span class="text-brightGreen-600"><img src="/images/common/icons/skillEvidence.svg" class="inline-block"></span>から、メモを入力することが<br class="hidden lg:inline">できます。（βリリースでは他のチームメンバーにヘルプを出したりできます）
+    </p>
+    """
+  end
+
+  defp score_mark_class(mark, color) do
+    BrightWeb.SkillPanelLive.SkillPanelComponents.score_mark_class(mark, color)
+  end
+end

--- a/lib/bright_web/live/graph_live/graphs.html.heex
+++ b/lib/bright_web/live/graph_live/graphs.html.heex
@@ -25,6 +25,7 @@
       num_skills={@num_skills}
       display_skill_edit_button={false}
       me={@me}
+      flash={@flash}
     />
     <div class="mt-12 lg:mt-0 flex flex-col-reverse lg:flex-row">
       <.live_component

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -3,6 +3,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
   import BrightWeb.ChartComponents
   import BrightWeb.ProfileComponents
   import BrightWeb.MegaMenuComponents
+  import BrightWeb.GuideMessageComponents
   import BrightWeb.SkillPanelLive.SkillPanelHelper, only: [calc_percentage: 2]
 
   # スコア（〇 △ー） 各スタイルと色の定義
@@ -361,7 +362,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
   def profile_area(assigns) do
     ~H"""
       <div class="flex flex-col lg:justify-between lg:flex-row">
-        <div class="lg:order-last mb-8 lg:mt-2 mr-3 flex flex-col gap-y-4">
+        <div class="lg:order-last mb-8 lg:mt-2 lg:mr-3 flex flex-col gap-y-2 lg:gap-y-4">
           <div
             class="flex justify-between items-center w-full lg:w-48 gap-x-2"
             :if={@display_skill_edit_button}
@@ -373,6 +374,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
               <span class="absolute material-icons-outlined left-4 top-1/2 text-white !text-xl -translate-y-1/2">edit</span>
               スキル入力する
             </.link>
+
             <div
               :if={@display_skill_edit_button}
               id="btn-help-enter-skills-button"
@@ -380,6 +382,26 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
               phx-click={JS.push("open", target: "#help-enter-skills-button") |> show("#help-enter-skills-button")}>
               <img class="w-8 h-8" src="/images/icon_help.svg" />
             </div>
+          </div>
+
+          <div class="lg:absolute lg:right-0 lg:top-16 lg:z-10 flex items-center lg:items-end flex-col">
+            <% # スキル入力前メッセージ %>
+            <% # NOTE: idはGAイベントトラッキング対象、変更の際は確認と共有必要 %>
+            <.live_component
+              :if={Map.get(@flash, "first_skills_edit")}
+              module={BrightWeb.HelpMessageComponent}
+              id="help-enter-skills">
+              <.first_skills_edit_message />
+            </.live_component>
+
+            <% # スキル入力するボタン 手動表示メッセージ %>
+            <% # NOTE: idはGAイベントトラッキング対象、変更の際は確認と共有必要 %>
+            <.live_component
+              module={BrightWeb.HelpMessageComponent}
+              id="help-enter-skills-button"
+              open={false}>
+              <.enter_skills_help_message reference_from={"button"} />
+            </.live_component>
           </div>
 
           <% # TODO: α版後にifを除去して表示 %>

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -6,6 +6,7 @@ defmodule BrightWeb.SkillPanelLive.Skills do
   import BrightWeb.SkillPanelLive.SkillsComponents
   import BrightWeb.SkillPanelLive.SkillPanelHelper
   import BrightWeb.DisplayUserHelper
+  import BrightWeb.GuideMessageComponents
 
   alias Bright.SkillPanels.SkillPanel
   alias Bright.SkillUnits

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -27,6 +27,7 @@
         skill_panel={@skill_panel}
         query={@query}
         me={@me}
+        flash={@flash}
       />
 
       <.help_messages_area flash={@flash} />

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -3,6 +3,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
 
   import BrightWeb.SkillPanelLive.SkillPanelComponents, only: [score_mark_class: 2]
   import BrightWeb.SkillPanelLive.SkillPanelHelper, only: [calc_percentage: 2]
+  import BrightWeb.GuideMessageComponents
 
   def compares(assigns) do
     ~H"""
@@ -436,15 +437,6 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
   def help_messages_area(assigns) do
     ~H"""
     <div class="lg:absolute lg:right-0 lg:top-16 lg:z-10 flex items-center lg:items-end flex-col">
-      <% # スキル入力前メッセージ %>
-      <% # NOTE: idはGAイベントトラッキング対象、変更の際は確認と共有必要 %>
-      <.live_component
-        :if={Map.get(@flash, "first_skills_edit")}
-        module={BrightWeb.HelpMessageComponent}
-        id="help-enter-skills">
-        <.first_skills_edit_message />
-      </.live_component>
-
       <% # スキル入力後メッセージ（初回のみ） %>
       <% # NOTE: idはGAイベントトラッキング対象、変更の際は確認と共有必要 %>
       <.live_component
@@ -462,146 +454,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
         id="help-next-class-opened">
         <.next_skill_class_opened_message />
       </.live_component>
-
-      <% # スキル入力するボタン 手動表示メッセージ %>
-      <% # NOTE: idはGAイベントトラッキング対象、変更の際は確認と共有必要 %>
-      <.live_component
-        module={BrightWeb.HelpMessageComponent}
-        id="help-enter-skills-button"
-        open={false}>
-        <.enter_skills_help_message reference_from={"button"} />
-      </.live_component>
     </div>
-    """
-  end
-
-  @doc """
-  スキル入力解説メッセージ
-  """
-  def enter_skills_help_message(%{reference_from: "button"} = assigns) do
-    # 現状はスキル入力前メッセージと同様
-    ~H"""
-    <.first_skills_edit_message />
-    """
-  end
-
-  def enter_skills_help_message(%{reference_from: "modal"} = assigns) do
-    ~H"""
-    <p>スキル入力は、途中保存可能でいつでも変更できます。</p>
-    <.score_mark_description />
-    <.shortcut_key_description />
-    """
-  end
-
-  @doc """
-  スキル入力前メッセージ
-  """
-  def first_skills_edit_message(assigns) do
-    ~H"""
-    <p>
-      <span class="font-bold">まずは「スキル入力する」ボタンをクリック</span>してスキル入力を始めてください。
-    </p>
-    <p>スキル入力は、途中保存可能でいつでも変更できます。</p>
-    <.score_mark_description />
-    <.shortcut_key_description />
-    <.evidence_introduction_description />
-    """
-  end
-
-  @doc """
-  スキル入力後メッセージ（初回のみ）
-  """
-  def first_submit_in_overall_message(assigns) do
-    ~H"""
-    <div>
-      <p>スキル入力完了おめでとうございます！</p>
-      <p class="mt-4">
-        <span class={[score_mark_class(:high, :green), "inline-block align-middle mr-1"]} /><span class="align-middle">が40％より下は「見習い」、40％以上で「平均」、60％以上で「ベテラン」となります。</span>
-      </p>
-      <p class="mt-2">
-        スキル入力後は「成長を見る・比較する」メニューで現在のスキルレベルを確認できます。
-      </p>
-      <p>
-        また、3ヶ月区切りでスキルレベルを集計するので、スキルの成長も体感できます。
-      </p>
-      <div class="mt-2 max-w-[400px]">
-        <img src="/images/sample_groth_graph.png" alt="成長グラフ" />
-      </div>
-      <.evidence_introduction_description />
-    </div>
-    """
-  end
-
-  @doc """
-  クラス開放メッセージ
-  """
-  def next_skill_class_opened_message(assigns) do
-    ~H"""
-    <div>
-      <p>クラス開放おめでとうございます！</p>
-      <p class="mt-2">クラス開放後は「成長を見る・比較する」メニューでスキルレベルを確認できます。</p>
-    </div>
-    <div class="mt-4 max-w-[400px]">
-      <img src="/images/sample_groth_graph.png" alt="成長グラフ" />
-    </div>
-    """
-  end
-
-  @doc """
-  求職案内メッセージ
-  """
-  def prompt_job_searching_message(assigns) do
-    ~H"""
-    <div id="job_searching_message" class="flex fixed lg:absolute items-center right-4 top-12 lg:-top-16 w-fit px-5 lg:px-0 z-10">
-      <div class="bg-designer-dazzle flex leading-normal px-4 py-2 rounded text-xs w-fit">
-        <p>上記の求職設定を行うと、スキル検索であなたのスキルを必要とするプロジェクト（副業含む）から声がかかるようになります。</p>
-      </div>
-      <div id="arrow-to-job-searching" class="arrow ml-1"></div>
-    </div>
-    """
-  end
-
-  defp score_mark_description(assigns) do
-    ~H"""
-    <ul class="my-2">
-      <li class="flex items-center">
-        <span class={[score_mark_class(:high, :green), "inline-block mr-1"]} />
-        実務経験がある、もしくは依頼されたら短期間で実行できる
-      </li>
-      <li class="flex items-center">
-        <span class={[score_mark_class(:middle, :green), "inline-block mr-1"]} />
-        知識はあるが、実務経験が浅く、自信が無い（調査が必要）
-      </li>
-      <li class="flex items-center">
-        <span class={[score_mark_class(:low, :green), "inline-block mr-1"]} />
-        知識や実務経験が無い
-      </li>
-    </ul>
-    """
-  end
-
-  defp shortcut_key_description(assigns) do
-    ~H"""
-    <div class="hidden lg:block">
-      <p class="flex flex-wrap items-center">
-        1キーを押すと
-        <span class={[score_mark_class(:high, :green), "inline-block mx-1"]} />
-        が付き、2キーを押すと
-        <span class={[score_mark_class(:middle, :green), "inline-block mx-1"]} />
-        、3キーで
-        <span class={[score_mark_class(:low, :green), "inline-block mx-1"]} />
-        が付くので、
-      </p>
-      <p>マウス無しのキーボード操作だけで快適にスキル入力できます。</p>
-    </div>
-    """
-  end
-
-  defp evidence_introduction_description(assigns) do
-    ~H"""
-    <p class="mt-4">
-      なお、各スキルを学んだ記録やメモを残したい場合は、<span class="text-brightGreen-600"><img src="/images/common/icons/skillEvidence.svg" class="inline-block"></span>から、メモを入力することが<br class="hidden lg:inline">できます。（βリリースでは他のチームメンバーにヘルプを出したりできます）
-    </p>
     """
   end
 

--- a/lib/bright_web/live/skill_panel_live/skills_form_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_form_component.ex
@@ -6,7 +6,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsFormComponent do
   import BrightWeb.SkillPanelLive.SkillPanelComponents,
     only: [profile_skill_class_level: 1, score_mark_class: 2, skill_score_percentages: 2]
 
-  import BrightWeb.SkillPanelLive.SkillsComponents,
+  import BrightWeb.GuideMessageComponents,
     only: [enter_skills_help_message: 1]
 
   import BrightWeb.SkillPanelLive.SkillPanelHelper,


### PR DESCRIPTION
## 対応内容

「スキル入力する」用のガイドメッセージを「スキル入力する」ボタン下に移動させました。
「スキル入力する」ボタンを上に配置した関係で、離れて表示されていた。

## カスタマーサクセス

Slackより。
https://digi-dock.slack.com/archives/C0550EENU86/p1697073624467989

現象：
![image](https://github.com/bright-org/bright/assets/121112529/30f99072-b72e-4173-bc10-2010efaca5bd)

## 修正後

![スクリーンショット 2023-10-12 173350](https://github.com/bright-org/bright/assets/121112529/88102dcd-b374-4b94-8edc-c535ffad5633)


※そのほかのメッセージの位置は変更していません。

![スクリーンショット 2023-10-12 173333](https://github.com/bright-org/bright/assets/121112529/a523d265-61ed-4a98-9e8b-91e598a627f7)
