### PR TITLE
SNS 連携で新規登録のプロバイダロゴの位置を修正

### DIFF
--- a/lib/bright_web/live/user_auth_components.ex
+++ b/lib/bright_web/live/user_auth_components.ex
@@ -284,7 +284,7 @@ defmodule BrightWeb.UserAuthComponents do
       <span class="block font-bold mb-2 text-xs max-w-xs mx-auto w-full">認証</span>
       <span
         class={[
-          "block bg-no-repeat border-solid bg-5 bg-left-2.5 border font-bold max-w-xs mx-auto px-4 py-2 rounded select-none text-center w-full",
+          "block bg-no-repeat border-solid bg-5 bg-left-2.5 border-b font-bold max-w-xs mx-auto px-4 py-2 select-none text-center w-full",
           @variant == "google" && "bg-bgGoogle border-black text-black",
           @variant == "github" && "bg-bgGithub bg-sns-github border-github text-white",
           @variant == "facebook" && "bg-bgFacebook bg-sns-facebook border-facebook text-white",

--- a/lib/bright_web/live/user_register_social_account_live.ex
+++ b/lib/bright_web/live/user_register_social_account_live.ex
@@ -13,6 +13,8 @@ defmodule BrightWeb.UserRegisterSocialAccountLive do
     ~H"""
     <UserAuthComponents.header>ユーザー新規作成</UserAuthComponents.header>
 
+    <UserAuthComponents.social_auth_banner variant={to_string(@provider)} />
+
     <UserAuthComponents.auth_form
       for={@form}
       id="registration_by_social_auth_form"
@@ -46,8 +48,6 @@ defmodule BrightWeb.UserRegisterSocialAccountLive do
             </label>
           </div>
         </div>
-
-        <UserAuthComponents.social_auth_banner variant={to_string(@provider)} />
 
         <UserAuthComponents.button variant="mx-auto" disabled={!(@is_terms_of_service_checked? && @is_privacy_policy_checked? && @is_law_checked?)}>ユーザーを新規作成する</UserAuthComponents.button>
       </UserAuthComponents.form_section>


### PR DESCRIPTION
- close: #1166 

PO にはこちらで確認済
https://digi-dock.slack.com/archives/C0550EENU86/p1700976358661879?thread_ts=1700387173.141589&cid=C0550EENU86

# スクショ
![image](https://github.com/bright-org/bright/assets/18478417/50d1ed78-fc07-49ce-9214-9b05258fadcc)

![image](https://github.com/bright-org/bright/assets/18478417/0a5ae1ca-f8b1-44e5-8882-e7fbc768a484)

![image](https://github.com/bright-org/bright/assets/18478417/e3077cd3-a701-473a-a4e8-1f194af7b2df)
