### PR TITLE
無料トライアルを薦めるときのTODOを追加

### DIFF
--- a/lib/bright_web/live/subscription_live/create_free_trial_component.ex
+++ b/lib/bright_web/live/subscription_live/create_free_trial_component.ex
@@ -132,6 +132,8 @@ defmodule BrightWeb.SubscriptionLive.CreateFreeTrialComponent do
   def update(%{open: true}, socket), do: {:ok, assign(socket, :open, true)}
 
   def update(assigns, socket) do
+    # TODO: plan_codeではなく厳密にはservice_codeをもとに適切なプランを取ること
+    # `Subscriptions.get_most_priority_free_trial_subscription_plan(service_code)`を用いること
     plan = Subscriptions.get_plan_by_plan_code(assigns.plan_code)
     free_trial = %FreeTrial{}
     changeset = FreeTrial.changeset(free_trial, %{})


### PR DESCRIPTION
## 対応内容

プランについてみていて、無料トライアル時にどのプランを薦めるかの関数が未使用だったので、使用すべき（と思われる）場所にTODOをひとまず記載しました（現状は問題なさそうですが今後のため）。