### PR TITLE
スキルパネル 個人と比較ほかボタン群の表示調整

### DIFF
--- a/lib/bright_web/components/bright_core_components.ex
+++ b/lib/bright_web/components/bright_core_components.ex
@@ -105,6 +105,39 @@ defmodule BrightWeb.BrightCoreComponents do
   end
 
   @doc """
+  Renders a action button
+  """
+  attr :type, :string, default: "button"
+  attr :icon, :string, default: nil
+  attr :class, :string, default: nil
+  attr :rest, :global, include: ~w(disabled form name value)
+
+  slot :inner_block, required: true
+
+  def action_button(%{icon: nil} = assigns) do
+    ~H"""
+    <button type={@type} class={["text-sm font-bold px-5 py-2 rounded border border-base", @class]} {@rest}>
+      <%= render_slot(@inner_block) %>
+    </button>
+    """
+  end
+
+  def action_button(assigns) do
+    ~H"""
+    <button
+      type={@type}
+      class={["text-sm font-bold border border-base rounded py-1.5 pl-3 flex items-center", @class]}
+      @rest
+    >
+      <%= render_slot(@inner_block) %>
+      <span
+        class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-7px] before:bg-brightGray-200 before:w-[1px] before:h-[38px]"
+        ><%= @icon %></span>
+    </button>
+    """
+  end
+
+  @doc """
   Renders an input with label and error messages.
 
   A `Phoenix.HTML.FormField` may be passed as argument,

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -4,6 +4,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
   import BrightWeb.SkillPanelLive.SkillPanelComponents, only: [score_mark_class: 2]
   import BrightWeb.SkillPanelLive.SkillPanelHelper, only: [calc_percentage: 2]
   import BrightWeb.GuideMessageComponents
+  import BrightWeb.BrightCoreComponents, only: [action_button: 1]
   import Phoenix.LiveView, only: [send_update: 2]
 
   alias BrightWeb.SkillPanelLive.SkillsFieldComponent
@@ -12,7 +13,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
     ~H"""
     <div class="flex flex-wrap mt-4 items-center lg:flex-nowrap">
       <.compare_timeline myself={@myself} timeline={@timeline} />
-      <div class="flex gap-x-4">
+      <div class="flex gap-x-4 ml-20">
         <.compare_individual current_user={@current_user} myself={@myself} />
         <.compare_team current_user={@current_user} myself={@myself} />
         <.compare_custom_group
@@ -90,15 +91,9 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
       data-dropdown-offset-skidding="307"
       data-dropdown-placement="bottom"
     >
-      <button
-        class="dropdownTrigger border border-brightGray-200 rounded-md py-1.5 pl-3 flex items-center"
-        type="button"
-      >
+      <.action_button icon="add" class="dropdownTrigger">
         <span class="min-w-[6em]">個人と比較</span>
-        <span
-          class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-7px] before:bg-brightGray-200 before:w-[1px] before:h-[38px]"
-          >add</span>
-      </button>
+      </.action_button>
       <div
         class="dropdownTarget bg-white rounded-md mt-1 w-[750px] bottom border-brightGray-100 border shadow-md hidden z-10"
       >
@@ -124,15 +119,9 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
       data-dropdown-offset-skidding="290"
       data-dropdown-placement="bottom"
     >
-      <button
-        class="dropdownTrigger border border-brightGray-200 rounded-md py-1.5 pl-3 flex items-center"
-        type="button"
-      >
+      <.action_button icon="add" class="dropdownTrigger">
         <span class="min-w-[6em]">チーム全員と比較</span>
-        <span
-          class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-7px] before:bg-brightGray-200 before:w-[1px] before:h-[38px]"
-          >add</span>
-      </button>
+      </.action_button>
       <div
         class="dropdownTarget bg-white rounded-md mt-1 w-[750px] border border-brightGray-100 shadow-md hidden z-10"
       >
@@ -157,12 +146,9 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
       data-dropdown-offset-skidding="110"
       data-dropdown-placement="bottom"
     >
-      <button
-        class="dropdownTrigger text-brightGray-600 bg-white px-2 py-2 inline-flex font-medium rounded-md text-sm items-center border border-brightGray-200"
-        type="button"
-      >
+      <.action_button class="dropdownTrigger">
         <span>カスタムグループと比較</span>
-      </button>
+      </.action_button>
       <div
         class="dropdownTarget z-10 hidden bg-white rounded-lg shadow-md min-w-[286px] border border-brightGray-50"
       >

--- a/lib/bright_web/live/team_live/team_add_user_component.ex
+++ b/lib/bright_web/live/team_live/team_add_user_component.ex
@@ -3,6 +3,8 @@ defmodule BrightWeb.TeamLive.TeamAddUserComponent do
 
   alias Bright.Accounts
 
+  import BrightWeb.BrightCoreComponents, only: [action_button: 1]
+
   @impl true
   def render(assigns) do
     ~H"""
@@ -34,12 +36,9 @@ defmodule BrightWeb.TeamLive.TeamAddUserComponent do
             phx-change="change_add_user"
             value={@search_word}
           />
-          <button
-            phx-target={@myself}
-            class="text-sm font-bold px-5 py-2 rounded border border-base ml-2.5"
-          >
+          <.action_button type="submit" class="ml-2.5">
             追加
-          </button>
+          </.action_button>
         </form>
       </div>
       <div :if={@search_word_error != nil}>


### PR DESCRIPTION
## 対応内容

スキルパネル 個人と比較ほかボタン群の表示調整しています。

- 「個人と比較」「チーム全員と比較」「カスタムグループと比較」のボタンスタイルを、チーム追加の「追加」ボタンと合わせる対応
- ボタン群と、タイムライン間の位置調整

## 参考画像

**before**

![スクリーンショット 2023-11-13 150755](https://github.com/bright-org/bright/assets/121112529/bb72ad13-d6f1-45dd-8b4e-3d24bc15c55b)


**after**

![スクリーンショット 2023-11-13 204324](https://github.com/bright-org/bright/assets/121112529/86589071-8f0e-407b-87f9-91aa9397f571)
