### PR TITLE
チーム分析で、チームをスイッチ時に表示スキルパネルが維持されない不具合解消

### DIFF
--- a/lib/bright_web/live/card_live/related_team_card_component.ex
+++ b/lib/bright_web/live/card_live/related_team_card_component.ex
@@ -99,11 +99,11 @@ defmodule BrightWeb.CardLive.RelatedTeamCardComponent do
 
     {:ok,
      socket
+     |> assign(:over_ride_on_card_row_click_target, false)
      |> assign(assigns)
      |> assign(:tabs, tabs)
      |> assign(:card, create_card_param(first_tab))
-     |> assign_card(first_tab)
-     |> assign(:over_ride_on_card_row_click_target, false)}
+     |> assign_card(first_tab)}
   end
 
   defp filter_tabs(tabs, nil), do: tabs

--- a/lib/bright_web/live/team_live/my_team_live.html.heex
+++ b/lib/bright_web/live/team_live/my_team_live.html.heex
@@ -47,7 +47,7 @@
           id="team_card"
           module={BrightWeb.CardLive.RelatedTeamCardComponent}
           display_user={@current_user}
-          over_ride_on_card_row_click_target={:true}
+          over_ride_on_card_row_click_target={true}
         />
       </.mega_menu_button>
       </div>


### PR DESCRIPTION
スイッチ時にスキルパネルを維持するロジック自体はあったが、イベント上書きフラグが常にfalseになっていたため、動作していなかった


https://github.com/bright-org/bright/assets/91950/655d2728-705f-47bc-8cee-698a47bdfe5d

