### PR TITLE
無料トライアルを薦めるときのTODOを追加

### DIFF
--- a/lib/bright/subscriptions.ex
+++ b/lib/bright/subscriptions.ex
@@ -478,6 +478,8 @@ defmodule Bright.Subscriptions do
   @doc """
   サービスコードをキーに該当サービスが利用可能な最も優先度の高いサブスクリプションプランを返す
 
+  TODO: 現契約プランと比較してチーム作成数などの制限数が落ちないプランを返すこと（service_code以外の条件考慮が必要）
+
   ## Examples
     iex> get_most_priority_free_trial_subscription_plan("team_up")
     %SubscriptionPlan{}

--- a/lib/bright_web/live/subscription_live/create_free_trial_component.ex
+++ b/lib/bright_web/live/subscription_live/create_free_trial_component.ex
@@ -134,6 +134,7 @@ defmodule BrightWeb.SubscriptionLive.CreateFreeTrialComponent do
   def update(assigns, socket) do
     # TODO: plan_codeではなく厳密にはservice_codeをもとに適切なプランを取ること
     # `Subscriptions.get_most_priority_free_trial_subscription_plan(service_code)`を用いること
+    # 現契約プランと比較してチーム作成数などの制限数が落ちないプランを取ること
     plan = Subscriptions.get_plan_by_plan_code(assigns.plan_code)
     free_trial = %FreeTrial{}
     changeset = FreeTrial.changeset(free_trial, %{})


### PR DESCRIPTION
## 対応内容

チームアップや採用支援のプランのextendedなプランの話を受けて、無料トライアルを薦める処理のTODOを修正しました。
