### PR TITLE
スキルパネル選択後のオーバーレイが案内メッセージ操作後も解除されない現象対応

### DIFF
--- a/lib/bright_web/components/layout_components.ex
+++ b/lib/bright_web/components/layout_components.ex
@@ -89,7 +89,7 @@ defmodule BrightWeb.LayoutComponents do
       |> assign(:page_sub_title, page_sub_title)
 
     ~H"""
-    <div id="user-header" class="sticky top-0 z-10 lg:z-20 flex flex-col-reverse justify-between px-4 py-2 border-brightGray-100 border-b bg-white w-full lg:flex-row lg:items-center lg:px-10 lg:relative">
+    <div id="user-header" class="sticky top-0 z-40 flex flex-col-reverse justify-between px-4 py-2 border-brightGray-100 border-b bg-white w-full lg:flex-row lg:items-center lg:px-10 lg:relative">
       <h4 class="lg:hidden font-bold mt-2 text-sm before:bg-bgGem before:bg-6 before:bg-left before:bg-no-repeat before:content-[''] before:h-6 before:inline-block before:align-[-5px] before:w-6">
         <%= @page_title %><%= @page_sub_title %>
       </h4>

--- a/lib/bright_web/components/mega_menu_components.ex
+++ b/lib/bright_web/components/mega_menu_components.ex
@@ -52,7 +52,7 @@ defmodule BrightWeb.MegaMenuComponents do
       </button>
 
       <div
-        class={["dropdownTarget z-10 hidden bg-white rounded-sm shadow static w-full", @menu_width]}
+        class={["dropdownTarget z-30 hidden bg-white rounded-sm shadow static w-full", @menu_width]}
       >
         <%= render_slot(@inner_block) %>
       </div>

--- a/lib/bright_web/live/help_message_component.ex
+++ b/lib/bright_web/live/help_message_component.ex
@@ -14,38 +14,44 @@ defmodule BrightWeb.HelpMessageComponent do
 
   def render(assigns) do
     ~H"""
-    <div id={@id} class="relative px-4 py-2 my-1 rounded text-sm bg-designer-dazzle leading-normal">
-      <%= render_slot(@inner_block) %>
+    <div id={@id}>
+      <div :if={@overlay} class="bg-pureGray-600/90 fixed inset-0 transition-opacity"></div>
+      <div class="relative px-4 py-2 my-1 rounded text-sm bg-designer-dazzle leading-normal">
+        <%= render_slot(@inner_block) %>
 
-      <div class="flex gap-4 justify-center pt-2">
+        <div class="flex gap-4 justify-center pt-2">
+          <button
+            id={good_button_id(@id)}
+            type="button"
+            class="btn-help-good bg-brightGray-900 border border-brightGray-900 font-bold p-1 rounded text-white w-48"
+            phx-click={JS.push("good", target: @myself) |> hide("##{@id}")}>
+            この説明は分かりやすい
+          </button>
+          <button
+            id={bad_button_id(@id)}
+            type="button"
+            class="btn-help-bad bg-white border border-brightGray-900 font-bold p-1 rounded text-brightGray-900 w-24"
+            phx-click={JS.push("bad", target: @myself) |> hide("##{@id}")}>
+            わかりにくい
+          </button>
+        </div>
+
         <button
-          id={good_button_id(@id)}
-          type="button"
-          class="btn-help-good bg-brightGray-900 border border-brightGray-900 font-bold p-1 rounded text-white w-48"
-          phx-click={JS.push("good", target: @myself) |> hide("##{@id}")}>
-          この説明は分かりやすい
-        </button>
-        <button
-          id={bad_button_id(@id)}
-          type="button"
-          class="btn-help-bad bg-white border border-brightGray-900 font-bold p-1 rounded text-brightGray-900 w-24"
-          phx-click={JS.push("bad", target: @myself) |> hide("##{@id}")}>
-          わかりにくい
+          class="absolute top-2 right-2"
+          phx-click={JS.push("close", target: @myself) |> hide("##{@id}")}>
+          <span class="material-icons text-white bg-brightGray-900 rounded-full !text-sm w-5 h-5 flex justify-center items-center">close</span>
         </button>
       </div>
-
-      <button
-        class="absolute top-2 right-2"
-        phx-click={JS.push("close", target: @myself) |> hide("##{@id}")}>
-        <span class="material-icons text-white bg-brightGray-900 rounded-full !text-sm w-5 h-5 flex justify-center items-center">close</span>
-      </button>
     </div>
     """
   end
 
   @impl true
   def mount(socket) do
-    {:ok, assign(socket, :open, true)}
+    {:ok,
+     socket
+     |> assign(:open, true)
+     |> assign(:overlay, false)}
   end
 
   @impl true

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -381,15 +381,14 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
             </div>
           </div>
 
-          <div class="lg:absolute lg:right-0 lg:top-16 lg:z-10 flex items-center lg:items-end flex-col">
+          <div class="lg:absolute lg:right-0 lg:top-16 z-10 flex items-center lg:items-end flex-col">
             <% # スキル入力前メッセージ %>
             <% # NOTE: idはGAイベントトラッキング対象、変更の際は確認と共有必要 %>
-
-            <div :if={Map.get(@flash, "first_skills_edit")} class="bg-pureGray-600/90 fixed inset-0 transition-opacity"></div>
             <.live_component
               :if={Map.get(@flash, "first_skills_edit")}
               module={BrightWeb.HelpMessageComponent}
-              id="help-enter-skills">
+              id="help-enter-skills"
+              overlay={true}>
               <.first_skills_edit_message />
             </.live_component>
 

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -175,7 +175,7 @@ defmodule BrightWeb.SkillPanelLive.Skills do
     %{skill_class: skill_class, skill_score_dict: skill_score_dict} = socket.assigns
     skill_scores = Map.values(skill_score_dict)
 
-    (skill_class.class == 1 && Enum.all?(skill_scores, &(&1.score == :low)))
+    (skill_class.class == 1 && Enum.all?(skill_scores, &(&1.id == nil)))
     |> if do
       update(socket, :flash, &Map.put(&1, "first_skills_edit", true))
     else


### PR DESCRIPTION
## 対応内容

「スキル入力する」ボタンをクリックせずに、スキルパネル選択後のバルーンをクローズ（「✕」ボタン、「分かりやすい」「わかりにくい」ボタン）すると、灰色背景が残ったままになる現象を解消しました。

もとの現象：
![image](https://github.com/bright-org/bright/assets/121112529/19219e3b-1a6e-439c-ba48-4085ba90a134)

修正後：
![sample58](https://github.com/bright-org/bright/assets/121112529/1d35a2f9-3567-4675-ac68-1f05a825bdd0)
