### PR TITLE
スキルパネル スキル一覧の自身の列幅最小指定を除去

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -295,7 +295,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
               </div>
             </td>
             <td>
-              <div class="flex justify-center gap-x-4 px-4 min-w-[150px]">
+              <div class="flex justify-center gap-x-4 px-4 h-[21px] items-center">
                 <span class={[score_mark_class(skill_score.score, :green), "inline-block", "score-mark-#{skill_score.score}"]} />
               </div>
             </td>


### PR DESCRIPTION
## 対応内容

スキルパネル スキル一覧の自身の列幅を、他ユーザーと合わせるようにしました。
（以前、入力フォームを入れるために確保していた幅ですが、必要なくなりました）

![image](https://github.com/bright-org/bright/assets/121112529/3aec471c-bb70-4d4f-97f4-fcb41f23ea9e)
