### PR TITLE
成長グラフ 「他者と比較」に対応

### DIFF
--- a/lib/bright/user_profiles.ex
+++ b/lib/bright/user_profiles.ex
@@ -171,4 +171,14 @@ defmodule Bright.UserProfiles do
   def build_icon_path(file_name) do
     "users/profile_icon_#{Ecto.UUID.generate()}" <> Path.extname(file_name)
   end
+
+  @doc """
+  匿名表示相当のUserProfileを返す
+  """
+  def get_anonymous_user_profile do
+    %UserProfile{
+      title: "非表示",
+      detail: "非表示"
+    }
+  end
 end

--- a/lib/bright_web/components/timeline_bar_components.ex
+++ b/lib/bright_web/components/timeline_bar_components.ex
@@ -184,7 +184,8 @@ defmodule BrightWeb.TimelineBarComponents do
   defp close_button(assigns) do
     ~H"""
     <button
-      phx-click={JS.push("timeline_bar_close_button_click", value: %{id: @id})}
+      phx-click="timeline_bar_close_button_click"
+      phx-value-id={@id}
       phx-target={@target}
       class="absolute right-0 -top-2 border rounded-full w-6 h-6 flex justify-center items-center bg-white border-brightGray-200"
     >


### PR DESCRIPTION
## 対応内容

issue #51 
成長グラフの「他者と比較」に対応しました。

## 参考画像

![sample56](https://github.com/bright-org/bright/assets/121112529/a82dcf2a-f3c0-45dc-8882-c1b5b7057481)

（採用候補者の匿名表示）
![image](https://github.com/bright-org/bright/assets/121112529/e606f2bc-c177-414a-9322-cca4913c1c94)
