### PR TITLE
ガイドメッセージ βリリースにて実装のアナウンスを削除

### DIFF
--- a/lib/bright_web/components/guide_message_components.ex
+++ b/lib/bright_web/components/guide_message_components.ex
@@ -115,7 +115,7 @@ defmodule BrightWeb.GuideMessageComponents do
   defp evidence_introduction_description(assigns) do
     ~H"""
     <p class="mt-4">
-      なお、各スキルを学んだ記録やメモを残したい場合は、<span class="text-brightGreen-600"><img src="/images/common/icons/skillEvidence.svg" class="inline-block"></span>から、メモを入力することが<br class="hidden lg:inline">できます。（βリリースでは他のチームメンバーにヘルプを出したりできます）
+      なお、各スキルを学んだ記録やメモを残したい場合は、<span class="text-brightGreen-600"><img src="/images/common/icons/skillEvidence.svg" class="inline-block"></span>から、メモを入力することが<br class="hidden lg:inline">できます。
     </p>
     """
   end


### PR DESCRIPTION
## 対応内容

βリリースで実装する旨のメッセージを外しました。

障害表：
https://docs.google.com/spreadsheets/d/1vcPuh1D-ae_SekHUqcjpqg37rkqhxK2qF_lAQhKQ0fE/edit#gid=0&range=8:9

## 参考画像

対応後

![スクリーンショット 2023-12-06 092152](https://github.com/bright-org/bright/assets/121112529/d950372f-eff5-4bb1-964e-7c4591c20cca)
