### PR TITLE
スキルパネル 「チームと比較」を初期表示するURL対応

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
@@ -17,6 +17,10 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
     evidence_filled: 0
   }
 
+  # queries: patch遷移時に保持するパラメータ
+  # NOTE:
+  #   初期状態を指定するteamなどのパラメータは含めないこと。
+  #   含めるとその状態で初期化される。
   @queries ~w(class)
 
   def assign_path(socket, url) do

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -71,8 +71,10 @@ defmodule BrightWeb.SkillPanelLive.Skills do
     {:noreply, push_redirect(socket, to: move_to)}
   end
 
-  defp apply_action(socket, :show, _params) do
-    put_flash_first_skills_edit(socket)
+  defp apply_action(socket, :show, params) do
+    socket
+    |> assign(:init_team_id, params["team"])
+    |> put_flash_first_skills_edit()
   end
 
   defp apply_action(socket, :edit, _params), do: socket

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -47,6 +47,7 @@
       display_user={@display_user}
       me={@me}
       anonymous={@anonymous}
+      init_team_id={@init_team_id}
     />
   </div>
 

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -976,7 +976,39 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       assert has_element?(show_live, "#user-2-percentages .score-high-percentage", "33％")
 
       # 招待済みでない3人目がいないこと
-      refute has_element?(show_live, "#user-3-percentages .score-high-percentage")
+      refute has_element?(show_live, "#user-3-percentages")
+    end
+
+    @tag score: :low
+    test "shows by query parameter", %{
+      conn: conn,
+      skill_panel: skill_panel,
+      team: team,
+      user: user,
+      user_2: user_2,
+      user_3: user_3
+    } do
+      skill_class_2 = insert(:skill_class, skill_panel: skill_panel, class: 2)
+      insert(:skill_class_score, user: user, skill_class: skill_class_2)
+
+      {:ok, show_live, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1&team=#{team.id}")
+
+      assert has_element?(show_live, "#skills-table-field", user_2.name)
+      assert has_element?(show_live, "#skills-table-field", user_3.name)
+      assert has_element?(show_live, "#user-1-percentages .score-high-percentage", "33％")
+      assert has_element?(show_live, "#user-2-percentages .score-high-percentage", "33％")
+      refute has_element?(show_live, "#user-3-percentages")
+
+      # 比較対象を変更してクラス切り替えで再初期化されないこと
+      show_live
+      |> element(~s(button[phx-click="reject_compared_user"][phx-value-name="#{user_3.name}"]))
+      |> render_click()
+
+      show_live
+      |> element("#class_tab_2 a")
+      |> render_click()
+
+      refute has_element?(show_live, "#user-2-percentages")
     end
   end
 


### PR DESCRIPTION
## 対応内容

issue close #1054 

スキルパネル画面で「チームと比較」のチームが最初から選択されている状態で遷移できるようにパラメータに対応しました。

- `/panels/<skill_panel_id>?team=<team_id>`
- team パラメータはあくまで初期表示を設定できる扱いにしています。