### PR TITLE
学習メモ 投稿とヘルプ宛先についてチーム支援関係に対応

### DIFF
--- a/lib/bright/skill_evidences.ex
+++ b/lib/bright/skill_evidences.ex
@@ -238,29 +238,62 @@ defmodule Bright.SkillEvidences do
 
   @doc """
   ヘルプ処理
-  チームの全メンバーにヘルプを伝える通知を生成
+  通知対象は、チームメンバー、支援元チームメンバー、支援先チームメンバー
   """
   def help(skill_evidence, user) do
     skill_breadcrumb = get_skill_breadcrumb(%{id: skill_evidence.skill_id})
+    timestamp = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
 
     base_attrs = %{
       from_user_id: user.id,
       message: "#{user.name}から「#{skill_breadcrumb}」のヘルプが届きました",
-      url: "/notifications/evidences/#{skill_evidence.id}"
+      url: "/notifications/evidences/#{skill_evidence.id}",
+      inserted_at: timestamp,
+      updated_at: timestamp
     }
 
-    timestamp = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    # ユーザー所属チームとその関連チーム取得
+    # NOTE: 今後設定によって通知要否（粒度未定）できるようになる想定です
+    teams =
+      Ecto.assoc(user, :teams)
+      |> preload([
+        :member_users,
+        supporter_teams: [:member_users],
+        supportee_teams: [:member_users]
+      ])
+      |> Repo.all()
 
-    Teams.list_user_ids_related_team_by_user(user)
+    # チームメンバー
+    team_related_ids = collect_team_user_ids(teams)
+
+    # 支援元メンバー
+    supporter_related_ids =
+      teams
+      |> Enum.flat_map(& &1.supporter_teams)
+      |> collect_team_user_ids()
+
+    # 支援先メンバー
+    supportee_related_ids =
+      teams
+      |> Enum.flat_map(& &1.supportee_teams)
+      |> collect_team_user_ids()
+
+    (team_related_ids ++ supporter_related_ids ++ supportee_related_ids)
+    |> Enum.uniq()
+    |> List.delete(user.id)
     |> Enum.map(fn user_id ->
       Map.merge(base_attrs, %{
         id: Ecto.ULID.generate(),
-        to_user_id: user_id,
-        inserted_at: timestamp,
-        updated_at: timestamp
+        to_user_id: user_id
       })
     end)
     |> then(&Notifications.create_notifications("evidence", &1))
+  end
+
+  defp collect_team_user_ids(teams) do
+    Enum.flat_map(teams, fn team ->
+      Enum.map(team.member_users, & &1.user_id)
+    end)
   end
 
   @doc """
@@ -296,20 +329,17 @@ defmodule Bright.SkillEvidences do
   end
 
   @doc """
-  学習メモを閲覧できるかどうかを返す
-  """
-  def can_read_skill_evidence?(skill_evidence, user) do
-    skill_evidence.user_id == user.id ||
-      user.id in Teams.list_user_ids_related_team_by_user(skill_evidence.user)
-  end
-
-  @doc """
   学習メモに書き込めるかどうかを返す
   NOTE: 現在は匿名書き込み不可。匿名書き込みを許可に変更するときは、通知メッセージ内のnameに注意
   """
   def can_write_skill_evidence?(skill_evidence, user) do
     skill_evidence.user_id == user.id ||
-      user.id in Teams.list_user_ids_related_team_by_user(skill_evidence.user)
+      Teams.joined_teams_or_supportee_teams_or_supporter_teams_by_user_id!(
+        skill_evidence.user_id,
+        user.id
+      )
+  rescue
+    Bright.Exceptions.ForbiddenResourceError -> false
   end
 
   @doc """

--- a/lib/bright/teams/team.ex
+++ b/lib/bright/teams/team.ex
@@ -16,6 +16,15 @@ defmodule Bright.Teams.Team do
     has_many :member_users, Bright.Teams.TeamMemberUsers, on_replace: :delete
     has_many :users, through: [:member_users, :user]
 
