### PR TITLE
share URLを app.bright-fun.orgから bright-fun.orgに変更

### DIFF
--- a/lib/bright_web/components/sns_components.ex
+++ b/lib/bright_web/components/sns_components.ex
@@ -43,7 +43,7 @@ defmodule BrightWeb.SnsComponents do
   attr :path, :string, required: true
 
   def floating_share_buttons(assigns) do
-    assigns = Map.put(assigns, :url, "https://app.bright-fun.org#{assigns.path}")
+    assigns = Map.put(assigns, :url, "https://bright-fun.org")
 
     ~H"""
       <%!-- NOTE: 一瞬だけ画面左上に表示されてしまうのを回避するため、hiddenクラスを付けておきJSでhiddenクラスを消している --%>


### PR DESCRIPTION
![スクリーンショット 2023-12-10 1 09 37](https://github.com/bright-org/bright/assets/91950/dbf80c7c-117a-4897-ba15-38456b8004a9)
![スクリーンショット 2023-12-10 1 09 51](https://github.com/bright-org/bright/assets/91950/7db42823-a84b-4583-99bb-02f1c077e307)
