### PR TITLE
スキルパネル スキル入力画面のドーナツグラフをスキルジェムに変更

### DIFF
--- a/test/bright_web/live/skill_panel_live/skills_test.exs
+++ b/test/bright_web/live/skill_panel_live/skills_test.exs
@@ -524,12 +524,12 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
 
       start_edit(show_live)
 
-      assert has_element?(show_live, "#doughnut_area_in_skills_form", "見習い")
-      assert has_element?(show_live, "#doughnut_area_in_skills_form .score-high-percentage", "0％")
+      assert has_element?(show_live, "#skill_gem_in_skills_form", "見習い")
+      assert has_element?(show_live, "#skill_gem_in_skills_form .score-high-percentage", "0％")
 
       assert has_element?(
                show_live,
-               "#doughnut_area_in_skills_form .score-middle-percentage",
+               "#skill_gem_in_skills_form .score-middle-percentage",
                "0％"
              )
 
@@ -545,19 +545,22 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       |> element(~s{#skill-3-form [phx-window-keydown="shortcut"]})
       |> render_keydown(%{"key" => "2"})
 
-      assert has_element?(show_live, "#doughnut_area_in_skills_form", "ベテラン")
+      assert has_element?(show_live, "#skill_gem_in_skills_form", "ベテラン")
 
       assert has_element?(
                show_live,
-               "#doughnut_area_in_skills_form .score-high-percentage",
+               "#skill_gem_in_skills_form .score-high-percentage",
                "66％"
              )
 
       assert has_element?(
                show_live,
-               "#doughnut_area_in_skills_form .score-middle-percentage",
+               "#skill_gem_in_skills_form .score-middle-percentage",
                "33％"
              )
+
+      data = [[66]] |> Jason.encode!()
+      assert has_element?(show_live, ~s(#skills-form-gem[data-data='#{data}']))
 
       submit_form(show_live)
 
@@ -581,14 +584,17 @@ defmodule BrightWeb.SkillPanelLive.SkillsTest do
       |> element(~s{#skill-3-form [phx-window-keydown="shortcut"]})
       |> render_keydown(%{"key" => "3"})
 
-      assert has_element?(show_live, "#doughnut_area_in_skills_form", "見習い")
-      assert has_element?(show_live, "#doughnut_area_in_skills_form .score-high-percentage", "0％")
+      assert has_element?(show_live, "#skill_gem_in_skills_form", "見習い")
+      assert has_element?(show_live, "#skill_gem_in_skills_form .score-high-percentage", "0％")
 
       assert has_element?(
                show_live,
-               "#doughnut_area_in_skills_form .score-middle-percentage",
+               "#skill_gem_in_skills_form .score-middle-percentage",
                "0％"
              )
+
+      data = [[0]] |> Jason.encode!()
+      assert has_element?(show_live, ~s(#skills-form-gem[data-data='#{data}']))
 
       submit_form(show_live)
 


### PR DESCRIPTION
## 対応内容

スキル入力時に表示されるドーナツグラフをスキルジェムに変更しました。

## 参考画像

iPhone SEレベルの幅だと「ベテラン」などの文字が縦になります。

**PC**

![image](https://github.com/bright-org/bright/assets/121112529/fafdb598-6c91-436c-8ac1-ea329b43ba1f)

**pixel7**

![image](https://github.com/bright-org/bright/assets/121112529/55268d54-aee7-49f6-a9d5-8c5016c6123c)

**iPhone SE**

![image](https://github.com/bright-org/bright/assets/121112529/dadda8b5-5509-4f47-b2be-a074b378cd71)
