### PR TITLE
スキルパネル スキルクラス開放仕様を外して常時開放に変更

### DIFF
--- a/lib/bright_web/components/guide_message_components.ex
+++ b/lib/bright_web/components/guide_message_components.ex
@@ -63,21 +63,6 @@ defmodule BrightWeb.GuideMessageComponents do
   end
 
   @doc """
-  クラス開放メッセージ
-  """
-  def next_skill_class_opened_message(assigns) do
-    ~H"""
-    <div>
-      <p>クラス開放おめでとうございます！</p>
-      <p class="mt-2">クラス開放後は「成長を見る・比較する」メニューでスキルレベルを確認できます。</p>
-    </div>
-    <div class="mt-4 max-w-[400px]">
-      <img src="/images/sample_groth_graph.png" alt="成長グラフ" />
-    </div>
-    """
-  end
-
-  @doc """
   求職案内メッセージ
   """
   def prompt_job_searching_message(assigns) do

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -332,29 +332,26 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
     ~H"""
     <ul class="flex shadow relative z-1 text-base font-bold text-brightGray-500 bg-brightGreen-50 lg:-bottom-1 lg:text-center lg:text-md w-full lg:w-fit">
       <%= for {skill_class, skill_class_score} <- pair_skill_class_score(@skill_classes) do %>
-        <%= if skill_class_score do %>
-          <% current = @skill_class.class == skill_class.class %>
-          <li id={"class_tab_#{skill_class.class}"} class={["grow", current && "bg-white text-base", "first:border-none last:border-none lg:border-x-4"]}>
-            <.link
-              patch={"#{@path}?#{build_query(@query, %{"class" => skill_class.class})}"}
-              class="flex lg:justify-start items-center px-2 lg:px-4 py-1 lg:py-3 lg:text-base"
-              aria-current={current && "page"}
-            >
-              <span class="text-sm lg:text-base" :if={current}>クラス<%= skill_class.class %></span>
-              <span class="text-xs lg:text-base" :if={!current}>クラス<%= skill_class.class %></span>
-              <span class="hidden lg:flex"><%= skill_class.name %></span>
-              <span class="text-lg text-right lg:text-xl min-w-[32px] lg:min-w-0 ml-1 lg:ml-4"><%= floor skill_class_score.percentage %></span>％
-            </.link>
-          </li>
-        <% else %>
-          <li id={"class_tab_#{skill_class.class}"} class="grow lg:grow-0 bg-pureGray-600 text-pureGray-100 first:border-none last:border-none lg:border-x-4">
-            <a href="#" class="flex items-center lg:select-none px-2 lg:px-4 py-1 lg:py-3 text-xs lg:text-base">
-              <span class="text-xs lg:text-base">クラス<%= skill_class.class %></span>
-              <span class="hidden lg:block"><%= skill_class.name %></span>
-              <span class="text-lg text-right lg:text-xl min-w-[32px] lg:min-w-0 ml-1 lg:ml-4">0</span>％
-            </a>
-          </li>
-        <% end %>
+        <% current = @skill_class.class == skill_class.class %>
+        <li id={"class_tab_#{skill_class.class}"} class={["grow", current && "bg-white text-base", "first:border-none last:border-none lg:border-x-4"]}>
+          <.link
+            patch={"#{@path}?#{build_query(@query, %{"class" => skill_class.class})}"}
+            class="flex lg:justify-start items-center px-2 lg:px-4 py-1 lg:py-3 lg:text-base"
+            aria-current={current && "page"}
+          >
+            <span class="text-sm lg:text-base" :if={current}>クラス<%= skill_class.class %></span>
+            <span class="text-xs lg:text-base" :if={!current}>クラス<%= skill_class.class %></span>
+            <span class="hidden lg:flex"><%= skill_class.name %></span>
+            <span class="text-lg text-right lg:text-xl min-w-[32px] lg:min-w-0 ml-1 lg:ml-4">
+              <%= if skill_class_score do %>
+                <%= floor skill_class_score.percentage %>
+              <% else %>
+                0
+              <% end %>
+              ％
+            </span>
+          </.link>
+        </li>
       <% end %>
     </ul>
     """

--- a/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
@@ -127,17 +127,9 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
   end
 
   def create_skill_class_score_if_not_existing(
-        %{
-          assigns: %{
-            me: true,
-            skill_class_score: nil,
-            skill_class: %{class: 1}
-          }
-        } = socket
+        %{assigns: %{me: true, skill_class_score: nil}} = socket
       ) do
-    # NOTE: skill_class_scoreが存在しないときの生成処理について
-    # 管理側でスキルクラスを増やすなどの操作も想定し、
-    # アクセスしたタイミングで生成するようにしています。
+    # 始めてスキルクラスにアクセスした際にスキルクラススコアを生成
     user = socket.assigns.current_user
     skill_class = socket.assigns.skill_class
 

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -446,15 +446,6 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
         id="help-first-skill-submit-in-overall">
         <.first_submit_in_overall_message />
       </.live_component>
-
-      <% # クラス開放メッセージ %>
-      <% # NOTE: idはGAイベントトラッキング対象、変更の際は確認と共有必要 %>
-      <.live_component
-        :if={Map.get(@flash, "next_skill_class_opened")}
-        module={BrightWeb.HelpMessageComponent}
-        id="help-next-class-opened">
-        <.next_skill_class_opened_message />
-      </.live_component>
     </div>
     """
   end

--- a/lib/bright_web/live/skill_panel_live/skills_form_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_form_component.ex
@@ -233,14 +233,13 @@ defmodule BrightWeb.SkillPanelLive.SkillsFormComponent do
     } = socket.assigns
 
     target_skill_scores = skill_score_dict |> Map.values() |> Enum.filter(& &1.changed)
-    {:ok, updated_result} = SkillScores.insert_or_update_skill_scores(target_skill_scores, user)
+    {:ok, _updated_result} = SkillScores.insert_or_update_skill_scores(target_skill_scores, user)
 
     # スキルクラスのレベル変更時に保有スキルカードの表示変更を通知
     maybe_update_skill_card_component(skill_class_score)
 
     {:noreply,
      socket
-     |> put_flash_next_skill_class_opened(updated_result, skill_class_score.id)
      |> put_flash_first_submit_in_overall()
      |> put_flash_first_submit_in_skill_panel()
      |> push_patch(to: socket.assigns.patch)}
@@ -358,16 +357,6 @@ defmodule BrightWeb.SkillPanelLive.SkillsFormComponent do
     if prev_level != new_level do
       send_update(SkillCardComponent, id: "skill_card", status: "level_changed")
     end
-  end
-
-  # スキルクラス解放時のメッセージ表示のためflashを設定
-  defp put_flash_next_skill_class_opened(socket, updated_result, skill_class_score_id) do
-    get_in(updated_result, [
-      :skill_class_scores,
-      :"skill_class_score_#{skill_class_score_id}",
-      :next_skill_class_score
-    ])
-    |> if(do: put_flash(socket, :next_skill_class_opened, true), else: socket)
   end
 
   # スキル初回入力（全体初）後に表示するメッセージのためのflashを設定


### PR DESCRIPTION
## 対応内容

issue close #1099

> クラス２や３は、下位スキルクラスを40%習得すると開放される（スキルクラス開放）。
この仕様を変更し、いつでも見れて入力できるようにする。

下記画像のように取得直後から閲覧可能になりました。

![スクリーンショット 2023-10-30 115159](https://github.com/bright-org/bright/assets/121112529/4183f5cd-b67f-477b-b865-425cad65cfa9)
