### PR TITLE
チームスキル分析チーム作成　チーム作成・チーム編集ボタンの背景全体にクリック判定が当たっていないバグ修正

### DIFF
--- a/lib/bright_web/live/team_live/my_team_live.html.heex
+++ b/lib/bright_web/live/team_live/my_team_live.html.heex
@@ -94,20 +94,20 @@
     <!-- スキルセット menu -->
 
     <div class="flex flex-col lg:flex-row gap-4">
-      <a 
-        href="/teams/new"
-        class="text-sm text-center font-bold px-5 py-3 rounded text-white bg-base lg:ml-auto w-full lg:w-44"
-      >
-        チームを作る（β）
-      </a>
+      <.link navigate={~p"/teams/new"}>
+        <button class="text-sm text-center font-bold px-5 py-3 rounded text-white bg-base lg:ml-auto w-full lg:w-44">
+          チームを作る（β）
+        </button>
+      </.link>
 
-      <a 
+      <.link
         :if={Teams.is_admin?(@display_team, @current_user)}
-        href={"/teams/#{@display_team.id}/edit"}
-        class="text-sm text-center font-bold px-5 py-3 rounded text-white bg-base lg:ml-auto w-full lg:w-52"
-      >
-        チームを編集する（β）
-      </a>
+        navigate={~p"/teams/#{@display_team.id}/edit"}
+        >
+        <button class="text-sm text-center font-bold px-5 py-3 rounded text-white bg-base lg:ml-auto w-full lg:w-52">
+          チームを編集する（β）
+        </button>
+      </.link>
       <button
         :if={!is_nil(@display_team) && Teams.is_admin?(@display_team, @current_user)}
         class="text-sm font-bold px-5 py-3 rounded text-white bg-base lg:ml-auto w-full lg:w-56"


### PR DESCRIPTION
[err-18,19対応](https://docs.google.com/spreadsheets/d/1SWBPuctl3E9-zwT1bhLy1uQgUqG0JoXt2u4Ylf3QVPA/edit#gid=0&range=E21:E22)