### PR TITLE
カスタムグループ 0件（かつチーム無し）のタブ切り替え時でエラーになる現象対応

### DIFF
--- a/lib/bright_web/live/card_live/related_user_card_component.ex
+++ b/lib/bright_web/live/card_live/related_user_card_component.ex
@@ -302,10 +302,11 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
     %{inner_selected_tab: custom_group_id, current_user: current_user} = socket.assigns
 
     custom_group =
-      CustomGroups.get_custom_group_by(
-        id: custom_group_id,
-        user_id: current_user.id
-      )
+      custom_group_id &&
+        CustomGroups.get_custom_group_by(
+          id: custom_group_id,
+          user_id: current_user.id
+        )
 
     if custom_group do
       member_users_page =

--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -335,10 +335,6 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       user_2: user_2,
       skill_panel: skill_panel
     } do
-      team = insert(:team)
-      insert(:team_member_users, user: user, team: team)
-      insert(:team_member_users, user: user_2, team: team)
-
       custom_group = insert(:custom_group, user: user)
       insert(:custom_group_member_user, user: user_2, custom_group: custom_group)
 


### PR DESCRIPTION
## 対応内容

障害表対応です。

https://docs.google.com/spreadsheets/d/1qag1sy_C9_kcTrwxMmPCRzlsObULDAvLyzwaNp4EhjI/edit#gid=0&range=5:5

> カスタムグループが0件時に「カスタムグループ」タブに切り替えができなかった