### PR TITLE
notification menu に click awayを追加

### DIFF
--- a/lib/bright_web/live/notification_live/notification_header_component.ex
+++ b/lib/bright_web/live/notification_live/notification_header_component.ex
@@ -11,6 +11,7 @@ defmodule BrightWeb.NotificationLive.NotificationHeaderComponent do
       <button
         class="fixed top-3 right-28 mr-4 hover:opacity-70 lg:top-0 lg:ml-4 lg:right-0 lg:mr-0 lg:relative"
         phx-click="toggle_notifications"
+        phx-click-away={@open? && "close_notifications"}
         phx-target={@myself}
       >
         <.icon name="hero-bell" class="h-8 w-8" />
@@ -53,6 +54,12 @@ defmodule BrightWeb.NotificationLive.NotificationHeaderComponent do
 
     socket
     |> assign(:open?, new_open?)
+    |> then(&{:noreply, &1})
+  end
+
+  def handle_event("close_notifications", _params, socket) do
+    socket
+    |> assign(:open?, false)
     |> then(&{:noreply, &1})
   end
 


### PR DESCRIPTION
採用通知は実装してあったが、通知の実装が漏れていた
https://github.com/bright-org/bright/assets/91950/b2b7b26e-4354-459a-9dc4-1ad557cde077

