### PR TITLE
チームカード チーム表示行の高さを管理者かどうかに問わず統一

### DIFF
--- a/lib/bright_web/components/team_components.ex
+++ b/lib/bright_web/components/team_components.ex
@@ -34,7 +34,7 @@ defmodule BrightWeb.TeamComponents do
       phx-target={@row_on_click_target}
       phx-value-team_id={@team_params.team_id}
       phx-value-team_type={@team_params.team_type}
-      class="text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded cursor-pointer"
+      class="h-[35px] text-left flex items-center text-base hover:bg-brightGray-50 p-1 rounded cursor-pointer"
     >
 
     <span


### PR DESCRIPTION
## 対応内容

チームカード内でチームの管理者かどうかで表示される高さがかわる件を対応しました。
１行高さを指定しています。

障害表：
https://docs.google.com/spreadsheets/d/1qag1sy_C9_kcTrwxMmPCRzlsObULDAvLyzwaNp4EhjI/edit#gid=0&range=6:6

## 参考画像

![sample62](https://github.com/bright-org/bright/assets/121112529/234dd950-c913-4a87-9cec-1e9f44d7d23a)