+    has_many :team_supporter_teams_on_supporter, Bright.Teams.TeamSupporterTeam,
+      foreign_key: :supporter_team_id
+
+    has_many :team_supporter_teams_on_supportee, Bright.Teams.TeamSupporterTeam,
+      foreign_key: :supportee_team_id
+
+    has_many :supportee_teams, through: [:team_supporter_teams_on_supporter, :supportee_team]
+    has_many :supporter_teams, through: [:team_supporter_teams_on_supportee, :supporter_team]
+
     timestamps()
   end
 

--- a/lib/bright_web/live/notification_live/evidence.ex
+++ b/lib/bright_web/live/notification_live/evidence.ex
@@ -92,8 +92,8 @@ defmodule BrightWeb.NotificationLive.Evidence do
       SkillEvidences.get_skill_evidence!(skill_evidence_id)
       |> Bright.Repo.preload(:user)
 
-    # 現在も閲覧可能な学習メモか確認
-    SkillEvidences.can_read_skill_evidence?(skill_evidence, socket.assigns.current_user)
+    # 現在も対応可能な学習メモか確認
+    SkillEvidences.can_write_skill_evidence?(skill_evidence, socket.assigns.current_user)
     |> if do
       skill = SkillUnits.get_skill!(skill_evidence.skill_id)
 

--- a/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
@@ -82,7 +82,7 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
           </div>
 
           <.simple_form
-            :if={postable_user?(@skill_evidence, @user)}
+            :if={@postable?}
             for={@form}
             id="skill_evidence_post-form"
             phx-target={@myself}
@@ -214,6 +214,7 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
      |> assign(:skill_evidence, skill_evidence)
      |> stream(:skill_evidence_posts, skill_evidence_posts)
      |> update(:user, &Bright.Repo.preload(&1, :user_profile))
+     |> assign(:postable?, postable_user?(skill_evidence, assigns.user))
      |> assign_form()}
   end
 
@@ -230,6 +231,8 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
      |> unassign_invalid_image_entries()}
   end
 
+  def handle_event("save", _, %{assigns: %{postable?: false}} = socket), do: {:noreply, socket}
+
   def handle_event("save", %{"skill_evidence_post" => params, "help" => help}, socket) do
     %{
       uploads: uploads,
@@ -238,8 +241,6 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
       user: user,
       skill: skill
     } = socket.assigns
-
-    # TODO: 画面からはフォームを消しているがサーバ側として権限確認が必要
 
     image_names = Enum.map(uploads.image.entries, & &1.client_name)
     help? = help == "on" && me

--- a/test/factories/team_supporter_team_factory.ex
+++ b/test/factories/team_supporter_team_factory.ex
@@ -1,0 +1,42 @@
+defmodule Bright.TeamSupporterTeamFactory do
+  @moduledoc """
+  Factory for Bright.Teams.TeamSupporterTeam
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      def team_supporter_team_factory do
+        %Bright.Teams.TeamSupporterTeam{
+          request_datetime: NaiveDateTime.utc_now(),
+          status: :requesting
+        }
+      end
+
+      def team_supporter_team_supporting_factory do
+        %Bright.Teams.TeamSupporterTeam{
+          request_datetime: NaiveDateTime.utc_now(),
+          start_datetime: NaiveDateTime.utc_now(),
+          status: :supporting
+        }
+      end
+
+      def relate_user_and_supporter(user_1, user_2) do
+        # 支援関係を生成し、それぞれのチームを返す
+        supportee_team = insert(:team)
+        insert(:team_member_users, team: supportee_team, user: user_1)
+
+        supporter_team = insert(:team, enable_hr_functions: true)
+        insert(:team_member_users, team: supporter_team, user: user_2)
+
+        insert(:team_supporter_team_supporting,
+          supportee_team: supportee_team,
+          supporter_team: supporter_team,
+          request_from_user: user_1,
+          request_to_user: user_2
+        )
+
+        {supportee_team, supporter_team}
+      end
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -89,6 +89,7 @@ defmodule Bright.Factory do
   # Teams context
   use Bright.TeamFactory
   use Bright.TeamMemberUsersFactory
+  use Bright.TeamSupporterTeamFactory
 
   # NotificationsFactory context
   use Bright.NotificationOperationFactory


### PR DESCRIPTION
## 対応内容

issue close #1182 

- 学習メモ 投稿権限：支援先と支援元でつながるチームメンバーも可能にしました。
- 学習メモ ヘルプ時宛先：支援先と支援元でつながるチームメンバーも追加しました。
