### PR TITLE
成長グラフ 他者と比較のスマホ版表示対応

### DIFF
--- a/lib/bright_web/live/chart_live/growth_graph_component.ex
+++ b/lib/bright_web/live/chart_live/growth_graph_component.ex
@@ -132,7 +132,7 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
 
       <% # タイムライン比較対象用 %>
       <div :if={@compared_user} id="timeline-bar-compared" class="lg:flex lg:items-center">
-        <div class="w-14 hidden lg:block">
+        <div class="w-14 hidden lg:block" data-size="pc">
           <.btn_timeline_shift_past enabled={@compared_timeline.past_enabled} id="other" myself={@myself} />
         </div>
 
@@ -146,11 +146,11 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
           display_now={false}
         />
 
-        <div class="w-14 hidden lg:flex justify-end">
+        <div class="w-14 hidden lg:flex justify-end" data-size="pc">
           <.btn_timeline_shift_future enabled={@compared_timeline.future_enabled} id="other" myself={@myself} />
         </div>
 
-        <div class="flex justify-between lg:hidden">
+        <div class="flex justify-between lg:hidden" data-size="sp">
           <% # スマホ版タイムライン移動ボタン %>
           <.btn_timeline_shift_past enabled={@compared_timeline.past_enabled} id="other" myself={@myself} />
           <.btn_timeline_shift_future enabled={@compared_timeline.future_enabled} id="other" myself={@myself} />
@@ -162,6 +162,7 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
 
   defp btn_timeline_shift_past(%{enabled: true} = assigns) do
     assigns = Map.put_new(assigns, :class, "")
+
     ~H"""
     <button
       :if={@enabled}
@@ -178,6 +179,7 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
 
   defp btn_timeline_shift_past(%{enabled: false} = assigns) do
     assigns = Map.put_new(assigns, :class, "")
+
     ~H"""
     <button
       :if={!@enabled}
@@ -191,6 +193,7 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
 
   defp btn_timeline_shift_future(%{enabled: true} = assigns) do
     assigns = Map.put_new(assigns, :class, "")
+
     ~H"""
     <button
       :if={@enabled}
@@ -207,6 +210,7 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
 
   defp btn_timeline_shift_future(%{enabled: false} = assigns) do
     assigns = Map.put_new(assigns, :class, "")
+
     ~H"""
     <button
       :if={!@enabled}

--- a/test/bright_web/live/graph_live/graph_test.exs
+++ b/test/bright_web/live/graph_live/graph_test.exs
@@ -442,7 +442,9 @@ defmodule BrightWeb.GraphLive.GraphsTest do
 
         # 比較側を１月ずらす確認
         show_live
-        |> element(~s(button[phx-click="shift_timeline_past"][phx-value-id="other"]))
+        |> element(
+          ~s(div[data-size="pc"] button[phx-click="shift_timeline_past"][phx-value-id="other"])
+        )
         |> render_click()
 
         data =
@@ -514,7 +516,9 @@ defmodule BrightWeb.GraphLive.GraphsTest do
 
         # 比較側を１月ずらす確認
         show_live
-        |> element(~s(button[phx-click="shift_timeline_past"][phx-value-id="other"]))
+        |> element(
+          ~s(div[data-size="pc"] button[phx-click="shift_timeline_past"][phx-value-id="other"])
+        )
         |> render_click()
 
         data =


### PR DESCRIPTION
## 対応内容

成長グラフの他者との比較をスマホでも可能にしました。

## 参考画像

他者との比較を選択して、成長グラフとスキルジェムに反映までになります。

![sample60](https://github.com/bright-org/bright/assets/121112529/86628eef-d3f5-4d30-b1c0-b13791b8fad1)


