### PR TITLE
スキルパネル カスタムグループと比較まわりの文言修正

### DIFF
--- a/lib/bright_web/live/skill_panel_live/compare_custom_group_menu_component.ex
+++ b/lib/bright_web/live/skill_panel_live/compare_custom_group_menu_component.ex
@@ -90,11 +90,11 @@ defmodule BrightWeb.SkillPanelLive.CompareCustomGroupMenuComponent do
           phx-click="assign"
           phx-target={@myself}
         >
-          下記の人たちでカスタムグループを更新する
+          表示メンバーでカスタムグループ更新
         </div>
       </li>
 
-      <% # カスタムグループの切り替え %>
+      <% # カスタムグループの選択 %>
       <li>
         <div
           id="custom-groups-list-dropdown"
@@ -106,11 +106,7 @@ defmodule BrightWeb.SkillPanelLive.CompareCustomGroupMenuComponent do
             class="dropdownTrigger w-full flex items-center justify-between block px-1 py-3 hover:bg-brightGray-50 text-base hover:cursor-pointer"
             type="button"
           >
-            <%= if @custom_group do %>
-              別のカスタムグループに切り替える
-            <% else %>
-              カスタムグループに切り替える
-            <% end %>
+            比較するカスタムグループの選択
             <svg class="w-2.5 h-2.5 ml-2.5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
               <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 9 4-4-4-4"/>
             </svg>
@@ -144,7 +140,7 @@ defmodule BrightWeb.SkillPanelLive.CompareCustomGroupMenuComponent do
           phx-target={@myself}
         >
           <div class="grow">
-            <BrightCoreComponents.input type="text" input_class="w-full" field={@form[:name]} placeholder="下記の人たちでカスタムグループを追加する" />
+            <BrightCoreComponents.input type="text" input_class="w-full" field={@form[:name]} placeholder="表示メンバーでカスタムグループ追加" />
           </div>
           <button class="grow-0 text-sm font-bold px-3 py-2 rounded border bg-base text-white">追加</button>
         </.form>

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -161,7 +161,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
         class="dropdownTrigger text-brightGray-600 bg-white px-2 py-2 inline-flex font-medium rounded-md text-sm items-center border border-brightGray-200"
         type="button"
       >
-        <span>カスタムグループ</span>
+        <span>カスタムグループと比較</span>
       </button>
       <div
         class="dropdownTarget z-10 hidden bg-white rounded-lg shadow-md min-w-[286px] border border-brightGray-50"


### PR DESCRIPTION
## 対応内容

文言修正です。

・「カスタムグループ」→「カスタムグループと比較」
・「カスタムグループに切り替える」→「比較するカスタムグループの選択」
・「下記の人たちでカスタムグループを追加」→「表示メンバーでカスタムグループ追加」
・「下記の人たちでカスタムグループを更新する」 → 「表示メンバーでカスタムグループ更新」

**対応後画像**

![スクリーンショット 2023-11-09 200558](https://github.com/bright-org/bright/assets/121112529/ec75da1e-5955-4bf1-8023-f4cd2c0cdfb6)
