### PR TITLE
スマホでスキル選択用一覧が見切れてページ送りできない問題対応

### DIFF
--- a/lib/bright/skill_panels.ex
+++ b/lib/bright/skill_panels.ex
@@ -65,7 +65,7 @@ defmodule Bright.SkillPanels do
       order_by: p.updated_at,
       distinct: true
     )
-    |> Repo.paginate(page: page, page_size: 15)
+    |> Repo.paginate(page: page, page_size: 10)
   end
 
   def list_users_skill_panels(user_ids, page \\ 1) do
@@ -77,7 +77,7 @@ defmodule Bright.SkillPanels do
       order_by: s.updated_at,
       distinct: true
     )
-    |> Repo.paginate(page: page, page_size: 15)
+    |> Repo.paginate(page: page, page_size: 10)
   end
 
   @doc """


### PR DESCRIPTION
## 対応内容

障害表：
https://docs.google.com/spreadsheets/d/1vcPuh1D-ae_SekHUqcjpqg37rkqhxK2qF_lAQhKQ0fE/edit#gid=0&range=15:15


スマホで閲覧時に、スキル選択用一覧が見切れてページ送りできないため、表示件数を少なくしました。
（最もストレートな対応ではあります）

ページのスクロールが足りないときに発生します。
一番問題になっているのが成長パネル画面です（常に見切れる）。

**問題になっている現象 / 切れてページ送りが表示されない**

![スクリーンショット 2023-12-14 101902](https://github.com/bright-org/bright/assets/121112529/418d3460-a9ce-48a2-9de9-2046bf889590)



## 参考画像

**表示量を10件にして解消した画像**

![スクリーンショット 2023-12-14 101833](https://github.com/bright-org/bright/assets/121112529/dac5906e-8d62-4c29-bc5f-82295e60a135)

**本件の影響を受けるマイページ 15件から10件の画像(PC)**

個人的にマイページだとスマホで15件流すのは長い気がしたので10件で良さそうですが、PCでは下図のようになります。

![スクリーンショット 2023-12-14 101730](https://github.com/bright-org/bright/assets/121112529/3b727216-5951-4fb3-9c14-227279d794f0)

