### PR TITLE
バッチ スキルパネル更新処理 insert_allのchunkサイズ調整

### DIFF
--- a/lib/bright/batches/update_skill_panels.ex
+++ b/lib/bright/batches/update_skill_panels.ex
@@ -37,8 +37,10 @@ defmodule Bright.Batches.UpdateSkillPanels do
   alias Bright.SkillExams.SkillExam
   alias Bright.SkillReferences.SkillReference
 
-  # postgresql limit of parameters
-  @max_insert_size 65_535
+  # max_insert_size:
+  #   Postgresql の最大パラメータ(65_535)を考慮したサイズ
+  #   2_000件として1レコードに30カラム程度を許容している
+  @max_insert_size 2_000
 
   def call(locked_date, dry_run \\ false) do
     skill_panels = Repo.all(SkillPanel)


### PR DESCRIPTION
## 対応内容

PR #1269 で設定した個数はレコードに含まれるカラム数を考慮していなかったので対応しました。
余裕を持たせて2000件にしています。

（もらったダンプで手元でバッチ処理は動きました）