### PR TITLE
カスタムグループの名前変更用ボタンのラベル修正

### DIFF
--- a/lib/bright_web/live/skill_panel_live/compare_custom_group_menu_component.ex
+++ b/lib/bright_web/live/skill_panel_live/compare_custom_group_menu_component.ex
@@ -54,7 +54,7 @@ defmodule BrightWeb.SkillPanelLive.CompareCustomGroupMenuComponent do
             phx-click="mode_update"
             phx-target={@myself}
           >
-            更新
+            名前変更
           </button>
           <button
             id="btn-custom-group-delete"


### PR DESCRIPTION
## 対応内容

カスタムグループの名前変更用ボタンが、メンバー更新と見分けがつきにくかったので「更新」から「名前変更」に修正しました。
（2023/11/21 ランチMTG内の議事事項です）

![image](https://github.com/bright-org/bright/assets/121112529/3ede67c6-94bc-407c-b8fa-3d032236ab69)
