### PR TITLE
働く際の希望の入力を促すガイドがヘッダー部より下になっていた現象(SP)対応

### DIFF
--- a/lib/bright_web/components/guide_message_components.ex
+++ b/lib/bright_web/components/guide_message_components.ex
@@ -67,9 +67,9 @@ defmodule BrightWeb.GuideMessageComponents do
   """
   def prompt_job_searching_message(assigns) do
     ~H"""
-    <div id="job_searching_message" class="flex fixed lg:absolute items-center right-4 top-12 lg:-top-16 w-fit px-5 lg:px-0 z-10">
+    <div id="job_searching_message" class="flex fixed lg:absolute items-center right-4 top-12 lg:-top-16 w-fit px-5 lg:px-0 z-[41]">
       <div class="bg-designer-dazzle flex leading-normal px-4 py-2 rounded text-xs w-fit">
-        <p>上記の求職設定を行うと、スキル検索であなたのスキルを必要とするプロジェクト（副業含む）から声がかかるようになります。</p>
+        <p>上記から「働く際の希望」設定を行うと、スキル検索であなたのスキルを必要とするプロジェクト（副業含む）から声がかかるようになります。</p>
       </div>
       <div id="arrow-to-job-searching" class="arrow ml-1"></div>
     </div>

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -76,7 +76,7 @@
     />
   </div>
 
-  <% # 求職設定を促すメッセージ %>
+  <% # 働く際の希望の入力を促すメッセージ %>
   <.prompt_job_searching_message :if={Map.get(@flash, "first_submit_in_skill_panel") && !user_job_searching?(@current_user)} />
 </div>
 


### PR DESCRIPTION
## 対応内容

働く際の希望の入力を促すガイドがヘッダー部より下になっていたため、ｚインデックスの調整を行いました。

その他

- 文言が「求職設定」のままだったので「働く際の希望」に変更しました。
- SNSシェアボタンより上にきていて部分的に重なりますが、このガイドの方は毎回でるわけではないのでそのままにしています。もし対応必要であればご指摘ください。

障害表：
https://docs.google.com/spreadsheets/d/1vcPuh1D-ae_SekHUqcjpqg37rkqhxK2qF_lAQhKQ0fE/edit#gid=0&range=10:11

## 参考画像

**対応前**

![スクリーンショット 2023-12-07 091212](https://github.com/bright-org/bright/assets/121112529/22a8666e-2ba3-4561-811f-5ebc7d715c76)


**対応後**

![スクリーンショット 2023-12-07 091439](https://github.com/bright-org/bright/assets/121112529/7b4e53e0-c65f-4980-893a-4e608edcfd8d)
