### PR TITLE
スキルアップ通知 通知メッセージ、ボタン文言の変更

### DIFF
--- a/lib/bright/skill_evidences.ex
+++ b/lib/bright/skill_evidences.ex
@@ -246,7 +246,7 @@ defmodule Bright.SkillEvidences do
 
     base_attrs = %{
       from_user_id: user.id,
-      message: "#{user.name}から「#{skill_breadcrumb}」のヘルプが届きました",
+      message: "#{user.name}さんから「#{skill_breadcrumb}」のヘルプが届きました",
       url: "/notifications/evidences/#{skill_evidence.id}",
       inserted_at: timestamp,
       updated_at: timestamp
@@ -272,7 +272,7 @@ defmodule Bright.SkillEvidences do
     Notifications.create_notification("evidence", %{
       from_user_id: user.id,
       to_user_id: skill_evidence.user_id,
-      message: "#{user.name}から「#{skill_breadcrumb}」にメッセージが届きました",
+      message: "#{user.name}さんから「#{skill_breadcrumb}」にメッセージが届きました",
       url: "/notifications/evidences/#{skill_evidence.id}"
     })
   end

--- a/lib/bright/skill_scores.ex
+++ b/lib/bright/skill_scores.ex
@@ -206,7 +206,7 @@ defmodule Bright.SkillScores do
     base_attrs = %{
       from_user_id: user.id,
       message:
-        "#{user.name}が#{skill_panel.name} #{skill_class.name}のスキルを習得し「#{Gettext.gettext(BrightWeb.Gettext, "level_#{level}")}」レベルになりました！",
+        "#{user.name}さんが#{skill_panel.name}【#{skill_class.name}】で「#{Gettext.gettext(BrightWeb.Gettext, "level_#{level}")}」レベルになりました",
       url: "/panels/#{skill_panel.id}/#{user.name}?class=#{skill_class.class}",
       inserted_at: timestamp,
       updated_at: timestamp

--- a/lib/bright_web/live/notification_live/skill_update.ex
+++ b/lib/bright_web/live/notification_live/skill_update.ex
@@ -29,7 +29,7 @@ defmodule BrightWeb.NotificationLive.SkillUpdate do
             </div>
             <div class="flex gap-x-2 w-full justify-end lg:justify-start lg:w-auto">
               <button phx-click="click" phx-value-notification_skill_update_id={notification.id} class="hidden hover:opacity-70 font-bold lg:inline-block bg-brightGray-900 text-white min-w-[76px] rounded p-2 text-sm">
-                内容を見る
+                詳細を見る
               </button>
             </div>
           </li>

--- a/test/bright/skill_evidences_test.exs
+++ b/test/bright/skill_evidences_test.exs
@@ -257,14 +257,14 @@ defmodule Bright.SkillEvidencesTest do
                NotificationEvidence,
                from_user_id: user.id,
                to_user_id: user_2.id,
-               message: "#{user.name}から「#{breadcrumb}」のヘルプが届きました"
+               message: "#{user.name}さんから「#{breadcrumb}」のヘルプが届きました"
              )
 
       assert Repo.get_by(
                NotificationEvidence,
                from_user_id: user.id,
                to_user_id: user_3.id,
-               message: "#{user.name}から「#{breadcrumb}」のヘルプが届きました"
+               message: "#{user.name}さんから「#{breadcrumb}」のヘルプが届きました"
              )
 
       # チーム外ユーザーへ作成されていない確認
@@ -350,7 +350,7 @@ defmodule Bright.SkillEvidencesTest do
 
       assert notification.from_user_id == user_2.id
       assert notification.to_user_id == user.id
-      assert notification.message == "#{user_2.name}から「#{breadcrumb}」にメッセージが届きました"
+      assert notification.message == "#{user_2.name}さんから「#{breadcrumb}」にメッセージが届きました"
     end
   end
 

--- a/test/bright/skill_scores_test.exs
+++ b/test/bright/skill_scores_test.exs
@@ -147,7 +147,7 @@ defmodule Bright.SkillScoresTest do
           page_size: 1
         })
 
-      assert notification.message == "HogeがElixir基本 零細Web開発のスキルを習得し「平均」レベルになりました！"
+      assert notification.message == "HogeさんがElixir基本【零細Web開発】で「平均」レベルになりました"
       assert notification.url == "/panels/#{skill_panel.id}/#{user.name}?class=1"
     end
 


### PR DESCRIPTION
## 対応内容

2023/12/27 MTGより、

メッセージ変更：
○○さんがスキルパネル名【クラス名】で「平均」レベルになりました

ボタン文言変更：
「内容を見る」→「詳細を見る」ボタンに変更

に対応しました。背景として、既存ユーザーに関してスキルアップ通知がスキル習得率が上がった場合も下がった場合も作成されるので、違和感のないものにしています。


## 参考画像

上２つが変更後の通知です。

![image](https://github.com/bright-org/bright/assets/121112529/4426b4b0-431b-40d7-85ba-3ff06e7c6e4c)

