### PR TITLE
学習メモ 支援関係のヘルプ通知先をサポート状態にあるチームのみに限定

### DIFF
--- a/lib/bright/skill_evidences.ex
+++ b/lib/bright/skill_evidences.ex
@@ -253,13 +253,13 @@ defmodule Bright.SkillEvidences do
     }
 
     # ユーザー所属チームとその関連チーム取得
-    # NOTE: 今後設定によって通知要否（粒度未定）できるようになる想定です
+    # NOTE: 今後設定によって通知要否（粒度未定）できるようになる想定です。そのため個別ロードしています。
     teams =
       Ecto.assoc(user, :teams)
       |> preload([
         :member_users,
-        supporter_teams: [:member_users],
-        supportee_teams: [:member_users]
+        supporter_teams_supporting: [:member_users],
+        supportee_teams_supporting: [:member_users]
       ])
       |> Repo.all()
 
@@ -269,13 +269,13 @@ defmodule Bright.SkillEvidences do
     # 支援元メンバー
     supporter_related_ids =
       teams
-      |> Enum.flat_map(& &1.supporter_teams)
+      |> Enum.flat_map(& &1.supporter_teams_supporting)
       |> collect_team_user_ids()
 
     # 支援先メンバー
     supportee_related_ids =
       teams
-      |> Enum.flat_map(& &1.supportee_teams)
+      |> Enum.flat_map(& &1.supportee_teams_supporting)
       |> collect_team_user_ids()
 
     (team_related_ids ++ supporter_related_ids ++ supportee_related_ids)

--- a/lib/bright/teams/team.ex
+++ b/lib/bright/teams/team.ex
@@ -22,8 +22,17 @@ defmodule Bright.Teams.Team do
     has_many :team_supporter_teams_on_supportee, Bright.Teams.TeamSupporterTeam,
       foreign_key: :supportee_team_id
 
-    has_many :supportee_teams, through: [:team_supporter_teams_on_supporter, :supportee_team]
-    has_many :supporter_teams, through: [:team_supporter_teams_on_supportee, :supporter_team]
+    many_to_many :supportee_teams_supporting,
+                 Bright.Teams.Team,
+                 join_through: Bright.Teams.TeamSupporterTeam,
+                 join_keys: [supporter_team_id: :id, supportee_team_id: :id],
+                 join_where: [status: :supporting]
+
+    many_to_many :supporter_teams_supporting,
+                 Bright.Teams.Team,
+                 join_through: Bright.Teams.TeamSupporterTeam,
+                 join_keys: [supportee_team_id: :id, supporter_team_id: :id],
+                 join_where: [status: :supporting]
 
     timestamps()
   end

--- a/test/bright/skill_evidences_test.exs
+++ b/test/bright/skill_evidences_test.exs
@@ -282,6 +282,19 @@ defmodule Bright.SkillEvidencesTest do
       assert Repo.get_by(NotificationEvidence, from_user_id: user.id, to_user_id: user_2.id)
     end
 
+    test "do not send supporter members if not in supporting status", %{
+      user: user,
+      skill_evidence: skill_evidence
+    } do
+      user_2 = insert(:user)
+      not_supporting_statuses = ~w(requesting support_ended reject)a
+
+      Enum.each(not_supporting_statuses, fn status ->
+        relate_user_and_supporter(user, user_2, status)
+        assert {0, _} = SkillEvidences.help(skill_evidence, user)
+      end)
+    end
+
     test "creates notification_evidences to supportee members", %{
       user: user,
       skill_evidence: skill_evidence
@@ -291,6 +304,19 @@ defmodule Bright.SkillEvidencesTest do
 
       {1, _} = SkillEvidences.help(skill_evidence, user)
       assert Repo.get_by(NotificationEvidence, from_user_id: user.id, to_user_id: user_2.id)
+    end
+
+    test "do not send supportee members if not in supporting status", %{
+      user: user,
+      skill_evidence: skill_evidence
+    } do
+      user_2 = insert(:user)
+      not_supporting_statuses = ~w(requesting support_ended reject)a
+
+      Enum.each(not_supporting_statuses, fn status ->
+        relate_user_and_supporter(user_2, user, status)
+        assert {0, _} = SkillEvidences.help(skill_evidence, user)
+      end)
     end
   end
 

--- a/test/factories/team_supporter_team_factory.ex
+++ b/test/factories/team_supporter_team_factory.ex
@@ -20,7 +20,7 @@ defmodule Bright.TeamSupporterTeamFactory do
         }
       end
 
-      def relate_user_and_supporter(user_1, user_2) do
+      def relate_user_and_supporter(user_1, user_2, status \\ :supporting) do
         # 支援関係を生成し、それぞれのチームを返す
         supportee_team = insert(:team)
         insert(:team_member_users, team: supportee_team, user: user_1)
@@ -32,7 +32,8 @@ defmodule Bright.TeamSupporterTeamFactory do
           supportee_team: supportee_team,
           supporter_team: supporter_team,
           request_from_user: user_1,
-          request_to_user: user_2
+          request_to_user: user_2,
+          status: status
         )
 
         {supportee_team, supporter_team}


### PR DESCRIPTION
## 対応内容

学習メモのヘルプ時の送信先について、下記の修正を行いました。

（修正前）支援関係にあるチームメンバー全員に通知
（修正後）現在、支援関係にあるチームメンバー全員に通知

障害表：

https://docs.google.com/spreadsheets/d/17Y4zuEjnunkpFAoKtfoAezu9wPibnQotvoX8fBLIJ3Y/edit#gid=0&range=6:6