### PR TITLE
sp版メニューにヘッダーが重なっていた現象対応

### DIFF
--- a/lib/bright_web/components/layout_components.ex
+++ b/lib/bright_web/components/layout_components.ex
@@ -128,13 +128,13 @@ defmodule BrightWeb.LayoutComponents do
 
   def side_menu(assigns) do
     ~H"""
-    <aside class="relative lg:z-20">
+    <aside class="relative z-50 lg:z-20">
       <input id="sp_navi_input" class="hidden peer" type="checkbox">
-      <label id="sp_navi_open" class="bg-white block cursor-pointer fixed h-10 ml-4 left-0 rounded top-2 w-10 z-50 lg:hidden" for="sp_navi_input">
+      <label id="sp_navi_open" class="bg-white block cursor-pointer fixed h-10 ml-4 left-0 rounded top-2 w-10 z-[60] lg:hidden" for="sp_navi_input">
         <span class="absolute bg-brightGray-300 block cursor-pointer h-[3px] left-1 top-1.5 w-8 before:bg-brightGray-300 before:block before:content-[''] before:cursor-pointer before:h-[3px] before:absolute before:top-3 before:w-8 after:bg-brightGray-300 after:block after:content-[''] after:cursor-pointer after:h-[3px] after:absolute after:top-6 after:w-8"></span>
       </label>
       <label id="sp_navi_close" for="sp_navi_input" class="cursor-pointer hidden h-full fixed right-0 top-0 w-full z-20 -ml-2"></label>
-      <div class="fixed bg-brightGray-900 pt-3 min-h-screen h-full hidden flex-col w-full z-40 lg:flex lg:static lg:w-[200px] peer-checked:flex overflow-y-scroll lg:overflow-y-hidden">
+      <div class="fixed bg-brightGray-900 pt-3 min-h-screen h-full hidden flex-col w-full lg:flex lg:static lg:w-[200px] peer-checked:flex overflow-y-scroll lg:overflow-y-hidden">
         <.link href="/mypage"><img src="/images/common/logo.svg" width="163px" class="ml-2 lg:ml-4 mt-12 lg:mt-0" /></.link>
         <ul class="grid lg:pt-2">
           <%= for {title, path, regex} <- links() do %>


### PR DESCRIPTION
## 対応内容

zインデックス調整の影響でスマホ版メニューに、ヘッダーが重なっていたので対応しました。
（画面で下部にでている「アップグレード」なども、実装上はヘッダーの一部になっています。）

## 参考画像

**発生していた現象**

![image](https://github.com/bright-org/bright/assets/121112529/8d32ce2c-2a42-40ed-a16c-b122b99f1688)


**対応後**

![image](https://github.com/bright-org/bright/assets/121112529/9cff3f53-b229-4cd6-951e-8a2e1ca85032)
