### PR TITLE
チーム数が6以上の場合の表示崩れとページめくりボタンのバグ修正

### DIFF
--- a/lib/bright_web/live/team_support_live/team_support_live_componet.ex
+++ b/lib/bright_web/live/team_support_live/team_support_live_componet.ex
@@ -601,7 +601,7 @@ defmodule BrightWeb.TeamSupportLiveComponent do
     %{
       selected_tab: selected_tab,
       entries: [],
-      page_params: %{page: page, page_size: 15},
+      page_params: %{page: page, page_size: 5},
       total_entries: 0,
       total_pages: 0,
       menu_items: @menu_items
@@ -609,7 +609,7 @@ defmodule BrightWeb.TeamSupportLiveComponent do
   end
 
   defp card_view(socket, tab_name, page) do
-    card = create_card_param(page)
+    card = create_card_param(tab_name, page)
 
     socket
     |> assign(:card, card)


### PR DESCRIPTION
[err-21 の表示崩れ](https://docs.google.com/spreadsheets/d/1SWBPuctl3E9-zwT1bhLy1uQgUqG0JoXt2u4Ylf3QVPA/edit#gid=0&range=E24)
[err-23 のページ遷移できない](https://docs.google.com/spreadsheets/d/1SWBPuctl3E9-zwT1bhLy1uQgUqG0JoXt2u4Ylf3QVPA/edit#gid=0&range=E26)
バグ修正