### PR TITLE
スキルパネル 「スキルを入力する」案内を強調する対応

### DIFF
--- a/lib/bright_web/components/layout_components.ex
+++ b/lib/bright_web/components/layout_components.ex
@@ -89,7 +89,7 @@ defmodule BrightWeb.LayoutComponents do
       |> assign(:page_sub_title, page_sub_title)
 
     ~H"""
-    <div id="user-header" class="sticky top-0 z-10 flex flex-col-reverse justify-between px-4 py-2 border-brightGray-100 border-b bg-white w-full lg:flex-row lg:items-center lg:px-10 lg:relative">
+    <div id="user-header" class="sticky top-0 z-10 lg:z-20 flex flex-col-reverse justify-between px-4 py-2 border-brightGray-100 border-b bg-white w-full lg:flex-row lg:items-center lg:px-10 lg:relative">
       <h4 class="lg:hidden font-bold mt-2 text-sm before:bg-bgGem before:bg-6 before:bg-left before:bg-no-repeat before:content-[''] before:h-6 before:inline-block before:align-[-5px] before:w-6">
         <%= @page_title %><%= @page_sub_title %>
       </h4>
@@ -128,7 +128,7 @@ defmodule BrightWeb.LayoutComponents do
 
   def side_menu(assigns) do
     ~H"""
-    <aside class="relative">
+    <aside class="relative lg:z-20">
       <input id="sp_navi_input" class="hidden peer" type="checkbox">
       <label id="sp_navi_open" class="bg-white block cursor-pointer fixed h-10 ml-4 left-0 rounded top-2 w-10 z-50 lg:hidden" for="sp_navi_input">
         <span class="absolute bg-brightGray-300 block cursor-pointer h-[3px] left-1 top-1.5 w-8 before:bg-brightGray-300 before:block before:content-[''] before:cursor-pointer before:h-[3px] before:absolute before:top-3 before:w-8 after:bg-brightGray-300 after:block after:content-[''] after:cursor-pointer after:h-[3px] after:absolute after:top-6 after:w-8"></span>

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -369,7 +369,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
             <.link
               patch={~p"/panels/#{@skill_panel}/edit?#{@query}"}
               id="link-skills-form"
-              class="flex-1 flex items-center text-sm font-bold justify-center pl-6 py-3 relative rounded !text-white bg-brightGray-900 hover:opacity-50">
+              class={[Map.get(@flash, "first_skills_edit") && "z-20", "flex-1 flex items-center text-sm font-bold justify-center pl-6 py-3 relative rounded !text-white bg-brightGray-900 hover:opacity-50"]}>
               <span class="absolute material-icons-outlined left-4 top-1/2 text-white !text-xl -translate-y-1/2">edit</span>
               スキル入力する
             </.link>
@@ -386,6 +386,8 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
           <div class="lg:absolute lg:right-0 lg:top-16 lg:z-10 flex items-center lg:items-end flex-col">
             <% # スキル入力前メッセージ %>
             <% # NOTE: idはGAイベントトラッキング対象、変更の際は確認と共有必要 %>
+
+            <div :if={Map.get(@flash, "first_skills_edit")} class="bg-pureGray-600/90 fixed inset-0 transition-opacity"></div>
             <.live_component
               :if={Map.get(@flash, "first_skills_edit")}
               module={BrightWeb.HelpMessageComponent}


### PR DESCRIPTION
## 対応内容

下記に対応しました。

①バルーンを目立たせるために、バルーンと「スキル入力する」以外の背景をグレーアウトした状態で初期表示
②上記①の状態から「スキル入力する」ボタンをクリックするまで、他をクリック不可（メニュー系除く）

## 参考画像

![スクリーンショット 2023-11-01 210333](https://github.com/bright-org/bright/assets/121112529/99eefcb3-65fb-4cc8-8ecb-f8bb37a4fd07)

![スクリーンショット 2023-11-01 210212](https://github.com/bright-org/bright/assets/121112529/ca4f0f19-3997-47df-9e24-6df1ae5a567b)
