### PR TITLE
マイページ スキルセットジェムの表示対応

### DIFF
--- a/lib/bright_web/live/mypage_live/index.ex
+++ b/lib/bright_web/live/mypage_live/index.ex
@@ -44,6 +44,7 @@ defmodule BrightWeb.MypageLive.Index do
   defp apply_action(socket, :search, _params) do
     socket
     |> assign(:page_title, "スキル検索／スカウト")
+    |> assign_skillset_gem()
     |> assign(:notification_detail, false)
     |> assign(:search, true)
   end

--- a/lib/bright_web/live/mypage_live/index.html.heex
+++ b/lib/bright_web/live/mypage_live/index.html.heex
@@ -15,9 +15,8 @@
     />
   </div>
 
-  <% # TODO: データ更新後にif: falseを外す %>
-  <div :if={false && @skillset_gem} class="chart-container flex flex-col justify-center items-center my-2 lg:my-0">
-    <% # TODO: クリックは成長パネル側の対応後に開放 %>
+  <div :if={@skillset_gem} class="chart-container flex flex-col justify-center items-center my-2 lg:my-0">
+    <% # TODO: リンクは成長パネル側の対応後に開放 %>
     <p class="text-base !font-bold">
       スキルセットジェム<span :if={false} class="font-normal text-xs ml-2">※クリックすると詳細</span>
     </p>

--- a/test/bright_web/live/mypage_live_test.exs
+++ b/test/bright_web/live/mypage_live_test.exs
@@ -2,7 +2,7 @@ defmodule BrightWeb.MypageLiveTest do
   use BrightWeb.ConnCase
 
   import Phoenix.LiveViewTest
-  # import Bright.Factory
+  import Bright.Factory
 
   describe "Index" do
     setup [:register_and_log_in_user, :setup_career_fields]
@@ -34,37 +34,36 @@ defmodule BrightWeb.MypageLiveTest do
     end
   end
 
-  # # スキルセットジェム確認
-  # # # TODO: 表示開始時にコメントを外す
-  # describe "Skillset gem" do
-  #   setup [:register_and_log_in_user, :setup_career_fields]
-  #
-  #   test "shows gem with data", %{
-  #     conn: conn,
-  #     user: user,
-  #     career_fields: career_fields
-  #   } do
-  #     [career_field | _] = career_fields
-  #     insert(:career_field_score, user: user, career_field: career_field, percentage: 10)
-  #
-  #     {:ok, index_live, _html} = live(conn, ~p"/mypage")
-  #
-  #     data = [[10, 0, 0, 0]] |> Jason.encode!()
-  #     assert has_element?(index_live, ~s(#skillset-gem[data-data='#{data}']))
-  #
-  #     data_labels = Enum.map(career_fields, & &1.name_ja) |> Jason.encode!()
-  #     assert has_element?(index_live, ~s(#skillset-gem[data-labels='#{data_labels}']))
-  #
-  #     # 未実装
-  #     # assert index_live |> has_element?("h5", "保有スキル（ジェムをクリック）")
-  #     # assert index_live |> has_element?("li a", "エンジニア")
-  #   end
-  #
-  #   test "shows gem without data", %{conn: conn} do
-  #     {:ok, index_live, _html} = live(conn, ~p"/mypage")
-  #
-  #     data = [[0, 0, 0, 0]] |> Jason.encode!()
-  #     assert has_element?(index_live, ~s(#skillset-gem[data-data='#{data}']))
-  #   end
-  # end
+  # スキルセットジェム確認
+  describe "Skillset gem" do
+    setup [:register_and_log_in_user, :setup_career_fields]
+
+    test "shows gem with data", %{
+      conn: conn,
+      user: user,
+      career_fields: career_fields
+    } do
+      [career_field | _] = career_fields
+      insert(:career_field_score, user: user, career_field: career_field, percentage: 10)
+
+      {:ok, index_live, _html} = live(conn, ~p"/mypage")
+
+      data = [[10, 0, 0, 0]] |> Jason.encode!()
+      assert has_element?(index_live, ~s(#skillset-gem[data-data='#{data}']))
+
+      data_labels = Enum.map(career_fields, & &1.name_ja) |> Jason.encode!()
+      assert has_element?(index_live, ~s(#skillset-gem[data-labels='#{data_labels}']))
+
+      # 未実装
+      # assert index_live |> has_element?("h5", "保有スキル（ジェムをクリック）")
+      # assert index_live |> has_element?("li a", "エンジニア")
+    end
+
+    test "shows gem without data", %{conn: conn} do
+      {:ok, index_live, _html} = live(conn, ~p"/mypage")
+
+      data = [[0, 0, 0, 0]] |> Jason.encode!()
+      assert has_element?(index_live, ~s(#skillset-gem[data-data='#{data}']))
+    end
+  end
 end


### PR DESCRIPTION
## 対応内容

マイページのスキルセットジェム表示に対応しました。
ロジックは先入れしている（#1236）ため、表示対応のPRになります。

- スキルセットジェム上の各リンクは成長パネル側の対応が必要なので非活性です。

## デプロイについて

dev環境：すでに#1236が入って一日経っているのでマージ後に想定のスキルセットジェムが表示される見込みです。
staging/prod環境：先に#1236をデプロイすると最初からスキルセットジェムが表示されます。一緒にデプロイした場合は翌日朝のバッチ処理後に「正しく」表示される想定です（* dev環境で確認後に一度非表示にして、分けてデプロイする場合はそのように対応しますのでお知らせください）


## 参考画面

**PC**

![スクリーンショット 2023-12-11 103234](https://github.com/bright-org/bright/assets/121112529/65631873-760c-4680-91a7-051075b6c66f)

**SP**

![スクリーンショット 2023-12-11 103300](https://github.com/bright-org/bright/assets/121112529/7fac1031-82fd-49d4-91a9-041c27548f3a)
