### PR TITLE
スキル検索障害対応

### DIFF
--- a/lib/bright_web/live/search_live/user_search_component.ex
+++ b/lib/bright_web/live/search_live/user_search_component.ex
@@ -200,7 +200,7 @@ defmodule BrightWeb.SearchLive.UserSearchComponent do
     assign(socket, :form, to_form(changeset))
   end
 
-  defp assign_result(socket, %{entries: []} = result) do
+  defp assign_result(socket, %{entries: []}) do
     socket
     |> assign(:search_results, [])
     |> assign(:skill_params, [])


### PR DESCRIPTION
# 障害内容
## 前提
一度検索を行い、検索条件を変更してページネーションの次へのボタンを行うと、変更した条件で検索とページネーションが行われる

## 問題
次へ、前へを押したときに、件数や次へ・前への活性・非活性の情報が更新されていなかった

## 対処
検索ボタン押下時だけでなく、次へ・前へボタン押下時にも件数等を更新するようにした


https://github.com/bright-org/bright/assets/91950/d5d3d7c1-4577-4d1f-86d0-c4522190d3ba



