### PR TITLE
スキル更新処理 ランダムに落ちるテスト対応

### DIFF
--- a/test/bright/batches/update_skill_panels_test.exs
+++ b/test/bright/batches/update_skill_panels_test.exs
@@ -170,8 +170,8 @@ defmodule Bright.Batches.UpdateSkillPanelsTest do
           Enum.flat_map(skill_unit.skill_categories, fn skill_category ->
             Enum.flat_map(skill_category.skills, fn skill ->
               [
-                insert(:skill_score, skill: skill, user: user1),
-                insert(:skill_score, skill: skill, user: user2)
+                insert(:skill_score, skill: skill, user: user1, score: :middle),
+                insert(:skill_score, skill: skill, user: user2, score: :middle)
               ]
             end)
           end)


### PR DESCRIPTION
## 対応内容

issue close #1011

スキル更新処理のテストで、状況によって、スキルクラス開放が発生して落ちるテストがあったので修正しました。

https://github.com/bright-org/bright/issues/1011#issuecomment-1756737186
