### PR TITLE
チームカード カスタムグループがないときの表示対応

### DIFF
--- a/lib/bright_web/live/card_live/related_team_card_component.ex
+++ b/lib/bright_web/live/card_live/related_team_card_component.ex
@@ -53,54 +53,61 @@ defmodule BrightWeb.CardLive.RelatedTeamCardComponent do
         target={@myself}
       >
         <div class="pt-3 pb-1 px-6 lg:h-[226px]">
-          <% # TODO ↓α版対応 %>
-          <ul :if={@card.selected_tab == "supporter_teams" and @card.total_entries == 0}
-            class="flex gap-y-2 flex-col">
-            <li class="flex items-center text-base p-1 rounded">
-              <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">支援を受けている採用・育成チームはありません</div>
-              <a class="text-sm font-bold px-5 py-3 rounded text-white bg-brightGray-200">
-                採用・育成チームに支援してもらう（β）
-              </a>
-            </li>
-            βリリース（11月予定）で利用可能になります
-          </ul>
-          <ul :if={@card.selected_tab == "supportee_teams" and @card.total_entries == 0}
-            class="flex gap-y-2 flex-col">
-            <li class="flex items-center text-base p-1 rounded">
-              <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">支援中の採用・育成先チームはありません</div>
+          <%= if @card.total_entries > 0 do %>
+            <ul class="flex gap-y-2 flex-col">
+              <%= for team_params <- @card.entries do %>
+                <.team_small
+                  id={team_params.team_id}
+                  team_params={team_params}
+                  row_on_click_target={assigns.row_on_click_target}
+                />
+              <% end %>
+            </ul>
+          <% else %>
+            <% # 表示内容がないときの表示 %>
+            <ul class="flex gap-y-2 flex-col">
+              <li :if={@card.selected_tab == "joined_teams"} class="flex items-center text-base p-1 rounded">
+                <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">所属しているチームはありません</div>
+                <a
+                   href="/teams/new"
+                   class="text-sm font-bold px-5 py-3 rounded text-white bg-base"
+                 >
+                  チームを作る（β）
+                 </a>
+              </li>
+
+              <li :if={@card.selected_tab == "custom_groups"} class="flex items-center text-base p-1 rounded">
+                <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">カスタムグループはありません</div>
+                <a
+                   href="/panels"
+                   class="text-sm font-bold px-5 py-3 rounded text-white bg-base"
+                 >
+                   カスタムグループを作る
+                 </a>
+              </li>
+
+              <% # TODO ↓α版対応 %>
+              <li :if={@card.selected_tab == "supporter_teams"} class="flex items-center text-base p-1 rounded">
+                <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">支援を受けている採用・育成チームはありません</div>
+                <a class="text-sm font-bold px-5 py-3 rounded text-white bg-brightGray-200">
+                  採用・育成チームに支援してもらう（β）
+                </a>
+              </li>
+              <p :if={@card.selected_tab == "supporter_teams"}>
+                βリリース（11月予定）で利用可能になります
+              </p>
+
+              <li :if={@card.selected_tab == "supportee_teams"} class="flex items-center text-base p-1 rounded">
+                <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">支援中の採用・育成先チームはありません</div>
                 <a href="https://bright-fun.org/plan" class="w-[calc(45%-6px)] lg:w-56" rel="noopener noreferrer" target="_blank">
                   <button type="button" class="text-white bg-planUpgrade-600 px-1 inline-flex justify-center rounded-md text-xs items-center font-bold h-9 w-full hover:opacity-70 lg:px-2 lg:text-sm">
                     <span class="bg-white material-icons mr-1 !text-sm !text-planUpgrade-600 rounded-full h-5 w-5 !font-bold material-icons-outlined lg:mr-2 lg:h-6 lg:w-6">upgrade</span>
                     アップグレード
                   </button>
                 </a>
-            </li>
-          </ul>
-          <%= if @card.selected_tab == "joined_teams" && @card.total_entries <= 0 do %>
-          <ul class="flex gap-y-2 flex-col">
-            <li
-            class="flex items-center text-base p-1 rounded">
-              <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">所属しているチームはありません</div>
-              <a
-                 href="/teams/new"
-                 class="text-sm font-bold px-5 py-3 rounded text-white bg-base"
-               >
-                チームを作る（β）
-               </a>
-            </li>
-          </ul>
-        <% end %>
-        <%= if @card.total_entries > 0 do %>
-          <ul class="flex gap-y-2 flex-col">
-            <%= for team_params <- @card.entries do %>
-              <.team_small
-                id={team_params.team_id}
-                team_params={team_params}
-                row_on_click_target={assigns.row_on_click_target}
-              />
-            <% end %>
-          </ul>
-        <% end %>
+              </li>
+            </ul>
+          <% end %>
         </div>
       </.tab>
     </div>


### PR DESCRIPTION
## 対応内容

下記のようにカスタムグループがないときの表示を追加しました（対応漏れ）。
「カスタムグループを作る」はスキルパネルへのリンクです。

![image](https://github.com/bright-org/bright/assets/121112529/bf1fa7dc-c24f-4169-a5e5-78e162bac188)

