### PR TITLE
Ecto.Query.CastErrorを404に変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
       - name: Run Test
         run: |
           mix deps.compile
+          # phoenix_ecto: exclude_ecto_exceptions_from_plug 反映のためコンパイル明示
+          mix deps.compile phoenix_ecto --force
           mix compile --warnings-as-errors
           mix test --warnings-as-errors
         env:

--- a/config/config.exs
+++ b/config/config.exs
@@ -75,6 +75,10 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
+# Configure ecto exceptions to change response status code
+config :phoenix_ecto,
+  exclude_ecto_exceptions_from_plug: [Ecto.Query.CastError]
+
 # ueberauth
 config :ueberauth, Ueberauth,
   providers: [

--- a/lib/bright/exceptions/plug_ecto_query_cast_error.ex
+++ b/lib/bright/exceptions/plug_ecto_query_cast_error.ex
@@ -1,0 +1,4 @@
+defimpl Plug.Exception, for: Ecto.Query.CastError do
+  def status(_exception), do: 404
+  def actions(_exception), do: []
+end

--- a/lib/bright/teams.ex
+++ b/lib/bright/teams.ex
@@ -950,15 +950,6 @@ defmodule Bright.Teams do
     count > 0
   end
 
-  def raise_if_not_ulid(team_id) do
-    # チームIDの指定が不正だった場合は404で返す。
-    Ecto.ULID.cast(team_id)
-    |> case do
-      {:ok, _} -> nil
-      _ -> raise Ecto.NoResultsError, queryable: "Bright.Teams.Team"
-    end
-  end
-
   @doc """
     所属チームによる各種機能の利用可否判定を取得する
     - enable_team_up_functions チームスキル分析などチームアップ系機能の利用可否

--- a/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
@@ -41,8 +41,6 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
   end
 
   def assign_skill_panel(socket, skill_panel_id) do
-    raise_if_not_ulid(skill_panel_id)
-
     skill_panel = SkillPanels.get_user_skill_panel(socket.assigns.display_user, skill_panel_id)
 
     raise_if_not_exists_skill_panel(skill_panel)
@@ -255,16 +253,6 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
     # 保有スキルパネルに存在しないクラスなどへのアクセスにあたる。404で返す。
     # 導線はなく、クエリストリングで指定される可能性がある。
     raise Ecto.NoResultsError, queryable: "Bright.SkillPanels.SkillClass"
-  end
-
-  def raise_if_not_ulid(ulid) do
-    # スキルパネルの指定が不正だった場合は404で返す。
-    # 導線はなく、URLで指定される可能性がある。
-    Ecto.ULID.cast(ulid)
-    |> case do
-      {:ok, _} -> nil
-      _ -> raise Ecto.NoResultsError, queryable: "Bright.SkillPanels.SkillPanel"
-    end
   end
 
   defp raise_if_not_exists_skill_panel(nil) do

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -1389,7 +1389,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
     end
 
     test "shows 404 if skill_panel_id is invalid ULID", %{conn: conn} do
-      assert_raise Ecto.NoResultsError, fn ->
+      assert_raise Ecto.Query.CastError, fn ->
         live(conn, ~p"/panels/abcd")
       end
     end


### PR DESCRIPTION
## 対応内容

デフォルトでEcto.Query.CastErrorは400を返しますが、Bright画面仕様として404で扱っています（400は使っていないの意）。
そのための処理をURLにULIDが入る画面全部で行うのは辛いため、設定で404にしました。
（学習メモの障害対応にもなっています）

結果、必要がなくなった処理を削除するなどの対応もいれています。

## マージ周知事項メモ

`phoenix_ecto`の再コンパイルが必要なので、main反映時に手元で`mix deps.compile phoenix_ecto --force`を実行してください。