### PR TITLE
#1233 プラン選択の権限チェック関数修正

### DIFF
--- a/lib/bright/subscriptions.ex
+++ b/lib/bright/subscriptions.ex
@@ -425,7 +425,7 @@ defmodule Bright.Subscriptions do
   end
 
   @doc """
-  サービスコードをキーに該当サービスの利用有無を返す
+  サービスコードをキーに該当サービスの利用可否を返す
 
   ## Examples
       iex> service_enabled?("01H7W3BZQY7CZVM5Q66T4EWEVC", "hogehoge")
@@ -446,6 +446,28 @@ defmodule Bright.Subscriptions do
       _ ->
         false
     end
+  end
+
+  @doc """
+  ユーザーIDをキーに採用、育成の基本サービスの利用可否を返す
+
+  ## Examples
+      iex> service_hr_basic_enabled?("01H7W3BZQY7CZVM5Q66T4EWEVC")
+      true
+  """
+  def service_hr_basic_enabled?(user_id) do
+    service_enabled?(user_id, "hr_basic")
+  end
+
+  @doc """
+  ユーザーIDをキーにチームアップサービスの利用可否を返す
+
+  ## Examples
+      iex> service_team_up_enabled?("01H7W3BZQY7CZVM5Q66T4EWEVC")
+      true
+  """
+  def service_team_up_enabled?(user_id) do
+    service_enabled?(user_id, "team_up")
   end
 
   @doc """

--- a/lib/bright_web/components/team_components.ex
+++ b/lib/bright_web/components/team_components.ex
@@ -7,6 +7,7 @@ defmodule BrightWeb.TeamComponents do
   alias Bright.Teams.TeamMemberUsers
   alias Bright.Teams
   alias Bright.Teams.Team
+  alias Bright.Subscriptions
 
   # チームタイプ事の定義(UI向け) Teamsの方のリストと異なりカスタムグループもチーム扱い
   @team_types [
@@ -22,12 +23,15 @@ defmodule BrightWeb.TeamComponents do
       team_type: :general_team,
       visiblily_check_function: &Teams.always_true?/1
     },
-    # TODO チームアップチームの対応までは選択肢を封印
-    # %{display_name: "チームアップチーム", team_type: :teamup_team, visiblily_check_function: &Teams.always_false?/1},
+    %{
+      display_name: "チームアップチーム",
+      team_type: :teamup_team,
+      visiblily_check_function: &Subscriptions.service_team_up_enabled?/1
+    },
     %{
       display_name: "採用・育成チーム",
       team_type: :hr_support_team,
-      visiblily_check_function: &Teams.enable_hr_functions?/1
+      visiblily_check_function: &Subscriptions.service_hr_basic_enabled?/1
     }
   ]
 


### PR DESCRIPTION
[err-25](https://docs.google.com/spreadsheets/d/1SWBPuctl3E9-zwT1bhLy1uQgUqG0JoXt2u4Ylf3QVPA/edit#gid=0&range=E28)対応

チーム作成時の権限チェックに所属チームによるチェックを実施していたので、加入プランによるチェックに修正

- フリープランのユーザー

![image](https://github.com/bright-org/bright/assets/45676464/1d1329c8-20e9-4fc0-879e-330dbfc22a53)


- チームアッププランの契約者

![image](https://github.com/bright-org/bright/assets/45676464/fa2c1401-ffbc-450a-9daa-d1898acaa129)


- 採用・育成プランの契約者

![image](https://github.com/bright-org/bright/assets/45676464/2be50905-c665-4131-bdf5-20a491fba8e6)
