### PR TITLE
未使用のjobs.career_field_idを削除

### DIFF
--- a/lib/bright/historical_skill_scores/historical_career_field_score.ex
+++ b/lib/bright/historical_skill_scores/historical_career_field_score.ex
@@ -14,7 +14,7 @@ defmodule Bright.HistoricalSkillScores.HistoricalCareerFieldScore do
     field :high_skills_count, :integer, default: 0
 
     belongs_to(:user, Bright.Accounts.User)
-    belongs_to(:career_field, Bright.Jobs.CareerField)
+    belongs_to(:career_field, Bright.CareerFields.CareerField)
 
     timestamps()
   end

--- a/lib/bright/jobs/job.ex
+++ b/lib/bright/jobs/job.ex
@@ -16,7 +16,6 @@ defmodule Bright.Jobs.Job do
     field :description, :string
     field :position, :integer
     field :rank, Ecto.Enum, values: [:entry, :basic, :advanced, :expert]
-    field :career_field_id, :string
 
     has_many :career_field_jobs, CareerFieldJob, on_replace: :delete
     has_many :career_fields, through: [:career_field_jobs, :career_field]

--- a/priv/repo/migrations/20231024010552_remove_career_field_id_from_jobs.exs
+++ b/priv/repo/migrations/20231024010552_remove_career_field_id_from_jobs.exs
@@ -1,0 +1,19 @@
+defmodule Bright.Repo.Migrations.RemoveCareerFieldIdFromJobs do
+  use Ecto.Migration
+
+  def up do
+    alter table(:jobs) do
+      remove :career_field_id
+    end
+
+    drop_if_exists index(:jobs, [:career_field_id])
+  end
+
+  def down do
+    alter table(:jobs) do
+      add :career_field_id, references(:career_fields, on_delete: :nothing)
+    end
+
+    create_if_not_exists index(:jobs, [:career_field_id])
+  end
+end


### PR DESCRIPTION
## 対応内容

jobsとcareer_fieldsの使用していない関連があったので削除しました。
いまは多対多でつながっています。

- 管理画面でjobを作成してキャリアフィールドとつなげてもカラムに情報が入らないことを確認しました。