### PR TITLE
スキルパネル 対象者切替時にも「スキル入力する」の初期メッセージが表示される現象対応

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -171,7 +171,7 @@ defmodule BrightWeb.SkillPanelLive.Skills do
   # 初回入力時のみメッセージを表示
   # 初回入力: スキルクラスがclass: 1でスキルスコアがない状態とする
   # メッセージ表示にはflashを利用している
-  defp put_flash_first_skills_edit(socket) do
+  defp put_flash_first_skills_edit(%{assigns: %{me: true}} = socket) do
     %{skill_class: skill_class, skill_score_dict: skill_score_dict} = socket.assigns
     skill_scores = Map.values(skill_score_dict)
 
@@ -182,6 +182,8 @@ defmodule BrightWeb.SkillPanelLive.Skills do
       socket
     end
   end
+
+  defp put_flash_first_skills_edit(socket), do: socket
 
   defp user_job_searching?(user) do
     user.id


### PR DESCRIPTION
## 対応内容

対象者切替をして他のユーザーをみているときにも、そのユーザーがスキルスコアを入力していないと「スキル入力する」を促すメッセージが表示されていた（他ユーザーなので当然できない）ので対応しました。

## 参考画像：発生していた現象

![image](https://github.com/bright-org/bright/assets/121112529/479bd909-766b-4c3d-891a-7117d3b0f264)
