### PR TITLE
チーム名の入力が、メンバー追加時に保持されない不具合解消

### DIFF
--- a/lib/bright_web/live/team_live/team_create_live_component.ex
+++ b/lib/bright_web/live/team_live/team_create_live_component.ex
@@ -104,11 +104,6 @@ defmodule BrightWeb.TeamCreateLiveComponent do
     save_team(socket, socket.assigns.action, team_params, admin_count, socket.assigns.plan)
   end
 
-  def handle_info({BrightWeb.TeamLive.TeamAddUserComponent, {:add, added_users}}, socket) do
-    IO.inspect("info")
-    {:noreply, assign(socket, :users, added_users)}
-  end
-
   def save_team(socket, :new, team_params, count, %{create_teams_limit: limit})
       when count >= limit do
     msg =


### PR DESCRIPTION

# 不具合内容

team_create_live_componentからユーザーを追加する箇所をteam_add_user_componentと別のコンポーネント化した

その際にadd_user イベントを sendで更新を通知するのですが live_componentにその通知がうまく送れないため
add_user_component -> my_team_live -> team_create_live_component の順で反映されます

流れとしては以下のようになります
add_user_component -> send(追加されたユーザーを通知) 
-> my_team_live ->  handle_info(usersの更新) 
-> team_create_live_component の assignされている usersが更新されたので、 updateが実行される


その updateの際にフォームの内容を初期化していたのでチームメンバを追加した際にフォームの内容が初期化されてしまうようでした

# 対処法
フォームが入力中の場合はsocketにteam_formがあり、モーダルを開いたときはteam_formがないためその差異をパターンマッチしてformの初期化をしないようにしました

https://github.com/bright-org/bright/assets/91950/b91297ef-6074-4613-af68-8fe827276c67


