### PR TITLE
関わっているユーザー (SP)タブ内スクロールが表示されない/見切れる現象対応

### DIFF
--- a/assets/js/hooks/TabSlideScroll.js
+++ b/assets/js/hooks/TabSlideScroll.js
@@ -19,39 +19,48 @@ const setElementMargin = function(element, property, value) {
   element.style[property] = value + "px"
 }
 
-const setButtonsDisplay = function(element, count) {
-  if (count > 3) {
-    element.style.display = "flex"
+const setButtonsDisplay = function(scrollerEl, thisEl, itemsSumWidth) {
+  // 表示幅からスクロール操作ボタンを出すかを決定
+  // ただし、SPでDropdownが開いていないときはthisEl.clientWidthが取得できない(autoのため0で返る)ため、全体幅に基づいている。
+  let width = thisEl.clientWidth
+  width = (width == 0) ? document.body.clientWidth : width
+
+  if (itemsSumWidth > width) {
+    scrollerEl.style.display = "flex"
   } else {
-    element.style.display = "none"
+    scrollerEl.style.display = "none"
   }
 }
 
 const TabSlideScroll = {
   mounted() {
+    // itemWidth: HTML側で指定されているタブ幅(200px)
+    const itemWidth = 200
     const relational_tab = this.el.querySelector(".inner_tab_list")
     const relational_tab_items = relational_tab.querySelectorAll("li")
     this.relational_buttons = this.el.querySelector(".inner_tab_slide_buttons")
+    // this.margin: スライドしている量。右矢印でマイナス側にずらして表示内容を変更している
     this.margin = 0
     this.first_tab_item = relational_tab_items[0]
-    this.count = relational_tab_items.length
-    const tab_width = this.count * 200
+    this.itemsSumWidth = relational_tab_items.length * itemWidth
     const buttons = this.relational_buttons.children
 
     // 表示設定
-    setButtonsDisplay(this.relational_buttons, this.count)
+    setButtonsDisplay(this.relational_buttons, this.el, this.itemsSumWidth)
 
     // イベント設定
     buttons[1].addEventListener("click", () => {
-      if (tab_width + this.margin > 600) {
-        this.margin = this.margin - 200
-        animateElement(this.first_tab_item, "marginLeft", this.margin + 200, this.margin, 250)
+      if (this.itemsSumWidth + this.margin > this.el.clientWidth) {
+        const newMargin = this.margin - itemWidth
+        animateElement(this.first_tab_item, "marginLeft", this.margin, newMargin, 250)
+        this.margin = newMargin
       }
     })
     buttons[0].addEventListener("click", () => {
       if (this.margin < 0) {
-        this.margin = this.margin + 200
-        animateElement(this.first_tab_item, "marginLeft", this.margin - 200, this.margin, 250)
+        const newMargin = this.margin + itemWidth
+        animateElement(this.first_tab_item, "marginLeft", this.margin, newMargin, 250)
+        this.margin = newMargin
       }
     })
   },
@@ -59,7 +68,7 @@ const TabSlideScroll = {
   updated() {
     // タブ押下時(updated)の位置と表示の再設定
     setElementMargin(this.first_tab_item, "marginLeft", this.margin)
-    setButtonsDisplay(this.relational_buttons, this.count)
+    setButtonsDisplay(this.relational_buttons, this.el, this.itemsSumWidth)
   }
 }
 


### PR DESCRIPTION
## 対応内容

下記障害対応です。

- 「個人」メガメニュー サブタブのスクロールが表示されなかった
  - （実際には描画されているがSPサイズだと見切れていました）
- 「個人」メガメニュー末尾(一番右)のチームが表示されなかった
  - （実際には描画されているがSPサイズだと見切れていました）


障害表：
https://docs.google.com/spreadsheets/d/1vcPuh1D-ae_SekHUqcjpqg37rkqhxK2qF_lAQhKQ0fE/edit#gid=0&range=12:14

## 参考画像

最後までスクロールしたときのキャプチャです。

![image](https://github.com/bright-org/bright/assets/121112529/8fc02384-a2b6-4f41-9845-ea1b4f3ac2be)
