### PR TITLE
#1227 チーム編集モーダルでのチームタイプ選択プルダウンを新規作成時のみ活性に制限

### DIFF
--- a/lib/bright_web/components/team_components.ex
+++ b/lib/bright_web/components/team_components.ex
@@ -150,13 +150,24 @@ defmodule BrightWeb.TeamComponents do
 
     ~H"""
     <div
+      :if={!assigns.is_clickable? || length(filter_team_type_select_list_by_user_id(@user_id)) <= 1}
+    >
+      <div
+        class={"text-left flex items-center text-base p-1 rounded border border-brightGray-100 bg-white w-full"}
+        type="button"
+      >
+        <img src={get_team_icon_path(@selected_team_type)} class="ml-2 mr-2"/>
+        <%= get_display_name(@selected_team_type) %>
+      </div>
+    </div>
+    <div
+      :if={assigns.is_clickable? && length(filter_team_type_select_list_by_user_id(@user_id)) >= 2}
       id={"{@id}"}
       phx-hook="Dropdown"
       data-dropdown-offset-skidding="0"
       data-dropdown-placement="bottom"
     >
       <bottun
-          :if={assigns.is_clickable? && length(filter_team_type_select_list_by_user_id(@user_id)) >= 2}
           class={"text-left flex items-center text-base p-1 rounded border border-brightGray-100 bg-white w-full  hover:bg-brightGray-50 dropdownTrigger"}
           type="button"
         >
@@ -164,18 +175,9 @@ defmodule BrightWeb.TeamComponents do
         <%= get_display_name(@selected_team_type) %>
       </bottun>
       <p
-        :if={assigns.is_clickable? && length(filter_team_type_select_list_by_user_id(@user_id)) >= 2}
       >
         チームタイプを選択してください
       </p>
-      <div
-          :if={!assigns.is_clickable?}
-          class={"text-left flex items-center text-base p-1 rounded border border-brightGray-100 bg-white w-full"}
-          type="button"
-        >
-        <img src={get_team_icon_path(@selected_team_type)} class="ml-2 mr-2"/>
-        <%= get_display_name(@selected_team_type) %>
-      </div>
       <!-- menue list-->
       <div
           :if={@is_clickable?}

--- a/lib/bright_web/live/team_live/team_create_live_component.html.heex
+++ b/lib/bright_web/live/team_live/team_create_live_component.html.heex
@@ -45,7 +45,7 @@
                   <.team_type_select_dropdown_menue
                     selected_team_type={@selected_team_type}
                     phx_target={@myself}
-                    is_clickable?={:true}
+                    is_clickable?={@action == :new}
                     user_id={@current_user.id}
                   />
                 </dd>


### PR DESCRIPTION
チームタイプが２種類以上選べないと非活性

![image](https://github.com/bright-org/bright/assets/45676464/5354ca1d-9065-4a71-a450-9c310ca2d110)

チームタイプが２種類以上選べる場合活性

![image](https://github.com/bright-org/bright/assets/45676464/bcff2c74-5b8f-4224-8322-b54769cad793)

チームタイプが２種類以上選べる場合活性も編集時は非活性

![image](https://github.com/bright-org/bright/assets/45676464/df8612bb-9186-4f78-902a-1d1ff06ebd25)


