### PR TITLE
チームスキル分析 「この人と比較」有効化

### DIFF
--- a/lib/bright_web/components/bright_core_components.ex
+++ b/lib/bright_web/components/bright_core_components.ex
@@ -110,7 +110,7 @@ defmodule BrightWeb.BrightCoreComponents do
   attr :type, :string, default: "button"
   attr :icon, :string, default: nil
   attr :class, :string, default: nil
-  attr :rest, :global, include: ~w(disabled form name value)
+  attr :rest, :global, include: ~w(disabled)
 
   slot :inner_block, required: true
 

--- a/lib/bright_web/live/chart_live/growth_graph_component.ex
+++ b/lib/bright_web/live/chart_live/growth_graph_component.ex
@@ -228,12 +228,13 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
     {:ok,
      socket
      |> assign(data: %{})
-     |> assign(compared_user: nil)}
+     |> assign(compared_user: nil, compared_timeline: nil)}
   end
 
   @impl true
   def update(assigns, socket) do
     timeline = TimelineHelper.get_current()
+    assigns = Map.update(assigns, :compared_user, nil, &put_profile/1)
 
     socket =
       socket
@@ -409,13 +410,20 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
       compared_user: compared_user,
       skill_panel_id: skill_panel_id,
       class: class,
-      compared_timeline: compared_timeline
+      compared_timeline: compared_timeline,
+      timeline: timeline
     } = socket.assigns
+
+    compared_timeline =
+      compared_timeline ||
+        TimelineHelper.select_past_if_label_is_now(timeline)
 
     past_values =
       get_past_score_values(compared_timeline, compared_user.id, skill_panel_id, class)
 
-    update(socket, :data, fn data ->
+    socket
+    |> assign(:compared_timeline, compared_timeline)
+    |> update(:data, fn data ->
       Map.merge(data, %{
         other: past_values,
         otherSelected: compared_timeline.selected_label,

--- a/lib/bright_web/live/graph_live/graphs.ex
+++ b/lib/bright_web/live/graph_live/graphs.ex
@@ -2,6 +2,9 @@ defmodule BrightWeb.GraphLive.Graphs do
   use BrightWeb, :live_view
 
   alias Bright.SkillPanels.SkillPanel
+  alias Bright.Teams
+  alias Bright.Accounts
+  alias BrightWeb.TimelineHelper
 
   import BrightWeb.SkillPanelLive.SkillPanelComponents
   import BrightWeb.SkillPanelLive.SkillPanelHelper
@@ -31,6 +34,7 @@ defmodule BrightWeb.GraphLive.Graphs do
      |> create_skill_class_score_if_not_existing()
      |> assign_skill_score_dict()
      |> assign_counter()
+     |> assign_compared_user(params["compare"])
      |> touch_user_skill_panel()}
   end
 
@@ -92,5 +96,23 @@ defmodule BrightWeb.GraphLive.Graphs do
      socket
      |> assign(:compared_user, nil)
      |> assign(:select_label_compared_user, nil)}
+  end
+
+  def assign_compared_user(socket, nil), do: socket
+
+  def assign_compared_user(socket, user_name) do
+    compared_user = Accounts.get_user_by_name!(user_name) |> Map.put(:anonymous, false)
+
+    Teams.joined_teams_or_supportee_teams_or_supporter_teams_by_user_id!(
+      socket.assigns.current_user.id,
+      compared_user.id
+    )
+
+    # 比較対象のnowはないため1つ前の時点を取得
+    select_label = TimelineHelper.get_latest_date_label()
+
+    socket
+    |> assign(:compared_user, compared_user)
+    |> assign(:select_label_compared_user, select_label)
   end
 end

--- a/lib/bright_web/live/graph_live/graphs.html.heex
+++ b/lib/bright_web/live/graph_live/graphs.html.heex
@@ -58,6 +58,7 @@
         user_id={@display_user.id}
         skill_panel_id={@skill_panel.id}
         class={@skill_class.class}
+        compared_user={@compared_user}
       />
       <div class="w-full pl-2 mt-4 mb-2 lg:w-[700px] lg:pl-28 lg:mt-0 lg:mb-0">
         <div class="hidden lg:block">

--- a/lib/bright_web/live/team_live/team_member_skill_card_component.ex
+++ b/lib/bright_web/live/team_live/team_member_skill_card_component.ex
@@ -7,7 +7,10 @@ defmodule BrightWeb.TeamMemberSkillCardComponent do
 
   import BrightWeb.SkillPanelLive.SkillPanelComponents
   import BrightWeb.PathHelper
+  import BrightWeb.BrightCoreComponents, only: [action_button: 1]
+
   alias Bright.UserProfiles
+  alias Bright.SkillPanels
 
   @impl true
   def render(assigns) do
@@ -134,9 +137,17 @@ defmodule BrightWeb.TeamMemberSkillCardComponent do
               </.link>
             <% end %>
           <% else %>
-          <button class="text-sm font-bold px-5 py-3 rounded text-white bg-brightGray-200">
-            この人と比較
-          </button>
+            <.link
+              :if={comparable_skill_panel?(@display_skill_panel, @display_skill_card, @current_user)}
+              href={
+                skill_panel_path("graphs", @display_skill_panel, @current_user, true, false)
+                <> "?class=#{@display_skill_card.select_skill_class.class}&compare=#{@display_skill_card.user.name}"
+              }
+            >
+              <.action_button class="px-5 py-3">
+                この人と比較
+              </.action_button>
+            </.link>
           <% end %>
           <button class="min-w-[124px] text-sm font-bold px-5 py-3 rounded text-white bg-brightGray-200">
             スキルアップ確認
@@ -182,5 +193,13 @@ defmodule BrightWeb.TeamMemberSkillCardComponent do
 
   defp icon_url(icon_file_path) do
     UserProfiles.icon_url(icon_file_path)
+  end
+
+  defp comparable_skill_panel?(skill_panel, skill_card, current_user) do
+    # 「この人と比較」押下可能かどうか
+    # - 「この人」にスキルスコアがあり、
+    # - 自身が取得済みのスキルパネルであること
+    skill_card.user_skill_class_score &&
+      SkillPanels.get_user_skill_panel(current_user, skill_panel.id)
   end
 end

--- a/lib/bright_web/live/timeline_helper.ex
+++ b/lib/bright_web/live/timeline_helper.ex
@@ -123,6 +123,15 @@ defmodule BrightWeb.TimelineHelper do
 
   def label_to_date(_label), do: nil
 
+  @doc """
+  nowを除く最新日付（ラベル）を返す
+  """
+  def get_latest_date_label do
+    get_by_date("now")
+    |> select_past_if_label_is_now()
+    |> Map.get(:selected_label)
+  end
+
   defp get_future_month(), do: get_future_month(@start_month, Date.utc_today())
 
   defp get_future_month(start_month, now) do


### PR DESCRIPTION
## 対応内容

issue close #481 

チームスキル分析画面の「この人と比較」から成長パネル画面に遷移する対応を行いました。
遷移時に最初から比較対象に選ばれた状態になります。

## 参考画像
![sample61](https://github.com/bright-org/bright/assets/121112529/a2af943e-2556-46b2-ac56-f1abd9be284f)

