### PR TITLE
スキルパネル更新バッチのflaky testを修正

### DIFF
--- a/test/bright/batches/update_skill_panels_test.exs
+++ b/test/bright/batches/update_skill_panels_test.exs
@@ -160,8 +160,8 @@ defmodule Bright.Batches.UpdateSkillPanelsTest do
       skill_unit_scores =
         Enum.flat_map(skill_units, fn skill_unit ->
           [
-            insert(:skill_unit_score, skill_unit: skill_unit, user: user1),
-            insert(:skill_unit_score, skill_unit: skill_unit, user: user2)
+            insert(:skill_unit_score, skill_unit: skill_unit, user: user1, percentage: 1.0),
+            insert(:skill_unit_score, skill_unit: skill_unit, user: user2, percentage: 1.0)
           ]
         end)
 
@@ -180,8 +180,8 @@ defmodule Bright.Batches.UpdateSkillPanelsTest do
       skill_class_scores =
         Enum.flat_map(skill_classes, fn skill_class ->
           [
-            insert(:skill_class_score, skill_class: skill_class, user: user1),
-            insert(:skill_class_score, skill_class: skill_class, user: user2)
+            insert(:skill_class_score, skill_class: skill_class, user: user1, percentage: 1.0),
+            insert(:skill_class_score, skill_class: skill_class, user: user2, percentage: 1.0)
           ]
         end)
 


### PR DESCRIPTION
Ref #1011

## やったこと

- スコアのパーセンテージが再計算後も偶然同じになってしまうケースに対応

## やってないこと

- スコアの再計算でスコアデータが増えてしまうケースの対応
  - https://github.com/bright-org/bright/issues/1011#issuecomment-1774520087