### PR TITLE
カスタムグループと比較 ボタンまわりの文言修正

### DIFF
--- a/lib/bright_web/live/skill_panel_live/compare_custom_group_menu_component.ex
+++ b/lib/bright_web/live/skill_panel_live/compare_custom_group_menu_component.ex
@@ -92,11 +92,11 @@ defmodule BrightWeb.SkillPanelLive.CompareCustomGroupMenuComponent do
       <% # カスタムグループメンバーの更新 %>
       <li :if={@custom_group}>
         <div
-          class="px-4 py-3 hover:bg-brightGray-50 text-base hover:cursor-pointer"
+          class="px-1 py-3 hover:bg-brightGray-50 text-base hover:cursor-pointer"
           phx-click="assign"
           phx-target={@myself}
         >
-          表示メンバーでカスタムグループ更新
+          現在のカスタムグループを表示メンバーで更新
         </div>
       </li>
 
@@ -112,7 +112,11 @@ defmodule BrightWeb.SkillPanelLive.CompareCustomGroupMenuComponent do
             class="dropdownTrigger w-full flex items-center justify-between block px-1 py-3 hover:bg-brightGray-50 text-base hover:cursor-pointer"
             type="button"
           >
-            比較するカスタムグループの選択
+            <%= if @custom_group do %>
+              現在のカスタムグループを切り替え
+            <% else %>
+              比較するカスタムグループの選択
+            <% end %>
             <svg class="w-2.5 h-2.5 ml-2.5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
               <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 9 4-4-4-4"/>
             </svg>


### PR DESCRIPTION
## 対応内容

カスタムグループ選択時のメニュー文言修正です。

- ・「表示メンバーでカスタムグループ更新」 => 「現在のカスタムグループを表示メンバーで更新」
- ・「比較するカスタムグループの選択」 => 「現在のカスタムグループを切り替え」

また文言を変えてわかりやすくなったので、「表示メンバーでカスタムグループ更新」 で少し取っていた左余白を消しています。


## 参考画像

**修正前**

![image](https://github.com/bright-org/bright/assets/121112529/0470c2ed-7ce2-4c52-bdf2-66b39b10b5b9)

**修正後**

![image](https://github.com/bright-org/bright/assets/121112529/8e7e6840-7ada-4013-9c5d-742f4036b19f)
