### PR TITLE
成長グラフ 「自分と比較」に対応

### DIFF
--- a/assets/js/hooks/GrowthGraph.js
+++ b/assets/js/hooks/GrowthGraph.js
@@ -43,14 +43,13 @@ const createDataset = (
 };
 
 const createData = (data) => {
-  const futureEnabled =
-    data["future_enabled"] === undefined ? true : data["future_enabled"];
-  const [myselfData, myselfFuture] = dataDivision(
-    data["myself"],
-    futureEnabled
-  );
-  const [otherData, otherFuture] = dataDivision(data["other"], futureEnabled);
-  const [roleData, roleFuture] = dataDivision(data["role"], futureEnabled);
+  const futureEnabled = data["futureEnabled"] === undefined ? true : data["futureEnabled"]
+  const otherFutureEnabled = data["otherFutureEnabled"] === undefined ? true : data["otherFutureEnabled"]
+  const roleFutureEnabled = data["roleFutureEnabled"] === undefined ? true : data["roleFutureEnabled"]
+
+  const [myselfData, myselfFuture] = dataDivision(data["myself"], futureEnabled);
+  const [otherData, otherFuture] = dataDivision(data["other"], otherFutureEnabled);
+  const [roleData, roleFuture] = dataDivision(data["role"], roleFutureEnabled);
   const datasets = [];
   datasets.push(
     createDataset(
@@ -364,7 +363,7 @@ const beforeDatasetsDraw = (chart, ease) => {
   const myselfSelectedIndex = data.labels.findIndex(myselfSelected);
 
   const otherSelected = (element) => element == data["otherSelected"];
-  const otherSelectedIndex = data.labels.findIndex(otherSelected);
+  const otherSelectedIndex = (data["otherLabels"] || []).findIndex(otherSelected);
 
   drawvVrticalLine(context, scales);
   drawHorizonLine(context, scales);
@@ -399,7 +398,7 @@ const afterDatasetsDraw = (chart, ease) => {
   const myselfSelectedIndex = data.labels.findIndex(myselfSelected);
 
   const otherSelected = (element) => element == data["otherSelected"];
-  const otherSelectedIndex = data.labels.findIndex(otherSelected);
+  const otherSelectedIndex = (data["otherLabels"] || []).findIndex(otherSelected);
 
   drawSelectedPoint(
     chart,

--- a/lib/bright/historical_skill_scores.ex
+++ b/lib/bright/historical_skill_scores.ex
@@ -106,9 +106,11 @@ defmodule Bright.HistoricalSkillScores do
 
   ## Examples
 
-      iex> get_historical_skill_class_scores(locked_date, skill_panel_id, class, user_id,from_date, to_date)
+      iex> get_historical_skill_class_scores(locked_date, skill_panel_id, class, user_id, from_date, to_date)
       [
-        %{locked_date: ~D[2022-10-01], percentage: 15.555555555555555}
+        {~D[2022-10-01], 15.555555555555555},
+        {~D[2023-01-01], 25.0},
+        ...
       ]
   """
   def list_historical_skill_class_score_percentages(

--- a/lib/bright_web/components/chart_components.ex
+++ b/lib/bright_web/components/chart_components.ex
@@ -54,9 +54,10 @@ defmodule BrightWeb.ChartComponents do
           role: [20, 20, 50, 60, 75, 100],
           now: 55,
           futureEnabled: true,
-          labels: ["2020.12", "2021.3", "2021.6", "2021.9", "2011.12"],
+          labels: ["2020.12", "2021.3", "2021.6", "2021.9", "2021.12"],
           myselfSelected: "2021.9",
-          otherSelected: "2020.12"
+          otherSelected: "2020.12",
+          otherLabels: ["2020.09", "2020.12", "2021.3", "2021.6", "2021.9"]
         }
 
   ## Examples

--- a/lib/bright_web/live/chart_live/growth_graph_component.ex
+++ b/lib/bright_web/live/chart_live/growth_graph_component.ex
@@ -4,32 +4,39 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
   """
 
   use BrightWeb, :live_component
+
   import BrightWeb.ChartComponents
   import BrightWeb.TimelineBarComponents
+
   alias Bright.SkillScores
   alias Bright.HistoricalSkillScores
+  alias Bright.UserProfiles
   alias BrightWeb.TimelineHelper
 
   @impl true
   def render(assigns) do
     ~H"""
     <div class="flex flex-col w-full lg:w-[880px]">
-      <!-- グラフ -->
+
+      <% # ロールモデル解除 %>
       <div class="ml-auto mr-28 mt-6 mb-1">
         <%# TODO 他者選択できるまで非表示 %>
-          <button :if={false}
-            type="button"
-            class="text-brightGray-600 bg-white px-2 py-1 inline-flex font-medium rounded-md text-sm items-center border border-brightGray-200"
-          >
-            ロールモデルを解除
-          </button>
+        <button :if={false}
+          type="button"
+          class="text-brightGray-600 bg-white px-2 py-1 inline-flex font-medium rounded-md text-sm items-center border border-brightGray-200"
+        >
+          ロールモデルを解除
+        </button>
       </div>
+
+      <% # 成長グラフ %>
       <div class="flex">
         <div class="w-14 relative">
           <button
             :if={@timeline.past_enabled}
+            phx-click="shift_timeline_past"
+            phx-value-id="myself"
             phx-target={@myself}
-            phx-click={JS.push("shift_timeline_past", value: %{id: "myself" })}
             class="w-8 h-6 bg-brightGray-900 flex justify-center items-center rounded absolute -bottom-1 lg:bottom-1 lg:w-11 lg:h-9"
             disabled={false}
           >
@@ -56,7 +63,8 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
           <p class="py-2 lg:py-6">見習い</p>
           <button
             :if={@timeline.future_enabled}
-            phx-click={JS.push("shift_timeline_future", value: %{id: "myself" })}
+            phx-click="shift_timeline_future"
+            phx-value-id="myself"
             phx-target={@myself}
             class="w-8 h-6 bg-brightGray-900 flex justify-center items-center rounded absolute -bottom-1 lg:bottom-1 lg:w-11 lg:h-9"
             disabled={false}
@@ -72,6 +80,8 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
           </button>
         </div>
       </div>
+
+      <% # タイムライン１ 自身 %>
       <div class="flex">
         <div class="w-7 lg:w-14"></div>
         <.timeline_bar
@@ -84,20 +94,35 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
         />
         <div class="flex justify-center items-center ml-2"></div>
       </div>
-      <div class="flex py-4">
+
+      <% # 比較対象 選択 PCのみ %>
+      <div :if={is_nil @compared_user} class="hidden lg:flex py-4">
+        <div class="w-7 lg:w-14"> </div>
+        <div class="flex w-full">
+          <button
+            class="text-brightGray-600 bg-white px-2 py-2 inline-flex font-medium rounded-md text-sm items-center border border-brightGray-200"
+            type="button"
+            phx-click="compare_myself"
+            phx-target={@myself}
+          >
+            <span class="min-w-[6em]">自分と比較</span>
+          </button>
+        </div>
+        <div class="flex justify-center items-center ml-2"></div>
+      </div>
+
+      <% # 比較対象 表示 PCのみ %>
+      <div :if={compared_user_display?(@compared_user, @user_id)} class="hidden lg:flex py-4">
         <div class="w-14"></div>
         <div class="w-[725px] flex justify-between items-center">
-          <div class="text-left flex items-center text-base hover:bg-brightGray-50">
-          <%# TODO 他者選択できるまで非表示 %>
-            <a :if={false} class="inline-flex items-center border border-brightGray-200 px-3 py-1 rounded">
-              <img class="inline-block h-10 w-10 rounded-full" src="https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=2&amp;w=256&amp;h=256&amp;q=80" />
-              <div>
-                <p>nokichi</p>
-                <p class="text-brightGray-300">アプリエンジニア</p>
-              </div>
-            </a>
+          <div class="text-left flex items-center text-base border border-brightGray-200 px-3 py-1 rounded">
+            <img class="inline-block h-10 w-10 rounded-full" src={UserProfiles.icon_url(@compared_user.user_profile.icon_file_path)} />
+            <div class="ml-2">
+              <p><%= @compared_user.name %></p>
+              <p class="text-brightGray-300"><%= @compared_user.user_profile.title %></p>
+            </div>
           </div>
-          <%# TODO 他者選択できるまで非表示 %>
+          <%# TODO ロールモデル対応できるまで非表示 %>
           <button :if={false}
             type="button"
             class="text-brightGray-600 bg-white px-2 py-1 inline-flex font-medium rounded-md text-sm items-center border border-brightGray-200"
@@ -108,20 +133,70 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
         <div></div>
       </div>
 
-      <%# TODO 他者選択できるまで非表示 %>
-      <div :if={false} class="flex">
-        <div class="w-14"></div>
+      <% # タイムライン２ 比較対象用 PCのみ %>
+      <% # TODO 他者選択できるまで非表示 %>
+      <div :if={@compared_user} class="flex">
+        <div class="w-14 flex justify-start items-center">
+          <button
+            :if={@compared_timeline.past_enabled}
+            phx-click="shift_timeline_past"
+            phx-value-id="other"
+            phx-target={@myself}
+            class="w-8 h-6 lg:w-11 lg:h-9 bg-brightGray-900 flex justify-center items-center rounded"
+            disabled={false}
+          >
+            <span class="material-icons text-white !text-xl lg:!text-4xl">arrow_left</span>
+          </button>
+          <button
+            :if={!@compared_timeline.past_enabled}
+            phx-target={@myself}
+            class="w-8 h-6 lg:w-11 lg:h-9 bg-brightGray-300 flex justify-center items-center rounded"
+            disabled={true}
+          >
+            <span class="material-icons text-white !text-4xl">arrow_left</span>
+          </button>
+        </div>
+
         <.timeline_bar
+          :if={@compared_timeline}
           id="other"
           target={@myself}
           type="other"
-          dates={["2022.12", "2023.3", "2023.6", "2023.9", "2023.12"]}
-          selected_date="2023.12"
+          dates={@compared_timeline.labels}
+          selected_date={@compared_timeline.selected_label}
+          display_now={false}
         />
-        <div class="flex justify-center items-center ml-2"></div>
+
+        <div class="w-14 flex justify-end items-center">
+          <button
+            :if={@compared_timeline.future_enabled}
+            phx-click="shift_timeline_future"
+            phx-value-id="other"
+            phx-target={@myself}
+            class="w-8 h-6 lg:w-11 lg:h-9 bg-brightGray-900 flex justify-center items-center rounded"
+            disabled={false}
+          >
+            <span class="material-icons text-white !text-xl lg:!text-4xl">arrow_right</span>
+          </button>
+          <button
+            :if={!@compared_timeline.future_enabled}
+            class="w-8 h-6 lg:w-11 lg:h-9 bg-brightGray-300 flex justify-center items-center rounded"
+            disabled={true}
+          >
+            <span class="material-icons text-white !text-xl lg:!text-4xl">arrow_right</span>
+          </button>
+        </div>
       </div>
     </div>
     """
+  end
+
+  @impl true
+  def mount(socket) do
+    {:ok,
+     socket
+     |> assign(data: %{})
+     |> assign(compared_user: nil)}
   end
 
   @impl true
@@ -132,144 +207,184 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
       socket
       |> assign(assigns)
       |> assign(timeline: timeline)
-      |> create_data()
+      |> create_user_data()
 
     {:ok, socket}
   end
 
   @impl true
-  def handle_event("timeline_bar_button_click", %{"date" => date} = params, socket) do
+  def handle_event(
+        "timeline_bar_button_click",
+        %{"id" => "myself", "date" => label} = params,
+        socket
+      ) do
     Process.send(self(), %{event_name: "timeline_bar_button_click", params: params}, [])
-
-    timeline =
-      socket.assigns.timeline
-      |> TimelineHelper.select_label(date)
-
-    socket =
-      socket
-      |> assign(timeline: timeline)
-      |> select_data()
-
-    {:noreply, socket}
+    {:noreply, select_data(socket, "myself", label)}
   end
 
-  def handle_event("shift_timeline_past", _params, socket) do
-    timeline =
-      socket.assigns.timeline
-      |> TimelineHelper.shift_for_past()
-
-    socket =
-      socket
-      |> assign(timeline: timeline)
-      |> create_data()
-
-    {:noreply, socket}
+  def handle_event("timeline_bar_button_click", %{"id" => "other", "date" => label}, socket) do
+    {:noreply, select_data(socket, "other", label)}
   end
 
-  def handle_event("shift_timeline_future", _params, socket) do
-    timeline =
-      socket.assigns.timeline
-      |> TimelineHelper.shift_for_future()
+  def handle_event("shift_timeline_past", %{"id" => "myself"}, socket) do
+    timeline = TimelineHelper.shift_for_past(socket.assigns.timeline)
 
-    socket =
-      socket
-      |> assign(timeline: timeline)
-      |> create_data()
-
-    {:noreply, socket}
+    {:noreply,
+     socket
+     |> assign(timeline: timeline)
+     |> create_user_data()}
   end
 
-  defp create_data(
-         %{
-           assigns: %{
-             user_id: user_id,
-             skill_panel_id: skill_panel_id,
-             class: class,
-             timeline: timeline
-           }
-         } = socket
-       ) do
-    data = %{
-      myselfSelected: timeline.selected_label,
-      labels: timeline.labels,
-      future_enabled: !timeline.future_enabled,
-      past_enabled: timeline.past_enabled
-    }
+  def handle_event("shift_timeline_past", %{"id" => "other"}, socket) do
+    compared_timeline = TimelineHelper.shift_for_past(socket.assigns.compared_timeline)
 
-    from_date =
-      data.labels
-      |> List.first()
-      |> TimelineHelper.label_to_date()
-      |> Timex.shift(months: -TimelineHelper.get_monthly_interval())
+    {:noreply,
+     socket
+     |> assign(compared_timeline: compared_timeline)
+     |> create_compared_user_data()}
+  end
 
-    # 未来データは別のテーブから取得するため、過去の範囲の日付にする
-    to_date_label_index = if data.future_enabled, do: -2, else: -1
+  def handle_event("shift_timeline_future", %{"id" => "myself"}, socket) do
+    timeline = TimelineHelper.shift_for_future(socket.assigns.timeline)
 
-    to_date =
-      data.labels
-      |> Enum.at(to_date_label_index)
-      |> TimelineHelper.label_to_date()
+    {:noreply,
+     socket
+     |> assign(timeline: timeline)
+     |> create_user_data()}
+  end
 
-    myself_init_data =
-      [date_to_label(from_date) | data.labels]
-      |> Enum.map(fn x -> {:"#{label_to_key_date(x)}", 0} end)
+  def handle_event("shift_timeline_future", %{"id" => "other"}, socket) do
+    compared_timeline = TimelineHelper.shift_for_future(socket.assigns.compared_timeline)
 
-    myself =
-      HistoricalSkillScores.list_historical_skill_class_score_percentages(
-        skill_panel_id,
-        class,
-        user_id,
-        TimelineHelper.get_shift_date_from_date(from_date, -1),
-        TimelineHelper.get_shift_date_from_date(to_date, -1)
-      )
-      |> Enum.reduce(myself_init_data, fn {key, val}, acc ->
-        Keyword.put(acc, label_to_key_date(date_to_label(key)) |> String.to_atom(), val)
-      end)
-      |> Keyword.take(Keyword.keys(myself_init_data))
-      |> Enum.sort()
-      |> Keyword.values()
+    {:noreply,
+     socket
+     |> assign(compared_timeline: compared_timeline)
+     |> create_compared_user_data()}
+  end
+
+  def handle_event("compare_myself", _params, socket) do
+    compared_timeline = TimelineHelper.select_past_if_label_is_now(socket.assigns.timeline)
+
+    {:noreply,
+     socket
+     |> assign(compared_timeline: compared_timeline)
+     |> assign(compared_user: socket.assigns.current_user)
+     |> create_compared_user_data()}
+  end
+
+  def handle_event("timeline_bar_close_button_click", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(compared_timeline: nil)
+     |> assign(compared_user: nil)}
+  end
+
+  defp create_user_data(socket) do
+    %{
+      user_id: user_id,
+      skill_panel_id: skill_panel_id,
+      class: class,
+      timeline: timeline,
+      data: data
+    } = socket.assigns
+
+    past_values = get_past_score_values(timeline, user_id, skill_panel_id, class)
 
     data =
-      Map.merge(
-        data,
-        %{
-          # role: [10, 20, 50, 60, 75, 100],
-          # myself: [nil, 0, 35, 45, 55, 65],
-          myself: myself
-          # other: [10, 10, 25, 35, 45, 70],
-          # otherSelected: "2022.12"
-        }
-      )
+      Map.merge(data, %{
+        myself: past_values,
+        myselfSelected: timeline.selected_label,
+        labels: timeline.labels,
+        # TODO: ここ`!`は意味が反転しているので未来対応時に要確認。timelineのfuture_enabled（未来選択可能)とグラフデータ上のfuture_enabled(未来が表示されている?)というようにそれぞれで意味が違うのかもしれない。
+        futureEnabled: !timeline.future_enabled
+      })
 
-    data =
-      if data.future_enabled,
-        do:
-          Map.put(
-            data,
-            :now,
-            SkillScores.get_class_score(user_id, skill_panel_id, class) |> get_now()
-          ),
-        else: data |> Map.delete(:now)
+    # 「現在」表示が存在するならばいれる。そうでないならばキー自体を除去
+    # TODO: ここもfuture_enabledの意味が反転している?ので要確認
+    now_value =
+      if data.futureEnabled do
+        (SkillScores.get_class_score(user_id, skill_panel_id, class) || %{})
+        |> Map.get(:percentage, 0)
+      end
+
+    data = if now_value, do: Map.put(data, :now, now_value), else: Map.delete(data, :now)
 
     assign(socket, data: data)
   end
 
-  defp label_to_key_date(label) do
-    [year, month] = String.split(label, ".")
-    month = String.pad_leading(month, 2, "0")
-    "#{year}.#{month}"
+  defp create_compared_user_data(socket) do
+    %{
+      compared_user: compared_user,
+      skill_panel_id: skill_panel_id,
+      class: class,
+      compared_timeline: compared_timeline
+    } = socket.assigns
+
+    past_values =
+      get_past_score_values(compared_timeline, compared_user.id, skill_panel_id, class)
+
+    update(socket, :data, fn data ->
+      Map.merge(data, %{
+        other: past_values,
+        otherSelected: compared_timeline.selected_label,
+        otherLabels: compared_timeline.labels,
+        # TODO: ここ`!`は意味が反転しているので未来対応時に要確認。timelineのfuture_enabled（未来選択可能)とグラフデータ上のfuture_enabled(未来が表示されている?)というようにそれぞれで意味が違うのかもしれない。
+        otherFutureEnabled: !compared_timeline.future_enabled
+      })
+    end)
   end
 
-  defp date_to_label(data), do: "#{data.year}.#{data.month}"
+  defp get_past_score_values(timeline, user_id, skill_panel_id, class) do
+    # タイムラインに表示されている範囲の過去履歴を取得する
+    # to_date_index: タイムラインに未来が表示されているかどうかを考慮し決定
+    from_date = TimelineHelper.get_date_at(timeline, 0)
+    future_display_on_timeline? = if(timeline.future_enabled, do: false, else: true)
+    to_date_index = if(future_display_on_timeline?, do: -2, else: -1)
+    to_date = TimelineHelper.get_date_at(timeline, to_date_index)
 
-  defp select_data(socket) do
-    data =
-      socket.assigns.data
-      |> Map.put(:myselfSelected, socket.assigns.timeline.selected_label)
+    # タイムライン上の点より、1つ過去から線を引くため1つ前にしている
+    invisible_past_date = TimelineHelper.get_shift_date_from_date(from_date, -1)
 
-    assign(socket, :data, data)
+    date_percentages =
+      HistoricalSkillScores.list_historical_skill_class_score_percentages(
+        skill_panel_id,
+        class,
+        user_id,
+        # 取得においてスキル構造系のデータから引くため1つ前のlocked_dateを指定している
+        TimelineHelper.get_shift_date_from_date(invisible_past_date, -1),
+        TimelineHelper.get_shift_date_from_date(to_date, -1)
+      )
+      |> Map.new()
+
+    # past_values: lablesの日付が小さい順にそのときの取得率
+    past_values =
+      timeline.labels
+      |> Enum.map(&TimelineHelper.label_to_date/1)
+      |> Enum.sort({:asc, Date})
+      |> Enum.map(&(Map.get(date_percentages, &1) || 0))
+
+    invisible_past_value = Map.get(date_percentages, invisible_past_date) || 0
+
+    [invisible_past_value | past_values]
   end
 
-  defp get_now(%{percentage: now}), do: now
-  defp get_now(nil), do: 0
+  defp select_data(socket, "myself", label) do
+    timeline = TimelineHelper.select_label(socket.assigns.timeline, label)
+
+    socket
+    |> assign(timeline: timeline)
+    |> update(:data, &Map.put(&1, :myselfSelected, label))
+  end
+
+  defp select_data(socket, "other", label) do
+    compared_timeline = TimelineHelper.select_label(socket.assigns.compared_timeline, label)
+
+    socket
+    |> assign(compared_timeline: compared_timeline)
+    |> update(:data, &Map.put(&1, :otherSelected, label))
+  end
+
+  defp compared_user_display?(compared_user, user_id) do
+    compared_user && !(compared_user.id == user_id)
+  end
 end

--- a/lib/bright_web/live/graph_live/graphs.html.heex
+++ b/lib/bright_web/live/graph_live/graphs.html.heex
@@ -31,6 +31,7 @@
       <.live_component
         id="rowth-graph"
         module={BrightWeb.ChartLive.GrowthGraphComponent}
+        current_user={@current_user}
         user_id={@display_user.id}
         skill_panel_id={@skill_panel.id}
         class={@skill_class.class}

--- a/lib/bright_web/live/timeline_helper.ex
+++ b/lib/bright_web/live/timeline_helper.ex
@@ -39,8 +39,7 @@ defmodule BrightWeb.TimelineHelper do
   end
 
   def select_label(timeline, label) do
-    timeline
-    |> Map.put(:selected_label, label)
+    Map.put(timeline, :selected_label, label)
   end
 
   def shift_for_future(timeline) do
@@ -73,6 +72,13 @@ defmodule BrightWeb.TimelineHelper do
     })
   end
 
+  def select_past_if_label_is_now(%{selected_label: "now"} = timeline) do
+    past_label = Enum.at(timeline.labels, -2)
+    select_label(timeline, past_label)
+  end
+
+  def select_past_if_label_is_now(timeline), do: timeline
+
   def get_monthly_interval, do: @monthly_interval
 
   @doc """
@@ -92,6 +98,15 @@ defmodule BrightWeb.TimelineHelper do
       {selected_label, false, latest_label} when selected_label == latest_label -> :future
       _ -> :past
     end
+  end
+
+  @doc """
+  指定されたindexの日付を返す
+  """
+  def get_date_at(timeline, index) do
+    timeline.labels
+    |> Enum.at(index)
+    |> label_to_date()
   end
 
   def label_to_date(label) when not is_bitstring(label), do: nil

--- a/storybook/chart_graph/growth_graph.story.exs
+++ b/storybook/chart_graph/growth_graph.story.exs
@@ -15,6 +15,7 @@ defmodule Storybook.ChartComponents.GrowthGraph do
             now: 55,
             futureEnabled: true,
             labels: ["2020.12", "2021.3", "2021.6", "2021.9", "2011.12"],
+            otherLabels: ["2020.12", "2021.3", "2021.6", "2021.9", "2011.12"],
             myselfSelected: "2021.9",
             otherSelected: "2020.12"
           }
@@ -30,6 +31,7 @@ defmodule Storybook.ChartComponents.GrowthGraph do
             now: 55,
             futureEnabled: true,
             labels: ["2020.12", "2021.3", "2021.6", "2021.9", "2011.12"],
+            otherLabels: ["2020.12", "2021.3", "2021.6", "2021.9", "2011.12"],
             myselfSelected: "2021.6",
             otherSelected: "2020.12"
           }
@@ -45,6 +47,7 @@ defmodule Storybook.ChartComponents.GrowthGraph do
             now: 55,
             futureEnabled: true,
             labels: ["2020.12", "2021.3", "2021.6", "2021.9", "2011.12"],
+            otherLabels: ["2020.12", "2021.3", "2021.6", "2021.9", "2011.12"],
             myselfSelected: "now",
             otherSelected: "2020.12"
           }
@@ -58,7 +61,8 @@ defmodule Storybook.ChartComponents.GrowthGraph do
             other: [10, 10, 10, 10, 45, 80],
             role: [20, 20, 50, 60, 75, 100],
             futureEnabled: false,
-            labels: ["2020.12", "2021.3", "2021.6", "2021.9", "2011.12"]
+            labels: ["2020.12", "2021.3", "2021.6", "2021.9", "2011.12"],
+            otherLabels: ["2020.12", "2021.3", "2021.6", "2021.9", "2011.12"]
           }
         }
       },
@@ -87,7 +91,9 @@ defmodule Storybook.ChartComponents.GrowthGraph do
           data: %{
             myself: [10, 10, 35, 45, 55, 60],
             other: [10, 10, 10, 10, 45, 80],
+            futureEnabled: false,
             labels: ["2020.12", "2021.3", "2021.6", "2021.9", "2011.12"],
+            otherLabels: ["2020.12", "2021.3", "2021.6", "2021.9", "2011.12"],
             myselfSelected: "2021.9",
             otherSelected: "2011.12"
           }

--- a/test/bright_web/live/graph_live/graph_test.exs
+++ b/test/bright_web/live/graph_live/graph_test.exs
@@ -3,6 +3,18 @@ defmodule BrightWeb.GraphLive.GraphsTest do
 
   import Phoenix.LiveViewTest
   import Bright.Factory
+  import Mock
+
+  defp date_mock do
+    {
+      Date,
+      [:passthrough],
+      [
+        utc_today: fn -> ~D[2023-10-25] end,
+        new: fn y, m, d -> passthrough([y, m, d]) end
+      ]
+    }
+  end
 
   describe "Show" do
     setup [:register_and_log_in_user]
@@ -56,6 +68,172 @@ defmodule BrightWeb.GraphLive.GraphsTest do
 
       {path, _} = assert_redirect(show_live)
       assert path == "/onboardings"
+    end
+  end
+
+  # 成長グラフ
+  # 成長グラフはJSでの描画のため渡しているdata属性を主な対象として確認している
+  describe "Growth grapth" do
+    setup [:register_and_log_in_user]
+
+    setup %{user: user} do
+      skill_panel = insert(:skill_panel)
+      skill_class = insert(:skill_class, skill_panel: skill_panel, class: 1)
+      insert(:user_skill_panel, user: user, skill_panel: skill_panel)
+
+      %{skill_panel: skill_panel, skill_class: skill_class}
+    end
+
+    @base_data %{
+      now: 0.0,
+      labels: ["2023.1", "2023.4", "2023.7", "2023.10", "2024.1"],
+      myself: [0, 0, 0, 0, 0, 0],
+      futureEnabled: true,
+      myselfSelected: "now"
+    }
+
+    test "shows growth graph", %{
+      conn: conn,
+      skill_panel: skill_panel
+    } do
+      with_mocks([date_mock()]) do
+        {:ok, show_live, _html} = live(conn, ~p"/graphs/#{skill_panel}")
+        data = Jason.encode!(@base_data)
+        assert has_element?(show_live, ~s(#growth-graph[data-data='#{data}']))
+      end
+    end
+
+    test "shows now data", %{
+      conn: conn,
+      user: user,
+      skill_panel: skill_panel,
+      skill_class: skill_class
+    } do
+      insert(:skill_class_score, user: user, skill_class: skill_class, percentage: 50.0)
+
+      with_mocks([date_mock()]) do
+        {:ok, show_live, _html} = live(conn, ~p"/graphs/#{skill_panel}")
+        data = Map.merge(@base_data, %{now: 50.0}) |> Jason.encode!()
+        assert has_element?(show_live, ~s(#growth-graph[data-data='#{data}']))
+      end
+    end
+
+    test "shows past data", %{
+      conn: conn,
+      user: user,
+      skill_panel: skill_panel
+    } do
+      h_skill_class_1 =
+        insert(:historical_skill_class,
+          locked_date: ~D[2023-07-01],
+          skill_panel_id: skill_panel.id,
+          class: 1
+        )
+
+      h_skill_class_2 =
+        insert(:historical_skill_class,
+          locked_date: ~D[2023-04-01],
+          skill_panel_id: skill_panel.id,
+          class: 1
+        )
+
+      insert(:historical_skill_class_score,
+        locked_date: ~D[2023-10-01],
+        user: user,
+        historical_skill_class: h_skill_class_1,
+        percentage: 20.0
+      )
+
+      insert(:historical_skill_class_score,
+        locked_date: ~D[2023-07-01],
+        user: user,
+        historical_skill_class: h_skill_class_2,
+        percentage: 10.0
+      )
+
+      with_mocks([date_mock()]) do
+        {:ok, show_live, _html} = live(conn, ~p"/graphs/#{skill_panel}")
+
+        data =
+          Map.merge(@base_data, %{
+            myself: [0, 0, 0, 10.0, 20.0, 0]
+          })
+          |> Jason.encode!()
+
+        assert has_element?(show_live, ~s(#growth-graph[data-data='#{data}']))
+      end
+    end
+
+    test "shows compared my data", %{
+      conn: conn,
+      user: user,
+      skill_panel: skill_panel
+    } do
+      h_skill_class_1 =
+        insert(:historical_skill_class,
+          locked_date: ~D[2023-07-01],
+          skill_panel_id: skill_panel.id,
+          class: 1
+        )
+
+      h_skill_class_2 =
+        insert(:historical_skill_class,
+          locked_date: ~D[2023-04-01],
+          skill_panel_id: skill_panel.id,
+          class: 1
+        )
+
+      insert(:historical_skill_class_score,
+        locked_date: ~D[2023-10-01],
+        user: user,
+        historical_skill_class: h_skill_class_1,
+        percentage: 20.0
+      )
+
+      insert(:historical_skill_class_score,
+        locked_date: ~D[2023-07-01],
+        user: user,
+        historical_skill_class: h_skill_class_2,
+        percentage: 10.0
+      )
+
+      with_mocks([date_mock()]) do
+        {:ok, show_live, _html} = live(conn, ~p"/graphs/#{skill_panel}")
+
+        # 「自分と比較」を選択
+        show_live
+        |> element(~s(button[phx-click="compare_myself"]))
+        |> render_click()
+
+        data =
+          Map.merge(@base_data, %{
+            myself: [0, 0, 0, 10.0, 20.0, 0],
+            other: [0, 0, 0, 10.0, 20.0, 0],
+            otherLabels: ["2023.1", "2023.4", "2023.7", "2023.10", "2024.1"],
+            otherFutureEnabled: true,
+            otherSelected: "2023.10"
+          })
+          |> Jason.encode!()
+
+        assert has_element?(show_live, ~s(#growth-graph[data-data='#{data}']))
+
+        # 比較側を１月ずらす操作
+        show_live
+        |> element(~s(button[phx-click="shift_timeline_past"][phx-value-id="other"]))
+        |> render_click()
+
+        data =
+          Map.merge(@base_data, %{
+            myself: [0, 0, 0, 10.0, 20.0, 0],
+            other: [0, 0, 0, 0, 10.0, 20.0],
+            otherLabels: ["2022.10", "2023.1", "2023.4", "2023.7", "2023.10"],
+            otherFutureEnabled: false,
+            otherSelected: "2023.10"
+          })
+          |> Jason.encode!()
+
+        assert has_element?(show_live, ~s(#growth-graph[data-data='#{data}']))
+      end
     end
   end
 end


### PR DESCRIPTION
## 対応内容

issue #51 

まずは「自分と比較」まで切りが良いので追加しています。

## 参考画像

「自分と比較」を開いて、比較側を動かしています。

![sample55](https://github.com/bright-org/bright/assets/121112529/f9361033-3166-46bf-8dc0-6f6ea298305b)
