### PR TITLE
スキルパネル スキルアップ通知対応 通知表示画面の追加, 通知作成有効化

### DIFF
--- a/lib/bright/notifications.ex
+++ b/lib/bright/notifications.ex
@@ -239,7 +239,8 @@ defmodule Bright.Notifications do
        ) do
     NotificationOperation.new_notifications_query(last_viewed_at) |> Repo.exists?() ||
       NotificationCommunity.new_notifications_query(last_viewed_at) |> Repo.exists?() ||
-      NotificationEvidence.new_notifications_query(user_id, last_viewed_at) |> Repo.exists?()
+      NotificationEvidence.new_notifications_query(user_id, last_viewed_at) |> Repo.exists?() ||
+      NotificationSkillUpdate.new_notifications_query(user_id, last_viewed_at) |> Repo.exists?()
   end
 
   @doc """

--- a/lib/bright_web/live/notification_live/notification_header_component.ex
+++ b/lib/bright_web/live/notification_live/notification_header_component.ex
@@ -86,7 +86,8 @@ defmodule BrightWeb.NotificationLive.NotificationHeaderComponent do
     [
       ["コミュニティ", ~p"/notifications/communities"],
       ["運営", ~p"/notifications/operations"],
-      ["学習メモのヘルプ", ~p"/notifications/evidences"]
+      ["学習メモのヘルプ", ~p"/notifications/evidences"],
+      ["スキルアップ", ~p"/notifications/skill_updates"]
     ]
   end
 

--- a/lib/bright_web/live/notification_live/skill_update.ex
+++ b/lib/bright_web/live/notification_live/skill_update.ex
@@ -1,0 +1,96 @@
+defmodule BrightWeb.NotificationLive.SkillUpdate do
+  use BrightWeb, :live_view
+
+  alias Bright.Notifications
+  alias BrightWeb.CardLive.CardListComponents
+  alias BrightWeb.TabComponents
+
+  @default_page 1
+  @page_per 10
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id="notification_skill_update_container" class="bg-white rounded-md my-1 mb-20 lg:my-20 lg:w-3/5 m-auto p-5">
+      <div class="text-sm font-medium text-center">
+        <li :if={Enum.count(@notifications) == 0} class="flex">
+          <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">
+            スキルアップの通知はありません
+          </div>
+        </li>
+        <%= for notification <- @notifications do %>
+          <li class="flex flex-wrap my-5">
+            <div phx-click="click" phx-value-notification_skill_update_id={notification.id} class="cursor-pointer hover:opacity-70 text-left flex flex-wrap items-center text-base px-1 py-1 flex-1 mr-4 w-full lg:w-auto lg:flex-nowrap">
+              <span class="material-icons text-lg text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center">
+                person
+              </span>
+              <span class={["order-3 lg:order-2 flex-1 mr-2"]}><%= notification.message %></span>
+              <CardListComponents.elapsed_time inserted_at={notification.inserted_at} />
+            </div>
+            <div class="flex gap-x-2 w-full justify-end lg:justify-start lg:w-auto">
+              <button phx-click="click" phx-value-notification_skill_update_id={notification.id} class="hidden hover:opacity-70 font-bold lg:inline-block bg-brightGray-900 text-white min-w-[76px] rounded p-2 text-sm">
+                内容を見る
+              </button>
+            </div>
+          </li>
+        <% end %>
+        <TabComponents.tab_footer id="notification_skill_update_footer" page={@page} total_pages={@total_pages} target={"#notification_skill_update_container"} />
+      </div>
+    </div>
+    """
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    socket
+    |> assign(:page_title, "スキルアップの通知")
+    |> assign_on_page(@default_page)
+    |> then(&{:ok, &1})
+  end
+
+  @impl true
+  def handle_event("previous_button_click", _params, socket) do
+    socket
+    |> assign_on_page(socket.assigns.page - 1)
+    |> then(&{:noreply, &1})
+  end
+
+  def handle_event("next_button_click", _params, socket) do
+    socket
+    |> assign_on_page(socket.assigns.page + 1)
+    |> then(&{:noreply, &1})
+  end
+
+  def handle_event("click", %{"notification_skill_update_id" => id} = _params, socket) do
+    notification = find_notification(socket.assigns.notifications, id)
+
+    socket
+    |> push_navigate(to: notification.url)
+    |> then(&{:noreply, &1})
+  end
+
+  # ---private---
+
+  defp get_notifications(user_id, page, per) do
+    Notifications.list_notification_by_type(
+      user_id,
+      "skill_update",
+      page: page,
+      page_size: per
+    )
+  end
+
+  defp find_notification(notifications, notification_skill_update_id) do
+    Enum.find(notifications, &(&1.id == notification_skill_update_id))
+  end
+
+  defp assign_on_page(socket, page) do
+    %{entries: notifications, total_pages: total_pages} =
+      get_notifications(socket.assigns.current_user.id, page, @page_per)
+
+    socket
+    |> assign(:page, page)
+    |> assign(:total_pages, total_pages)
+    |> assign(:notifications, notifications)
+  end
+end

