### PR TITLE
スキルパネル画面 カスタムグループ メニュー名「カスタムグループ追加・比較」に変更

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -147,7 +147,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
       data-dropdown-placement="bottom"
     >
       <.action_button class="dropdownTrigger">
-        <span>カスタムグループと比較</span>
+        <span>カスタムグループ追加・比較</span>
       </.action_button>
       <div
         class="dropdownTarget z-10 hidden bg-white rounded-lg shadow-md min-w-[286px] border border-brightGray-50"


### PR DESCRIPTION
## 対応内容

>  「カスタムグループと比較」が、追加の意図が伝わっていないみたいなので、「カスタムグループ追加・比較」に文言変更

## 参考画像

![スクリーンショット 2023-12-01 135150](https://github.com/bright-org/bright/assets/121112529/16be9927-60f9-4031-b44f-cadc9fda8c25)
