### PR TITLE
スキルジェム ラベルのフォントサイズ調整

### DIFF
--- a/assets/js/hooks/SkillGem.js
+++ b/assets/js/hooks/SkillGem.js
@@ -6,6 +6,22 @@ const otherColorPattern = ["#D659F0AA", "#7B0D92AA", "#BC14E0AA"];
 const pastColorPattern = ["#FFFFFF55", "#FFFFFF55", "#FFFFFF55"];
 const linkColor = "#0000FF";
 const minValue = -5;
+const gemSizeSet = {
+  // サイズと主な使用箇所
+  // sm: スキル検索(スキルジェム), マイページ(スキルバランス)
+  // sp: スマートホン用途 スキルジェム
+  // md: チームスキル分析
+  "default": {width: "535px", height: "450px"},
+  "sm": {width: "250px", height: "165px"},
+  "sp": {width: "350px", height: "300px"},
+  "md": {width: "450px", height: "400px"}
+}
+const labelFontSet = {
+  "default": {size: 12},
+  "sm": {size: 10},
+  "sp": {size: 12},
+  "md": {size: 12}
+}
 
 const getColorPattern = (length, colors) => {
   const pattern = [];
@@ -146,7 +162,7 @@ const beforeDatasetsDraw = (chart) => {
   }
 };
 
-const createChartFromJSON = (labels, datasets, isLink) => {
+const createChartFromJSON = (labels, datasets, isLink, labelFont) => {
   const color = isLink ? linkColor : "#000000";
   const rightPadding = isLink ? 22 : 0;
   const pointLabelsPadding = isLink ? 25 : 5;
@@ -191,10 +207,13 @@ const createChartFromJSON = (labels, datasets, isLink) => {
             stepSize: 20,
             display: false,
           },
+          // see: https://www.chartjs.org/docs/latest/axes/radial/linear.html#point-label-options
+          // font 指定なしでデフォルト12とあるが画面をみるともっと小さく10あたりにみえる
           pointLabels: {
             color: color,
             backdropPadding: 5,
             padding: pointLabelsPadding,
+            font: labelFont
           },
         },
       },
@@ -209,7 +228,8 @@ export const SkillGem = {
     const dataset = element.dataset;
     const labels = JSON.parse(dataset.labels);
     const data = JSON.parse(dataset.data);
-    const gemSize = this.getGemSize(dataset.size);
+    const gemSize = gemSizeSet[dataset.size] || gemSizeSet["default"]
+    const labelFont = labelFontSet[dataset.size] || labelFontSet["default"]
     const isLink = JSON.parse(dataset.displayLink);
     const datasets = [];
 
@@ -224,27 +244,12 @@ export const SkillGem = {
     this.ctx = document.querySelector("#" + element.id + " canvas");
     window.myRadar[element.id] = new Chart(
       this.ctx,
-      createChartFromJSON(labels, datasets, isLink)
+      createChartFromJSON(labels, datasets, isLink, labelFont)
     );
     window.myRadar[element.id].canvas.parentNode.style.width = gemSize.width;
     window.myRadar[element.id].canvas.parentNode.style.height = gemSize.height;
 
     this.ctx.addEventListener("click", this.clickEvent);
-  },
-  getGemSize(size) {
-    let gemSize = { width: "535px", height: "450px" };
-    switch (size) {
-      case "sm":
-        gemSize = { width: "250px", height: "165px" };
-        break;
-      case "sp":
-        gemSize = { width: "350px", height: "300px" };
-        break;
-      case "md":
-        gemSize = { width: "450px", height: "400px" };
-        break;
-    }
-    return gemSize;
   },
   clickEvent(event) {
     const element = event.target.parentElement;

--- a/lib/bright_web/live/chart_live/skill_gem_component.ex
+++ b/lib/bright_web/live/chart_live/skill_gem_component.ex
@@ -23,7 +23,7 @@ defmodule BrightWeb.ChartLive.SkillGemComponent do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="mx-auto w-full -mt-24 lg:mt-0 lg:w-[450px]">
+    <div class="mx-auto w-full -mt-20 lg:mt-0 lg:w-[450px]">
       <%= if length(@skill_gem_labels) < 3 do %>
         <div class="bg-white w-[450px] h-[360px] flex items-center justify-center">
           <p class="text-start font-bold">データが破損しています</p>


### PR DESCRIPTION
## 対応内容

スキルジェムの一角のラベルが小さいため、依頼を受けて調整しました。

実装は、一律でするとスキル検索結果にでるスキルジェムで大きくなりすぎたのでケース分けしています。

**参考画像**

- 成長パネル画面 変更前

![image](https://github.com/bright-org/bright/assets/121112529/165f29c9-a63e-4170-9c53-39e5cfc54ec5)


- 成長パネル画面 変更後

![image](https://github.com/bright-org/bright/assets/121112529/b0f1e09d-c3d7-4fd2-ab21-ec33390e5040)
（データ違います。対象はフォントサイズだけです）

  - スマホ 変更後
 
![image](https://github.com/bright-org/bright/assets/121112529/a88e821e-6eb2-49a1-bac9-407b599bf570)

- チームスキル分先画面 変更後

![image](https://github.com/bright-org/bright/assets/121112529/8cda1120-bbfc-4277-abcd-7af39fa7fdd5)

