### PR TITLE
career_field_scores更新用のバッチ用処理を追加

### DIFF
--- a/lib/bright/batches.ex
+++ b/lib/bright/batches.ex
@@ -18,6 +18,15 @@ defmodule Bright.Batches do
     Bright.Batches.UpdateSkillPanels.call(today, dry_run)
   end
 
+  @doc """
+  キャリアフィールドスコアの更新バッチを実行する。
+  """
+  def update_career_field_scores do
+    load_app()
+
+    Bright.Batches.UpdateCareerFieldScores.call()
+  end
+
   defp load_app do
     Application.load(@app)
     Application.ensure_all_started(@app)

--- a/lib/bright/batches/update_career_field_scores.ex
+++ b/lib/bright/batches/update_career_field_scores.ex
@@ -1,0 +1,154 @@
+defmodule Bright.Batches.UpdateCareerFieldScores do
+  @moduledoc """
+  キャリアフィールドスコアを更新するバッチ。
+
+  キャリアフィールドスコアは、大規模な集計のため、スキルスコア更新（画面操作）の度には更新せずにバッチによって更新する。
+  """
+
+  import Ecto.Query, warn: false
+  alias Bright.Repo
+
+  alias Bright.CareerFields.CareerField
+  alias Bright.Jobs.Job
+  alias Bright.SkillPanels.SkillPanel
+  alias Bright.SkillUnits.SkillUnit
+  alias Bright.Accounts.User
+  alias Bright.SkillScores.{SkillScore, CareerFieldScore}
+
+  def call do
+    users = list_users()
+    dict_skill_ids = map_skill_ids_career_field()
+    dict_count = map_values_count(dict_skill_ids)
+    career_fields = Repo.all(CareerField)
+
+    users
+    |> Enum.each(&upsert_career_field_scores(&1, career_fields, dict_skill_ids, dict_count))
+  end
+
+  # ユーザー単位のキャリアフィールドスコア更新処理
+  defp upsert_career_field_scores(user, career_fields, dict_skill_ids, dict_count) do
+    scores =
+      career_fields
+      |> Enum.map(fn career_field ->
+        skill_ids = Map.get(dict_skill_ids, career_field.id) || []
+        count = Map.get(dict_count, career_field.id) || 0
+        high_skills_count = count_high_skills(user, skill_ids)
+        percentage = if count == 0, do: 0.0, else: high_skills_count / count
+
+        %{
+          id: Ecto.ULID.generate(),
+          user_id: user.id,
+          career_field_id: career_field.id,
+          high_skills_count: high_skills_count,
+          percentage: percentage,
+          inserted_at: {:placeholder, :timestamp},
+          updated_at: {:placeholder, :timestamp}
+        }
+      end)
+
+    timestamp = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    placeholders = %{timestamp: timestamp}
+
+    Repo.insert_all(
+      CareerFieldScore,
+      scores,
+      placeholders: placeholders,
+      on_conflict: {
+        :replace,
+        [:high_skills_count, :percentage, :updated_at]
+      },
+      conflict_target: [:user_id, :career_field_id]
+    )
+  end
+
+  # score: highのレコード数取得
+  defp count_high_skills(user, skill_ids) do
+    from(
+      skill_score in SkillScore,
+      where: skill_score.user_id == ^user.id,
+      where: skill_score.skill_id in ^skill_ids,
+      where: skill_score.score == :high
+    )
+    |> Repo.aggregate(:count)
+  end
+
+  # 対象となるユーザーを取得
+  defp list_users do
+    from(user in User, where: not is_nil(user.confirmed_at))
+    |> Repo.all()
+  end
+
+  # キャリアフィールド単位のskillsを取得
+  # career_fields - jobs - skill_panels - ... - skills と関連が深いので分割取得している
+  defp map_skill_ids_career_field do
+    career_fields = list_career_fields()
+    dict_skill_panels_job = map_jobs()
+    dict_skill_units_skill_panel = map_skill_panels()
+    dict_skills_skill_unit = map_skill_units()
+
+    career_fields
+    |> Map.new(fn career_field ->
+      jobs = career_field.jobs
+      skill_panels = Enum.flat_map(jobs, &Map.get(dict_skill_panels_job, &1.id))
+      skill_units = Enum.flat_map(skill_panels, &Map.get(dict_skill_units_skill_panel, &1.id))
+
+      skills =
+        skill_units
+        |> Enum.flat_map(&Map.get(dict_skills_skill_unit, &1.id))
+        |> Enum.uniq()
+
+      {career_field.id, Enum.map(skills, & &1.id)}
+    end)
+  end
+
+  defp list_career_fields do
+    from(
+      career_field in CareerField,
+      join: jobs in assoc(career_field, :jobs),
+      preload: [jobs: jobs]
+    )
+    |> Repo.all()
+  end
+
+  defp map_jobs do
+    from(
+      job in Job,
+      join: skill_panels in assoc(job, :skill_panels),
+      preload: [skill_panels: skill_panels]
+    )
+    |> Repo.all()
+    |> Map.new(&{&1.id, &1.skill_panels})
+  end
+
+  defp map_skill_panels do
+    from(
+      skill_panel in SkillPanel,
+      join: skill_classes in assoc(skill_panel, :skill_classes),
+      join: skill_units in assoc(skill_classes, :skill_units),
+      preload: [skill_classes: {skill_classes, skill_units: skill_units}]
+    )
+    |> Repo.all()
+    |> Map.new(fn skill_panel ->
+      skill_units = Enum.flat_map(skill_panel.skill_classes, & &1.skill_units)
+      {skill_panel.id, skill_units}
+    end)
+  end
+
+  defp map_skill_units do
+    from(
+      skill_unit in SkillUnit,
+      join: skill_categories in assoc(skill_unit, :skill_categories),
+      join: skills in assoc(skill_categories, :skills),
+      preload: [skill_categories: {skill_categories, skills: skills}]
+    )
+    |> Repo.all()
+    |> Map.new(fn skill_unit ->
+      skills = Enum.flat_map(skill_unit.skill_categories, & &1.skills)
+      {skill_unit.id, skills}
+    end)
+  end
+
+  defp map_values_count(map) do
+    Map.new(map, fn {key, values} -> {key, Enum.count(values)} end)
+  end
+end

