### PR TITLE
学習メモ テキストエリアのプレースホルダ文言を変更

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
@@ -324,7 +324,7 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
       <textarea
         id={@id}
         name={@name}
-        placeholder="コメントを入力"
+        placeholder="学習メモを入力"
         class="w-full min-h-1 outline-none border-none focus:ring-0 p-2"
       ><%= Phoenix.HTML.Form.normalize_value("textarea", @value) %></textarea>
       <div>


### PR DESCRIPTION
## 対応内容

「コメント」になっていたので「学習メモ」にしました。

![スクリーンショット 2023-10-30 130209](https://github.com/bright-org/bright/assets/121112529/ffb3fe39-7bce-4f93-bb14-62e7679162c8)
