### PR TITLE
学習メモ 他者のメモも削除できる不具合対応

### DIFF
--- a/lib/bright/skill_evidences.ex
+++ b/lib/bright/skill_evidences.ex
@@ -154,6 +154,10 @@ defmodule Bright.SkillEvidences do
   """
   def get_skill_evidence_post!(id), do: Repo.get!(SkillEvidencePost, id)
 
+  def get_skill_evidence_post_by!(condition) do
+    Repo.get_by!(SkillEvidencePost, condition)
+  end
+
   @doc """
   Creates a skill_evidence_post.
 

--- a/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
@@ -44,13 +44,13 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
                   <% nil -> %>
                   <% [] -> %>
                   <% [image_path] -> %>
-                    <div class="evidence-image object-cover relative mt-3">
+                    <div class="evidence-image object-cover relative mt-3 cursor-pointer">
                       <img class="imagebox" src={image_url(image_path)} />
                     </div>
                   <% image_paths -> %>
                     <div class="evidence-images gap-2 flex flex-wrap mt-3">
                       <%= for image_path <- image_paths do %>
-                        <div class="object-cover relative w-[calc(50%-0.25rem)] box-border">
+                        <div class="object-cover relative w-[calc(50%-0.25rem)] box-border cursor-pointer">
                           <img class="imagebox" src={image_url(image_path)} />
                         </div>
                       <% end %>
@@ -59,6 +59,7 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
 
                 <% # 削除ボタン %>
                 <div
+                  :if={post_by_myself?(post, @user)}
                   class="h-6 w-6 py-2 ml-auto cursor-pointer"
                   phx-click="delete"
                   phx-target={@myself}
@@ -94,13 +95,13 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
                 <.error :for={err <- @entry_errors}><%= upload_error_to_string(err) %></.error>
               </div>
               <%= if Enum.count(@uploads.image.entries) == 1 do %>
-                <div class="object-cover relative mt-1">
+                <div class="object-cover relative mt-1 cursor-pointer">
                   <.uploading_image myself={@myself} entry={hd(@uploads.image.entries)} />
                 </div>
               <% else %>
                 <div class="gap-2 flex flex-wrap mt-1">
                   <%= for entry <- @uploads.image.entries do %>
-                    <div class="object-cover relative w-[calc(50%-0.25rem)] box-border">
+                    <div class="object-cover relative w-[calc(50%-0.25rem)] box-border cursor-pointer">
                       <.uploading_image myself={@myself} entry={entry} />
                     </div>
                   <% end %>
@@ -160,7 +161,7 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
         phx-hook="Imagebox"
         data-imagebox-container={@id}
         data-imagebox-img-target-class="imagebox">
-        <img class="object-cover" />
+        <img class="object-cover cursor-pointer" />
         <a class="btn-close-imagebox absolute z-50 top-6 right-8 text-white text-5xl font-bold">&times;</a>
       </div>
     </div>
@@ -257,7 +258,10 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
   end
 
   def handle_event("delete", %{"id" => skill_evidence_post_id}, socket) do
-    SkillEvidences.get_skill_evidence_post!(skill_evidence_post_id)
+    SkillEvidences.get_skill_evidence_post_by!(
+      id: skill_evidence_post_id,
+      user_id: socket.assigns.user.id
+    )
     |> SkillEvidences.delete_skill_evidence_post()
     |> case do
       {:ok, %{delete: skill_evidence_post}} ->
@@ -340,6 +344,10 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
 
   defp image_url(image_path) do
     Storage.public_url(image_path)
+  end
+
+  defp post_by_myself?(evidence_post, user) do
+    evidence_post.user_id == user.id
   end
 
   defp unassign_invalid_image_entries(socket) do

--- a/test/bright/skill_evidences_test.exs
+++ b/test/bright/skill_evidences_test.exs
@@ -160,6 +160,19 @@ defmodule Bright.SkillEvidencesTest do
                skill_evidence_post
     end
 
+    test "get_skill_evidence_post_by!/1 returns the skill_evidence_post with given condition", %{
+      valid_attrs: valid_attrs
+    } do
+      skill_evidence_post = insert(:skill_evidence_post, valid_attrs)
+
+      assert SkillEvidences.get_skill_evidence_post_by!(id: skill_evidence_post.id) ==
+               skill_evidence_post
+
+      assert_raise Ecto.NoResultsError, fn ->
+        SkillEvidences.get_skill_evidence_post_by!(id: skill_evidence_post.id, content: "hoge")
+      end
+    end
+
     test "create_skill_evidence_post/1 with valid data creates a skill_evidence_post", %{
       user: user,
       skill_evidence: skill_evidence

--- a/test/bright_web/live/skill_panel_live/skill_evident_component_test.exs
+++ b/test/bright_web/live/skill_panel_live/skill_evident_component_test.exs
@@ -113,7 +113,16 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponentTest do
       {:ok, lv, _html} = live(conn, ~p"/panels/#{skill_panel}?class=1")
       open_modal(lv)
 
-      assert render(lv) =~ skill_evidence_post.content
+      assert has_element?(
+               lv,
+               ~s(#skill_evidence_posts-#{skill_evidence_post.id}),
+               "some content by others"
+             )
+
+      refute has_element?(
+               lv,
+               ~s(#skill_evidence_posts-#{skill_evidence_post.id} [phx-click="delete"])
+             )
     end
   end
 


### PR DESCRIPTION
## 対応内容

削除アイコンが他の人のメモ投稿にも出ていたので修正しました。
また画像がクリックできることがわかるようにcursor-pointerを追加しています（前回ランチMTGでの指摘事項）
