### PR TITLE
学習メモ 投稿制限と所有者の他者投稿削除に対応

### DIFF
--- a/lib/bright/skill_evidences.ex
+++ b/lib/bright/skill_evidences.ex
@@ -300,4 +300,12 @@ defmodule Bright.SkillEvidences do
     skill_evidence.user_id == user.id ||
       user.id in Teams.list_user_ids_related_team_by_user(skill_evidence.user)
   end
+
+  @doc """
+  学習メモ投稿を削除できるかどうかを返す
+  """
+  def can_delete_skill_evidence_post?(skill_evidence_post, skill_evidence, user) do
+    skill_evidence_post.user_id == user.id ||
+      skill_evidence.user_id == user.id
+  end
 end

--- a/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
@@ -59,7 +59,7 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
 
                 <% # 削除ボタン %>
                 <div
-                  :if={post_by_myself?(post, @user)}
+                  :if={deletable_user?(post, @skill_evidence, @user)}
                   class="h-6 w-6 py-2 ml-auto cursor-pointer"
                   phx-click="delete"
                   phx-target={@myself}
@@ -264,10 +264,8 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
   end
 
   def handle_event("delete", %{"id" => skill_evidence_post_id}, socket) do
-    SkillEvidences.get_skill_evidence_post_by!(
-      id: skill_evidence_post_id,
-      user_id: socket.assigns.user.id
-    )
+    # TODO: 画面からはボタンを消しているがサーバ側として権限確認が必要
+    SkillEvidences.get_skill_evidence_post!(skill_evidence_post_id)
     |> SkillEvidences.delete_skill_evidence_post()
     |> case do
       {:ok, %{delete: skill_evidence_post}} ->
@@ -352,8 +350,8 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
     Storage.public_url(image_path)
   end
 
-  defp post_by_myself?(skill_evidence_post, user) do
-    skill_evidence_post.user_id == user.id
+  defp deletable_user?(skill_evidence_post, skill_evidence, user) do
+    SkillEvidences.can_delete_skill_evidence_post?(skill_evidence_post, skill_evidence, user)
   end
 
   defp postable_user?(skill_evidence, user) do

--- a/test/bright/skill_evidences_test.exs
+++ b/test/bright/skill_evidences_test.exs
@@ -339,4 +339,55 @@ defmodule Bright.SkillEvidencesTest do
       assert false == SkillEvidences.can_write_skill_evidence?(skill_evidence, user_2)
     end
   end
+
+  describe "can_delete_skill_evidence_post?/3" do
+    setup do
+      skill_unit = insert(:skill_unit)
+      skill_category = insert(:skill_category, skill_unit: skill_unit)
+      skill = insert(:skill, skill_category: skill_category)
+
+      %{skill: skill}
+    end
+
+    test "returns true if the user is same as skill_evidence owner or post owner", %{skill: skill} do
+      user = insert(:user)
+      skill_evidence = insert(:skill_evidence, user: user, skill: skill)
+
+      user_2 = insert(:user)
+
+      skill_evidence_post =
+        insert(:skill_evidence_post, user: user_2, skill_evidence: skill_evidence)
+
+      assert true ==
+               SkillEvidences.can_delete_skill_evidence_post?(
+                 skill_evidence_post,
+                 skill_evidence,
+                 user
+               )
+
+      assert true ==
+               SkillEvidences.can_delete_skill_evidence_post?(
+                 skill_evidence_post,
+                 skill_evidence,
+                 user_2
+               )
+    end
+
+    test "returns false if the user is viewer", %{skill: skill} do
+      user = insert(:user)
+      skill_evidence = insert(:skill_evidence, user: user, skill: skill)
+
+      skill_evidence_post =
+        insert(:skill_evidence_post, user: user, skill_evidence: skill_evidence)
+
+      user_2 = insert(:user)
+
+      assert false ==
+               SkillEvidences.can_delete_skill_evidence_post?(
+                 skill_evidence_post,
+                 skill_evidence,
+                 user_2
+               )
+    end
+  end
 end


### PR DESCRIPTION
## 対応内容

学習メモについて、

- 自身とチームメンバーのみ投稿可能
  - 誰かわからない人からの投稿禁止
- 自身が他者の投稿削除可能
  - 誰かが自分の学習メモに変なことを書いても削除可能

の対応を行いました。（採用・人材チームに関する対応は別途予定です。）

SNS要素の設計まで暫定的な対応です。
https://github.com/bright-org/bright/issues/1131