--- a/lib/bright_web/router.ex
+++ b/lib/bright_web/router.ex
@@ -258,6 +258,7 @@ defmodule BrightWeb.Router do
       live "/notifications/communities", NotificationLive.Community, :index
       live "/notifications/evidences", NotificationLive.Evidence, :index
       live "/notifications/evidences/:skill_evidence_id", NotificationLive.Evidence, :show
+      live "/notifications/skill_updates", NotificationLive.SkillUpdate, :index
 
       live "/recruits/interviews", RecruitInterviewLive.Index, :index
       live "/recruits/interviews/:id", RecruitInterviewLive.Index, :show_interview

--- a/test/bright/notifications_test.exs
+++ b/test/bright/notifications_test.exs
@@ -445,6 +445,20 @@ defmodule Bright.NotificationsTest do
       assert Notifications.has_unread_notification?(to_user)
     end
 
+    test "returns true if the user has unread notification_skill_update" do
+      last_viewed_at = NaiveDateTime.utc_now()
+      [from_user, to_user] = insert_pair(:user)
+      insert(:user_notification, user: to_user, last_viewed_at: NaiveDateTime.utc_now())
+
+      insert(:notification_skill_update,
+        from_user: from_user,
+        to_user: to_user,
+        updated_at: last_viewed_at |> NaiveDateTime.add(1)
+      )
+
+      assert Notifications.has_unread_notification?(to_user)
+    end
+
     test "returns false if the user does not have unread notification" do
       last_viewed_at = NaiveDateTime.utc_now()
       [from_user, to_user] = insert_pair(:user)

--- a/test/bright_web/live/notification_live/notification_header_component_test.exs
+++ b/test/bright_web/live/notification_live/notification_header_component_test.exs
@@ -16,12 +16,14 @@ defmodule BrightWeb.NotificationLive.NotificationHeaderComponentTest do
       refute lv |> has_element?(~s{a[href="/notifications/operations"]})
       refute lv |> has_element?(~s{a[href="/notifications/communities"]})
       refute lv |> has_element?(~s{a[href="/notifications/evidences"]})
+      refute lv |> has_element?(~s{a[href="/notifications/skill_updates"]})
 
       assert lv |> element(~s{button[phx-click="toggle_notifications"]}) |> render_click()
 
       assert lv |> has_element?(~s{a[href="/notifications/operations"]})
       assert lv |> has_element?(~s{a[href="/notifications/communities"]})
       assert lv |> has_element?(~s{a[href="/notifications/evidences"]})
