### PR TITLE
スキルパネル テーブル横見出しの固定対応

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -7,6 +7,31 @@
 @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700;900&display=swap");
 @import url("https://fonts.googleapis.com/css?family=Material+Icons%7CMaterial+Icons+Outlined%7CMaterial+Icons+Round%7CMaterial+Icons+Sharp%7CMaterial+Icons+Two+Tone%7CMaterial+Symbols+Outlined");
 
+
+.skill-panel-table .sticky-border {
+  border: none;
+}
+
+.skill-panel-table .sticky-border:before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-right: 1px solid #97ACAC;
+  border-bottom: 1px solid #97ACAC;
+  z-index: -1;
+}
+
+.skill-panel-table .sticky-border-plus-left:before {
+  border-left: 1px solid #97ACAC;
+}
+
+.skill-panel-table .sticky-border-plus-top:before {
+  border-top: 1px solid #97ACAC;
+}
+
 /* Skill panels */
 
 #arrow-to-job-searching {

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -37,7 +37,8 @@
       me={@me}
     />
   </div>
-  <div class="bg-white shadow relative z-2 pb-10 pt-1 lg:pt-3">
+
+  <div class="lg:max-w-[1640px] bg-white shadow relative z-2 pb-10 pt-1 lg:pt-3">
     <div class="px-2 lg:px-6">
       <h3 class="text-xl my-4 lg:hidden"><%= "クラス#{@skill_class.class} : #{@skill_class.name}" %></h3>
       <.profile_area

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -179,20 +179,20 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
 
   def skills_table(assigns) do
     ~H"""
-    <div id="skills-table-field" class="h-[70vh] w-full overflow-auto scroll-pt-[76px] mt-4 lg:h-[50vh]">
-      <table class="skill-panel-table min-w-full border-t border-l border-brightGray-200">
-        <thead class="sticky top-0 bg-white">
+    <div id="skills-table-field" class="h-[70vh] overflow-auto scroll-pt-[76px] mt-4 h-[50vh]">
+      <table class="skill-panel-table">
+        <% # z-[1]: table内のsticky優先表示で使用 %>
+        <thead>
           <tr>
-            <td colspan="4" class="!border-t !border-l-white !border-t-white !border-l">
-            </td>
-            <td class="!border-l !border-brightGray-200">
-              <div class="flex justify-center items-center min-w-[80px] lg:min-w-[150px]">
+            <td colspan="4" class="sticky z-[1] left-0 top-0 min-w-[900px] bg-white sticky-border"> </td>
+            <td class="sticky top-0 bg-white sticky-border sticky-border-plus-top">
+              <div class="flex justify-center items-center min-w-[80px] min-w-[150px]">
                 <p class="inline-flex flex-1 justify-center">
                   <%= if(@anonymous, do: "非表示", else: @display_user.name) %>
                 </p>
               </div>
             </td>
-            <td :for={user <- @compared_users} class="!border-l !border-brightGray-200">
+            <td :for={user <- @compared_users} class="sticky top-0 bg-white sticky-border sticky-border-plus-top">
               <div class="flex justify-center items-center">
                 <p class="inline-flex flex-1 justify-center"><%= if user.anonymous, do: "非表示", else: user.name %></p>
                 <button
@@ -208,19 +208,19 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
             </td>
           </tr>
           <tr>
-            <th class="bg-base text-white text-center lg:min-w-[200px]">
+            <th class="bg-base text-white text-center min-w-[200px] sticky z-[1] left-0 top-[37px] sticky-border sticky-border-plus-left">
               知識エリア
             </th>
-            <th class="bg-base text-white text-center lg:min-w-[200px]">
+            <th class="bg-base text-white text-center min-w-[200px] sticky z-[1] left-[200px] top-[37px] sticky-border">
               カテゴリー
             </th>
-            <th class="bg-base text-white text-center lg:min-w-[420px]">
+            <th class="bg-base text-white text-center min-w-[420px] sticky z-[1] left-[400px] top-[37px] sticky-border">
               スキル
             </th>
-            <th class="bg-base text-white text-center">
+            <th class="bg-base text-white text-center min-w-[80px] sticky z-[1] left-[820px] top-[37px] sticky-border">
               合計
             </th>
-            <td id="my-percentages">
+            <td id="my-percentages" class="bg-white sticky top-[37px] sticky-border">
               <div class="flex justify-center flex-wrap gap-x-2">
                 <div class="min-w-[3em] flex items-center">
                   <span class={[score_mark_class(:high, :green), "inline-block mr-1"]} />
@@ -232,7 +232,11 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
                 </div>
               </div>
             </td>
-            <td id={"user-#{index}-percentages"} :for={{user, index} <- Enum.with_index(@compared_users, 1)}>
+            <td
+              :for={{user, index} <- Enum.with_index(@compared_users, 1)}
+              id={"user-#{index}-percentages"}
+              class="bg-white sticky top-[37px] sticky-border"
+            >
               <% user_data = Map.get(@compared_user_dict, user.name) %>
               <div class="flex justify-center gap-x-2">
                 <div class="min-w-[3em] flex items-center">
@@ -254,13 +258,13 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
           <% current_skill_score = Map.get(@current_skill_score_dict, Map.get(current_skill, :id)) %>
 
           <tr id={"skill-#{row}"}>
-            <td :if={col1} rowspan={col1.size} id={"unit-#{col1.position}"} class="align-top">
+            <td :if={col1} rowspan={col1.size} id={"unit-#{col1.position}"} class="align-top sticky left-0 bg-white sticky-border sticky-border-plus-left">
               <%= col1.skill_unit.name %>
             </td>
-            <td :if={col2} rowspan={col2.size} class="align-top">
+            <td :if={col2} rowspan={col2.size} class="align-top sticky left-[200px] bg-white sticky-border">
               <%= col2.skill_category.name %>
             </td>
-            <td>
+            <td class="sticky left-[400px] bg-white sticky-border">
               <div class="flex justify-between items-center">
                 <p><%= col3.skill.name %></p>
                 <div class="flex justify-between items-center gap-x-2">
@@ -270,7 +274,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
                 </div>
               </div>
             </td>
-            <td>
+            <td class="sticky left-[820px] bg-white sticky-border">
               <div class="num-high-users flex justify-center gap-x-1">
                 <div class="min-w-[3em] flex items-center">
                   <span class={[score_mark_class(:high, :gray), "inline-block mr-1"]}></span>


### PR DESCRIPTION
## 対応内容

issue close #1184 

スキルパネル画面のスキルテーブル(PC)横見出しの固定対応を行いました。

- PCで横幅が小さい(1920px以下)の場合は、横スクロールとあいまって操作感が落ちるかもしれません。


## 参考画像

閲覧時1920pxのときは、全体横スクロールはでない（厳密には縦スクロール分のみ）ようになっています。

![image](https://github.com/bright-org/bright/assets/121112529/80c1bae1-a9c4-4d37-9495-807d102ac4c5)

1920px以下のときは、全体横スクロールもでるので若干操作性が落ちます。

![image](https://github.com/bright-org/bright/assets/121112529/56734c2c-5625-4ee7-b240-69c1bd6e2e35)
