### PR TITLE
成長グラフ＆スキルパネル 対象者切替時に未開放のクラスをクリック不可にする修正

### DIFF
--- a/lib/bright_web/live/graph_live/graphs.html.heex
+++ b/lib/bright_web/live/graph_live/graphs.html.heex
@@ -30,7 +30,13 @@
       active="graph"
     />
     </div>
-    <.class_tab skill_classes={@skill_classes} skill_class={@skill_class} path={@path} query={@query} />
+    <.class_tab
+      skill_classes={@skill_classes}
+      skill_class={@skill_class}
+      path={@path}
+      query={@query}
+      me={@me}
+    />
   </div>
   <div class="bg-white shadow relative z-2 px-2 py-1 lg:pl-7 lg:pr-5 lg:py-0">
     <h3 class="text-xl my-4 lg:hidden"><%= "クラス#{@skill_class.class} : #{@skill_class.name}" %></h3>

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -332,25 +332,35 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
     <ul class="flex shadow relative z-1 text-base font-bold text-brightGray-500 bg-brightGreen-50 lg:-bottom-1 lg:text-center lg:text-md w-full lg:w-fit">
       <%= for {skill_class, skill_class_score} <- pair_skill_class_score(@skill_classes) do %>
         <% current = @skill_class.class == skill_class.class %>
-        <li id={"class_tab_#{skill_class.class}"} class={["grow", current && "bg-white text-base", "first:border-none last:border-none lg:border-x-4"]}>
-          <.link
-            patch={"#{@path}?#{build_query(@query, %{"class" => skill_class.class})}"}
-            class="flex lg:justify-start items-center px-2 lg:px-4 py-1 lg:py-3 lg:text-base"
-            aria-current={current && "page"}
-          >
-            <span class="text-sm lg:text-base" :if={current}>クラス<%= skill_class.class %></span>
-            <span class="text-xs lg:text-base" :if={!current}>クラス<%= skill_class.class %></span>
-            <span class="hidden lg:flex"><%= skill_class.name %></span>
-            <span class="text-lg text-right lg:text-xl min-w-[32px] lg:min-w-0 ml-1 lg:ml-4">
-              <%= if skill_class_score do %>
-                <%= floor skill_class_score.percentage %>
-              <% else %>
-                0
-              <% end %>
-              ％
-            </span>
-          </.link>
-        </li>
+        <%= if !@me && is_nil(skill_class_score) do %>
+          <li id={"class_tab_#{skill_class.class}"} class="grow lg:grow-0 bg-pureGray-600 text-pureGray-100 first:border-none last:border none lg:border-x-4">
+            <a href="#" class="flex items-center lg:select-none px-2 lg:px-4 py-1 lg:py-3 text-xs lg:text-base">
+              <span class="text-xs lg:text-base">クラス<%= skill_class.class %></span>
+              <span class="hidden lg:block"><%= skill_class.name %></span>
+              <span class="text-lg text-right lg:text-xl min-w-[32px] lg:min-w-0 ml-1 lg:ml-4">0</span>％
+            </a>
+          </li>
+        <% else %>
+          <li id={"class_tab_#{skill_class.class}"} class={["grow", current && "bg-white text-base", "first:border-none last:border-none lg:border-x-4"]}>
+            <.link
+              patch={"#{@path}?#{build_query(@query, %{"class" => skill_class.class})}"}
+              class="flex lg:justify-start items-center px-2 lg:px-4 py-1 lg:py-3 lg:text-base"
+              aria-current={current && "page"}
+            >
+              <span class="text-sm lg:text-base" :if={current}>クラス<%= skill_class.class %></span>
+              <span class="text-xs lg:text-base" :if={!current}>クラス<%= skill_class.class %></span>
+              <span class="hidden lg:flex"><%= skill_class.name %></span>
+              <span class="text-lg text-right lg:text-xl min-w-[32px] lg:min-w-0 ml-1 lg:ml-4">
+                <%= if skill_class_score do %>
+                  <%= floor skill_class_score.percentage %>
+                <% else %>
+                  0
+                <% end %>
+                ％
+              </span>
+            </.link>
+          </li>
+        <% end %>
       <% end %>
     </ul>
     """

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -29,7 +29,13 @@
         active="panel"
       />
     </div>
-    <.class_tab skill_classes={@skill_classes} skill_class={@skill_class} path={@path} query={@query} />
+    <.class_tab
+      skill_classes={@skill_classes}
+      skill_class={@skill_class}
+      path={@path}
+      query={@query}
+      me={@me}
+    />
   </div>
   <div class="bg-white shadow relative z-2 pb-10 pt-1 lg:pt-3">
     <div class="px-2 lg:px-6">


### PR DESCRIPTION
## 対応内容

対象者を切り替えているときに、そのユーザーが開放していないスキルクラスまでクリックできるようになっていたので修正しました。

- スキルクラス開放の仕様変更で、スキルクラスタブをクリック可能な状態にした際の対応漏れです。
  - （チーム分析側のクラスタブは無関係です）
- サーバー側では、クリックされてもEcto.NoResultErrorを出るだけですがクリックさせないようにしました。


## 参考画像

クラス３が未開放です。クリックできない＋灰色にしています。

![スクリーンショット 2023-11-08 084856](https://github.com/bright-org/bright/assets/121112529/e6a2e8d6-116f-4e30-b605-e600533c2977)