+      assert lv |> has_element?(~s{a[href="/notifications/skill_updates"]})
     end
 
     test "renders notification unread batch when user does not have user_notification", %{

--- a/test/bright_web/live/notification_live/skill_update_test.exs
+++ b/test/bright_web/live/notification_live/skill_update_test.exs
@@ -1,0 +1,123 @@
+defmodule BrightWeb.NotificationLive.SkillUpdateTest do
+  use BrightWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Bright.Factory
+
+  setup [:register_and_log_in_user]
+
+  describe "render page" do
+    test "renders page", %{conn: conn, user: user} do
+      {:ok, _lv, html} = live(conn, ~p"/notifications/skill_updates")
+
+      assert html =~ "スキルアップの通知"
+      assert html =~ "スキルアップの通知はありません"
+
+      insert(:notification_skill_update, to_user: user)
+
+      {:ok, _lv, html} = live(conn, ~p"/notifications/skill_updates")
+
+      refute html =~ "スキルアップの通知はありません"
+    end
+  end
+
+  describe "render paginated notifications" do
+    test "renders paginated notifications", %{conn: conn, user: to_user} do
+      notification_skill_updates =
+        insert_list(11, :notification_skill_update, to_user: to_user)
+        |> Enum.sort_by(& &1.id, :desc)
+
+      {:ok, lv, _html} = live(conn, ~p"/notifications/skill_updates")
+
+      notification_message_10 = notification_skill_updates |> Enum.at(9) |> Map.get(:message)
+      notification_message_11 = notification_skill_updates |> Enum.at(10) |> Map.get(:message)
+
+      assert lv
+             |> has_element?("#notification_skill_update_container span", notification_message_10)
+
+      refute lv
+             |> has_element?("#notification_skill_update_container span", notification_message_11)
+
+      lv |> element(~s{button[phx-click="next_button_click"]}) |> render_click()
+
+      refute lv
+             |> has_element?("#notification_skill_update_container span", notification_message_10)
+
+      assert lv
+             |> has_element?("#notification_skill_update_container span", notification_message_11)
+
+      lv |> element(~s{button[phx-click="previous_button_click"]}) |> render_click()
+
+      assert lv
+             |> has_element?("#notification_skill_update_container span", notification_message_10)
+
+      refute lv
+             |> has_element?("#notification_skill_update_container span", notification_message_11)
+    end
+  end
+
+  describe "notification clicked" do
+    setup do
+      # スキル構造のデータ準備
+      skill_panel = insert(:skill_panel)
+      skill_class = insert(:skill_class, skill_panel: skill_panel, class: 1)
+      %{skill_panel: skill_panel, skill_class: skill_class}
+    end
+
+    setup %{skill_panel: skill_panel, skill_class: skill_class} do
+      # 通知元（スキルアップを達成した）ユーザーのデータ準備
+      user_2 = insert(:user) |> with_user_profile()
+      insert(:user_skill_panel, user: user_2, skill_panel: skill_panel)
+      insert(:skill_class_score, user: user_2, skill_class: skill_class, level: :normal)
+
+      %{user_2: user_2}
+    end
+
+    test "redirects /panels page", %{
+      conn: conn,
+      user: user,
+      user_2: user_2,
+      skill_panel: skill_panel
+    } do
+      insert(
+        :notification_skill_update,
+        to_user: user,
+        from_user: user_2,
+        message: "タイトル",
+        url: "/panels/#{skill_panel.id}/#{user_2.name}"
+      )
+
+      # user/user_2の関係を作っている
+      relate_user_and_supporter(user, user_2)
+
+      {:ok, lv, _html} = live(conn, ~p"/notifications/skill_updates")
+      result = lv |> element(~s{div[phx-click="click"]}, "タイトル") |> render_click()
+
+      assert {:ok, _, _} =
+               follow_redirect(result, conn, "/panels/#{skill_panel.id}/#{user_2.name}")
+    end
+
+    test "raises error if the user is unrelated", %{
+      conn: conn,
+      user: user,
+      user_2: user_2,
+      skill_panel: skill_panel
+    } do
+      # 通知を作っているが、user/user_2の関係を作っていない
+      insert(
+        :notification_skill_update,
+        to_user: user,
+        from_user: user_2,
+        message: "タイトル",
+        url: "/panels/#{skill_panel.id}/#{user_2.name}"
+      )
+
+      {:ok, lv, _html} = live(conn, ~p"/notifications/skill_updates")
+      result = lv |> element(~s{div[phx-click="click"]}, "タイトル") |> render_click()
+
+      assert_raise Bright.Exceptions.ForbiddenResourceError, fn ->
+        follow_redirect(result, conn, "/panels/#{skill_panel.id}/#{user_2.name}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 対応内容

issue close https://github.com/bright-org/bright/issues/1064

仕様概要:
https://docs.google.com/spreadsheets/d/1xPdvZboKtIHwZv6EizZyIZkH_XKMvLRo95SU35zp994/edit#gid=319780291

前提PR: #1266 （画面以外のスキーマ追加などのPR、マージ済み）

スキルアップ通知画面の追加と、通知が作成される処理を有効化しています。


## 参考画像

**通知アイコン下のメニュー**

- 「スキルアップ」を追加

![スクリーンショット 2023-12-26 085523](https://github.com/bright-org/bright/assets/121112529/79b9820d-7eba-4dfa-8ced-fc9cf2face5a)

**スキルアップの通知画面**

- メッセージフォーマット
  - <users.name>が<スキルパネル名> <スキルクラス名>のスキルを取得し「<平均 or ベテラン>」レベルになりました！
- 各行をクリックする or 「内容を見る」をクリックすると、該当スキルパネル画面に遷移します。

![image](https://github.com/bright-org/bright/assets/121112529/741b866f-5993-4968-971c-2917b2f26fc1)

