### PR TITLE
βリリース（10月予定）をβリリース（11月予定）に変更

### DIFF
--- a/lib/bright_web/live/card_live/communication_card_component.ex
+++ b/lib/bright_web/live/card_live/communication_card_component.ex
@@ -47,7 +47,7 @@ defmodule BrightWeb.CardLive.CommunicationCardComponent do
           <ul :if={@card.selected_tab != "community"} class="flex content-between  text-brightGray-500 w-[600px] lg:w-full">
             <li class="flex">
               <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">
-                βリリース（10月予定）で利用可能になります
+                βリリース（11月予定）で利用可能になります
               </div>
             </li>
           </ul>

--- a/lib/bright_web/live/card_live/contact_card_component.ex
+++ b/lib/bright_web/live/card_live/contact_card_component.ex
@@ -45,7 +45,7 @@ defmodule BrightWeb.CardLive.ContactCardComponent do
           <ul :if={@card.selected_tab != "operation"} class="flex gap-y-2.5 flex-col">
             <li class="flex">
               <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">
-                βリリース（10月予定）で利用可能になります
+                βリリース（11月予定）で利用可能になります
               </div>
             </li>
           </ul>

--- a/lib/bright_web/live/card_live/related_team_card_component.ex
+++ b/lib/bright_web/live/card_live/related_team_card_component.ex
@@ -54,7 +54,7 @@ defmodule BrightWeb.CardLive.RelatedTeamCardComponent do
           <ul :if={@card.selected_tab != "joined_teams"} class="flex gap-y-2 flex-col">
             <li class="flex">
               <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">
-                βリリース（10月予定）で利用可能になります
+                βリリース（11月予定）で利用可能になります
               </div>
             </li>
           </ul>

--- a/lib/bright_web/live/card_live/related_user_card_component.ex
+++ b/lib/bright_web/live/card_live/related_user_card_component.ex
@@ -72,7 +72,7 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
           <ul :if={@selected_tab == "intriguing"} class="flex gap-y-2.5 flex-col">
             <li class="flex">
               <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">
-                βリリース（10月予定）で利用可能になります
+                βリリース（11月予定）で利用可能になります
               </div>
             </li>
           </ul>

--- a/lib/bright_web/live/search_live/search_result_component.ex
+++ b/lib/bright_web/live/search_live/search_result_component.ex
@@ -66,10 +66,10 @@ defmodule BrightWeb.SearchLive.SearchResultComponent do
           <a
             class="bg-brightGray-900 border border-solid border-brightGray-300 cursor-pointer font-bold px-4 py-2 rounded select-none text-center text-white w-56 opacity-50"
           >
-          採用面談調整<br />βリリース（10月予定）から
+          採用面談調整<br />βリリース（11月予定）から
           </a>
           <a class="bg-brightGray-900 border border-solid border-brightGray-300 cursor-pointer font-bold px-4 py-2 rounded select-none text-center text-white w-56 opacity-50">
-          採用・育成チームに採用依頼 <br />βリリース（10月予定）から
+          採用・育成チームに採用依頼 <br />βリリース（11月予定）から
           </a>
         </div>
       </div>


### PR DESCRIPTION
■やったこと
βリリース（10月予定）をβリリース（11月予定）に全件変更しました。

![スクリーンショット 2023-11-10 190400](https://github.com/bright-org/bright/assets/61276836/f292635d-888b-4dd9-aa31-43cb3564cc49)
![スクリーンショット 2023-11-10 190308](https://github.com/bright-org/bright/assets/61276836/bb1ad93b-9828-4537-9dde-c33252777b68)
![スクリーンショット 2023-11-10 190237](https://github.com/bright-org/bright/assets/61276836/b9afbcd5-9b72-4d7b-96fb-fd598b036287)
![スクリーンショット 2023-11-10 190209](https://github.com/bright-org/bright/assets/61276836/ec6e2278-383a-44f0-be29-602f70f306c9)
![スクリーンショット 2023-11-10 190131](https://github.com/bright-org/bright/assets/61276836/ec914dec-efc8-4557-af9c-69445cc76bec)
