### PR TITLE
スキルパネル チームと比較の未招待ユーザー制御対応とメッセージ調整

### DIFF
--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -941,6 +941,10 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       insert(:team_member_users, user: user_2, team: team)
       insert(:team_member_users, user: user_3, team: team)
 
+      # 招待が終わっていないメンバーをダミーとして追加
+      user_dummy = insert(:user)
+      insert(:team_member_users, user: user_dummy, team: team, invitation_confirmed_at: nil)
+
       %{team: team}
     end
 
@@ -970,6 +974,9 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       assert has_element?(show_live, "#skills-table-field", user_3.name)
       assert has_element?(show_live, "#user-1-percentages .score-high-percentage", "33％")
       assert has_element?(show_live, "#user-2-percentages .score-high-percentage", "33％")
+
+      # 招待済みでない3人目がいないこと
+      refute has_element?(show_live, "#user-3-percentages .score-high-percentage")
     end
   end
 


### PR DESCRIPTION
## 対応内容

（１）右上メッセージのクリアが不十分だったので対応しました。ほか、メッセージ内容を調整しています。

一度エラーメッセージを出すとその後にチーム選択に成功しても、右上メッセージが消えない。

（２）招待未完了のユーザーが存在するチームを選択するとエラーになっていたので対応しました。

Sentry prod: https://digidockconsulting.sentry.io/issues/4557467583/?environment=prod&project=4505708138528768&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0