### PR TITLE
カスタムグループ sp表示時のカードから作成を促すボタンを削除

### DIFF
--- a/lib/bright_web/live/card_live/related_team_card_component.ex
+++ b/lib/bright_web/live/card_live/related_team_card_component.ex
@@ -80,7 +80,7 @@ defmodule BrightWeb.CardLive.RelatedTeamCardComponent do
                 <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">カスタムグループはありません</div>
                 <a
                    href="/panels"
-                   class="text-sm font-bold px-5 py-3 rounded text-white bg-base"
+                   class="hidden lg:inline text-sm font-bold px-5 py-3 rounded text-white bg-base"
                  >
                    カスタムグループを作る
                  </a>


### PR DESCRIPTION
## 対応内容

カスタムグループの作成を促すボタンをメガメニューなどのカードから削除しました（SP）。
SPでは画面遷移しても作れないためです。

障害表：
https://docs.google.com/spreadsheets/d/1qag1sy_C9_kcTrwxMmPCRzlsObULDAvLyzwaNp4EhjI/edit#gid=0&range=11:11

## 参考画像

**対応前**

![image](https://github.com/bright-org/bright/assets/121112529/2a0330e4-c6af-46f8-b55c-0338d24a4fe2)

**対応後**

![スクリーンショット 2023-12-06 091059](https://github.com/bright-org/bright/assets/121112529/de6f259c-e305-4263-bcc9-514c87408d1d)
