### PR TITLE
重複しているHTML id属性を削除

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -236,10 +236,9 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
 
   def toggle_link(assigns) do
     ~H"""
-      <div class="bg-white text-brightGray-500 rounded-full inline-flex flex-row text-sm font-bold h-10">
+    <div class="bg-white text-brightGray-500 rounded-full inline-flex flex-row text-sm font-bold h-10">
       <.link navigate={"#{PathHelper.skill_panel_path("graphs", @skill_panel, @display_user, @me, @anonymous)}?class=#{@skill_class}"}>
         <button
-          id="grid"
           class={
             "inline-flex items-center font-bold rounded-l-full px-6 py-2 " <>
             if @active == "graph", do: "button-toggle-active", else: ""
@@ -247,19 +246,18 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
         >
           成長パネル
         </button>
-        </.link>
-        <.link navigate={"#{PathHelper.skill_panel_path("panels", @skill_panel, @display_user, @me, @anonymous)}?class=#{@skill_class}"}>
-          <button
-            id="list"
-            class={
-              "inline-flex items-center font-bold rounded-r-full px-4 py-2 " <>
-              if @active == "panel", do: "button-toggle-active", else: ""
-            }
-          >
-            スキルパネル
-          </button>
-        </.link>
-      </div>
+      </.link>
+      <.link navigate={"#{PathHelper.skill_panel_path("panels", @skill_panel, @display_user, @me, @anonymous)}?class=#{@skill_class}"}>
+        <button
+          class={
+            "inline-flex items-center font-bold rounded-r-full px-4 py-2 " <>
+            if @active == "panel", do: "button-toggle-active", else: ""
+          }
+        >
+          スキルパネル
+        </button>
+      </.link>
+    </div>
     """
   end
 

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -20,15 +20,14 @@
   </div>
   <div class="flex justify-between">
     <div class="hidden lg:flex">
-          <.toggle_link
-      skill_panel={@skill_panel}
-      display_user={@display_user}
-      me={@me}
-      anonymous={@anonymous}
-      skill_class={@skill_class.class}
-      active="panel"
-    />
-
+      <.toggle_link
+        skill_panel={@skill_panel}
+        display_user={@display_user}
+        me={@me}
+        anonymous={@anonymous}
+        skill_class={@skill_class.class}
+        active="panel"
+      />
     </div>
     <.class_tab skill_classes={@skill_classes} skill_class={@skill_class} path={@path} query={@query} />
   </div>


### PR DESCRIPTION
## 対応内容

PCとスマホの出し分け要素でid重複があった（用途無しとみられるid）ので解消しています。
（成長グラフ <=> スキルパネルのトグルスイッチ部分）