--- a/lib/bright/career_fields/career_field.ex
+++ b/lib/bright/career_fields/career_field.ex
@@ -5,6 +5,8 @@ defmodule Bright.CareerFields.CareerField do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Bright.CareerFields.CareerFieldJob
+
   @primary_key {:id, Ecto.ULID, autogenerate: true}
   @foreign_key_type Ecto.ULID
 
@@ -13,7 +15,8 @@ defmodule Bright.CareerFields.CareerField do
     field :name_ja, :string
     field :position, :integer
 
-    has_many :jobs, Bright.Jobs.Job
+    has_many :career_field_jobs, CareerFieldJob
+    has_many :jobs, through: [:career_field_jobs, :job]
     has_many :career_field_scores, Bright.SkillScores.CareerFieldScore
 
     has_many :historical_career_field_scores,

--- a/test/bright/batches/update_career_field_scores_test.exs
+++ b/test/bright/batches/update_career_field_scores_test.exs
@@ -1,0 +1,200 @@
+defmodule Bright.Batches.UpdateCareerFieldScoresTest do
+  use Bright.DataCase
+  import Bright.Factory
+
+  alias Bright.Batches.UpdateCareerFieldScores
+  alias Bright.SkillScores.CareerFieldScore
+
+  # データ用意／キャリアフィールド
+  setup do
+    career_fields = insert_pair(:career_field)
+    %{career_fields: career_fields}
+  end
+
+  # データ用意／ジョブ
+  setup %{career_fields: career_fields} do
+    jobs =
+      Enum.flat_map(career_fields, fn career_field ->
+        insert_pair(
+          :job,
+          career_fields: [career_field],
+          career_field_jobs: [build(:career_field_job, career_field: career_field)]
+        )
+      end)
+
+    %{jobs: jobs}
+  end
+
+  # データ用意／スキルパネル
+  setup %{jobs: jobs} do
+    skill_panels =
+      Enum.flat_map(jobs, fn job ->
+        insert_pair(
+          :skill_panel,
+          jobs: [job],
+          job_skill_panels: [build(:job_skill_panel, job: job)]
+        )
+      end)
+
+    %{skill_panels: skill_panels}
+  end
+
+  # データ用意／スキルユニット
+  setup %{skill_panels: skill_panels} do
+    skill_units =
+      Enum.flat_map(skill_panels, fn skill_panel ->
+        skill_class = insert(:skill_class, skill_panel: skill_panel)
+
+        insert_pair(
+          :skill_unit,
+          skill_classes: [skill_class],
+          skill_class_units: [build(:skill_class_unit, skill_class: skill_class)]
+        )
+      end)
+
+    %{skill_units: skill_units}
+  end
+
+  # データ用意／スキル
+  setup %{skill_units: skill_units} do
+    skills =
+      Enum.flat_map(skill_units, fn skill_unit ->
+        [%{skills: skills_a}, %{skills: skills_b}] =
+          insert_skill_categories_and_skills(skill_unit, [2, 2])
+
+        skills_a ++ skills_b
+      end)
+
+    %{skills: skills}
+  end
+
+  describe "call/0" do
+    setup do
+      user = insert(:user)
+      %{user: user}
+    end
+
+    test "creates career_field_scores, case skill_scores are empty", %{user: user} do
+      UpdateCareerFieldScores.call()
+
+      [career_field_score_1, career_field_score_2] =
+        Repo.preload(user, :career_field_scores).career_field_scores
+
+      assert career_field_score_1.percentage == 0.0
+      assert career_field_score_2.percentage == 0.0
+    end
+
+    test "creates career_field_scores", %{
+      user: user,
+      career_fields: [career_field_1, career_field_2],
+      skills: skills
+    } do
+      # スキルスコア用意
+      [
+        # 0, 1はcareer_field_1に属する
+        {Enum.at(skills, 0), :high},
+        {Enum.at(skills, 1), :high},
+        # -1, -2はcareer_field_2に属する
+        {Enum.at(skills, -1), :high},
+        {Enum.at(skills, -2), :middle}
+      ]
+      |> Enum.each(fn {skill, score} ->
+        insert(:skill_score, user: user, skill: skill, score: score)
+      end)
+
+      UpdateCareerFieldScores.call()
+
+      career_field_score_1 =
+        Repo.get_by(CareerFieldScore, user_id: user.id, career_field_id: career_field_1.id)
+
+      career_field_score_2 =
+        Repo.get_by(CareerFieldScore, user_id: user.id, career_field_id: career_field_2.id)
+
+      assert career_field_score_1.high_skills_count == 2
+      assert career_field_score_1.percentage == 2 / 32
+
+      assert career_field_score_2.high_skills_count == 1
+      assert career_field_score_2.percentage == 1 / 32
+    end
+
+    test "updates career_field_scores", %{
+      user: user,
+      career_fields: [career_field, _],
+      skills: [skill | _]
+    } do
+      career_field_score =
+        insert(:career_field_score,
+          user: user,
+          career_field: career_field,
+          percentage: 100.0,
+          high_skills_count: 100
+        )
+
+      insert(:skill_score, user: user, skill: skill, score: :high)
+
+      UpdateCareerFieldScores.call()
+
+      career_field_score = Repo.get(CareerFieldScore, career_field_score.id)
+      assert career_field_score.high_skills_count == 1
+      assert career_field_score.percentage == 1 / 32
+    end
+
+    test "multiple users must be covered", %{
+      user: user_1,
+      career_fields: [career_field_1, career_field_2],
+      skills: skills
+    } do
+      # キャリアフィールドスコア [1, 2] に対して、
+      # user_1 [1/32, 0]
+      # user_2 [0, 1/32]
+      # がupsertにより期待結果となるようなデータを準備
+      user_2 = insert(:user)
+      skill_1 = Enum.at(skills, 0)
+      skill_2 = Enum.at(skills, -1)
+      insert(:skill_score, user: user_1, skill: skill_1, score: :high)
+      insert(:skill_score, user: user_2, skill: skill_2, score: :high)
+
+      insert(:career_field_score,
+        user: user_1,
+        career_field: career_field_2,
+        percentage: 100.0,
+        high_skills_count: 100
+      )
+
+      insert(:career_field_score,
+        user: user_2,
+        career_field: career_field_1,
+        percentage: 100.0,
+        high_skills_count: 100
+      )
+
+      UpdateCareerFieldScores.call()
+
+      percentage = 1 / 32
+
+      assert %{high_skills_count: 1, percentage: ^percentage} =
+               Repo.get_by(CareerFieldScore,
+                 user_id: user_1.id,
+                 career_field_id: career_field_1.id
+               )
+
+      assert %{high_skills_count: 0, percentage: 0.0} =
+               Repo.get_by(CareerFieldScore,
+                 user_id: user_1.id,
+                 career_field_id: career_field_2.id
+               )
+
+      assert %{high_skills_count: 0, percentage: 0.0} =
+               Repo.get_by(CareerFieldScore,
+                 user_id: user_2.id,
+                 career_field_id: career_field_1.id
+               )
+
+      assert %{high_skills_count: 1, percentage: ^percentage} =
+               Repo.get_by(CareerFieldScore,
+                 user_id: user_2.id,
+                 career_field_id: career_field_2.id
+               )
+    end
+  end
+end

--- a/test/bright/batches_test.exs
+++ b/test/bright/batches_test.exs
@@ -41,4 +41,19 @@ defmodule Bright.BatchesTest do
       ]
     end
   end
+
+  describe "update_career_field_scores/0" do
+    # see ./batches/update_career_field_scores_test.exs
+
+    alias Bright.Batches.UpdateCareerFieldScores
+
+    test "call" do
+      with_mocks([
+        {UpdateCareerFieldScores, [:passthrough], [call: fn -> nil end]}
+      ]) do
+        Batches.update_career_field_scores()
+        assert_called(UpdateCareerFieldScores.call())
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 対応内容

issue #1065 

career_field_scoresを更新するバッチ処理を追加しました。
（稼働設定は、頻度などの調整のうえで別PRで扱います）

career_field_scoresはキャリアフィールド（「エンジニア」などの括り）単位でのスキル取得率を保存します。
下記の元データとして使用します。

![image](https://github.com/bright-org/bright/assets/121112529/73265972-af8a-4847-8d5c-47506175bc5c)
