### PR TITLE
ユーザーカード 「チーム」を「所属チーム」に文言修正

### DIFF
--- a/lib/bright_web/live/card_live/related_user_card_component.ex
+++ b/lib/bright_web/live/card_live/related_user_card_component.ex
@@ -16,7 +16,7 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
   @tabs [
     # 気になる人はβリリース対象外のため非表示
     # {"intriguing", "気になる人"},
-    {"team", "チーム"},
+    {"team", "所属チーム"},
     {"custom_group", "カスタムグループ"},
     {"candidate_for_employment", "採用候補者"}
   ]


### PR DESCRIPTION
## 対応内容

「チーム」を「所属チーム」に文言修正しました。

障害表：https://docs.google.com/spreadsheets/d/1qag1sy_C9_kcTrwxMmPCRzlsObULDAvLyzwaNp4EhjI/edit#gid=0&range=7:7

## 参考画像

![image](https://github.com/bright-org/bright/assets/121112529/7950fa83-6b36-406f-9b0b-b921afd93b53)
