### PR TITLE
チームID指定時の所属チェックに承認有無の考慮が抜けていたバグの修正

### DIFF
--- a/lib/bright_web/live/team_live/my_team_helper.ex
+++ b/lib/bright_web/live/team_live/my_team_helper.ex
@@ -116,7 +116,7 @@ defmodule BrightWeb.TeamLive.MyTeamHelper do
   defp iam_team_member?(team, user_id) do
     team.member_users
     |> Enum.any?(fn member_user ->
-      member_user.user_id == user_id
+      member_user.user_id == user_id && !is_nil(member_user.invitation_confirmed_at)
     end)
   end
 
@@ -129,7 +129,8 @@ defmodule BrightWeb.TeamLive.MyTeamHelper do
            Teams.is_my_supportee_team_or_supporter_team?(user_id, team.id) do
         team
       else
-        nil
+        # 所属関係による権限がない場合ユーザーには404表示
+        raise(Bright.Exceptions.ForbiddenResourceError)
       end
     rescue
       # 結果が取得できない場合、カスタムグループ判定に移動


### PR DESCRIPTION
[err-16対応](https://docs.google.com/spreadsheets/d/1SWBPuctl3E9-zwT1bhLy1uQgUqG0JoXt2u4Ylf3QVPA/edit#gid=0&range=E19)

ついでに他画面の仕様にあわせて権限のないチームを指定された場合404表示に変更