### PR TITLE
UpdateCareerFieldScore テーブル状況次第でエラーになる現象対応

### DIFF
--- a/lib/bright/batches/update_career_field_scores.ex
+++ b/lib/bright/batches/update_career_field_scores.ex
@@ -89,12 +89,14 @@ defmodule Bright.Batches.UpdateCareerFieldScores do
     career_fields
     |> Map.new(fn career_field ->
       jobs = career_field.jobs
-      skill_panels = Enum.flat_map(jobs, &Map.get(dict_skill_panels_job, &1.id))
-      skill_units = Enum.flat_map(skill_panels, &Map.get(dict_skill_units_skill_panel, &1.id))
+      skill_panels = Enum.flat_map(jobs, &(Map.get(dict_skill_panels_job, &1.id) || []))
+
+      skill_units =
+        Enum.flat_map(skill_panels, &(Map.get(dict_skill_units_skill_panel, &1.id) || []))
 
       skills =
         skill_units
-        |> Enum.flat_map(&Map.get(dict_skills_skill_unit, &1.id))
+        |> Enum.flat_map(&(Map.get(dict_skills_skill_unit, &1.id) || []))
         |> Enum.uniq()
 
       {career_field.id, Enum.map(skills, & &1.id)}

--- a/test/bright/batches/update_career_field_scores_test.exs
+++ b/test/bright/batches/update_career_field_scores_test.exs
@@ -196,5 +196,10 @@ defmodule Bright.Batches.UpdateCareerFieldScoresTest do
                  career_field_id: career_field_2.id
                )
     end
+
+    test "no error occured if jobsskill_panels is empty", %{jobs: [job | _]} do
+      Repo.delete_all(Ecto.assoc(job, :job_skill_panels))
+      UpdateCareerFieldScores.call()
+    end
   end
 end


### PR DESCRIPTION
## 対応内容

キャリアフィールドスコア更新処理のバグ対応です。
あまり実際にはないかもしれませんが、発生する可能性のあるエラーをつぶしました。
