### PR TITLE
通知一覧と表示モーダルのスマホ表示調整

### DIFF
--- a/lib/bright_web/components/bright_modal_components.ex
+++ b/lib/bright_web/components/bright_modal_components.ex
@@ -49,15 +49,18 @@ defmodule BrightWeb.BrightModalComponents do
 
   attr :id, :string, required: true
   attr :show, :boolean, default: false
-  attr :style_of_modal_flame_out, :string, default: "p-4 sm:p-6 lg:py-8"
+  attr :style_of_modal_flame_out, :string, default: "p-2 lg:py-8"
 
   attr :style_of_modal_flame, :string,
     default:
-      "shadow-zinc-700/10 ring-zinc-700/10 relative hidden rounded-md bg-white p-14 shadow-lg ring-1 transition"
+      "shadow-zinc-700/10 ring-zinc-700/10 relative hidden rounded-md bg-white p-8 lg:p-14 shadow-lg ring-1 transition"
 
   attr :enable_cancel_button, :boolean, default: true
   attr :cancel_button_confirm, :string, default: nil
-  attr :style_of_cancel_button_rayout, :string, default: "absolute top-6 right-5"
+
+  attr :style_of_cancel_button_rayout, :string,
+    default: "absolute top-2 right-2 lg:top-6 lg:right-5"
+
   attr :style_of_cancel_button, :string, default: "-m-3 flex-none p-3 opacity-80"
   attr :style_of_cancel_button_x_mark, :string, default: "h-8 w-8"
   attr :on_cancel, JS, default: %JS{}

--- a/lib/bright_web/live/notification_live/evidence.ex
+++ b/lib/bright_web/live/notification_live/evidence.ex
@@ -24,11 +24,11 @@ defmodule BrightWeb.NotificationLive.Evidence do
         </li>
         <%= for notification <- @notifications do %>
           <li class="flex flex-wrap my-5">
-            <div phx-click="click" phx-value-notification_evidence_id={notification.id} class="cursor-pointer hover:opacity-70 text-left flex flex-wrap items-center text-base px-1 py-1 flex-1 mr-4 w-full lg:w-auto lg:flex-nowrap truncate">
+            <div phx-click="click" phx-value-notification_evidence_id={notification.id} class="cursor-pointer hover:opacity-70 text-left flex flex-wrap items-center text-base px-1 py-1 flex-1 mr-4 w-full lg:w-auto lg:flex-nowrap">
               <span class="material-icons text-lg text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center">
                 person
               </span>
-              <span class={["order-3 lg:order-2 flex-1 mr-2 truncate"]}><%= notification.message %></span>
+              <span class={["order-3 lg:order-2 flex-1 mr-2"]}><%= notification.message %></span>
               <CardListComponents.elapsed_time inserted_at={notification.inserted_at} />
             </div>
             <div class="flex gap-x-2 w-full justify-end lg:justify-start lg:w-auto">


### PR DESCRIPTION
## 対応内容

- 通知一覧のtruncateを削除
  - 学習メモのヘルプで、ヘルプか返信による通知かの区別がつかないため。
  - 障害表：https://docs.google.com/spreadsheets/d/17Y4zuEjnunkpFAoKtfoAezu9wPibnQotvoX8fBLIJ3Y/edit#gid=0&range=7:7
- モーダルの余白を縮小
  - SPでみえにくいのが気になっていたので対応しました。

## 参考画像

iPhone SE幅です。

**変更前：通知一覧のtruncateを削除**

![スクリーンショット 2023-12-05 095153](https://github.com/bright-org/bright/assets/121112529/49d32f56-282c-4a41-bb45-fed29f0c7cbc)

**変更後：通知一覧のtruncateを削除**

![スクリーンショット 2023-12-05 095358](https://github.com/bright-org/bright/assets/121112529/0aca64f1-fc92-4539-8ae8-e38afb719d54)

**変更前：モーダル余白**

![スクリーンショット 2023-12-05 095132](https://github.com/bright-org/bright/assets/121112529/27916529-5fbe-413e-ab19-977db2cb79de)

**変更後：モーダル余白**

![スクリーンショット 2023-12-05 095348](https://github.com/bright-org/bright/assets/121112529/b55ab892-5562-4f34-ad3b-20597e61ac74)
