### PR TITLE
スキルパネル取得時にスキルクラススコアを作成する対応

### DIFF
--- a/lib/bright/skill_panels.ex
+++ b/lib/bright/skill_panels.ex
@@ -214,6 +214,14 @@ defmodule Bright.SkillPanels do
     Repo.all(query)
   end
 
+  def list_skill_classes_by_skill_panel_id(skill_panel_id) do
+    from(
+      sc in SkillClass,
+      where: sc.skill_panel_id == ^skill_panel_id
+    )
+    |> list_skill_classes()
+  end
+
   def get_skill_class!(id), do: Repo.get!(SkillClass, id)
 
   def get_skill_class_by(condition) do

--- a/lib/bright/user_skill_panels/user_skill_panel.ex
+++ b/lib/bright/user_skill_panels/user_skill_panel.ex
@@ -22,5 +22,6 @@ defmodule Bright.UserSkillPanels.UserSkillPanel do
     user_skill_panel
     |> cast(attrs, [:user_id, :skill_panel_id])
     |> validate_required([:user_id, :skill_panel_id])
+    |> unique_constraint([:user_id, :skill_panel_id])
   end
 end

--- a/lib/bright_web/live/onboarding_live/skill_panel.ex
+++ b/lib/bright_web/live/onboarding_live/skill_panel.ex
@@ -132,15 +132,11 @@ defmodule BrightWeb.OnboardingLive.SkillPanel do
   end
 
   defp select_skill_panel(user_id, skill_panel_id) do
-    # 一度取得したスキルパネルを再度選択してもエラーにしないためにUnique indexの例外を握りつぶす
-    try do
-      UserSkillPanels.create_user_skill_panel(%{
-        user_id: user_id,
-        skill_panel_id: skill_panel_id
-      })
-    rescue
-      Ecto.ConstraintError -> :ok
-    end
+    # 一度取得したスキルパネルを再度選択した際に作成自体が行われないが問題ないため、処理を入れていない。
+    UserSkillPanels.create_user_skill_panel(%{
+      user_id: user_id,
+      skill_panel_id: skill_panel_id
+    })
   end
 
   defp finish_onboarding(nil, user_id, skill_panel_id) do

--- a/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_helper.ex
@@ -110,6 +110,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelHelper do
         %{assigns: %{me: true, skill_class_score: nil}} = socket
       ) do
     # 始めてスキルクラスにアクセスした際にスキルクラススコアを生成
+    # NOTE: 現在はスキルパネル取得時に全クラスのスキルクラススコアを生成している。本処理は後方互換性のために残している。
     user = socket.assigns.current_user
     skill_class = socket.assigns.skill_class
 

--- a/test/bright/skill_panels_test.exs
+++ b/test/bright/skill_panels_test.exs
@@ -196,5 +196,20 @@ defmodule Bright.SkillPanelsTest do
       assert SkillPanels.list_skill_classes()
              |> Bright.Repo.preload(:skill_panel) == [skill_class]
     end
+
+    test "list_skill_classes_by_skill_panel_id/1 returns skill_classs belongs to skill_panel" do
+      skill_panel_1 = insert(:skill_panel)
+      skill_panel_2 = insert(:skill_panel)
+      skill_class_1_1 = insert(:skill_class, skill_panel: skill_panel_1, class: 1)
+      skill_class_1_2 = insert(:skill_class, skill_panel: skill_panel_1, class: 2)
+      skill_class_2_1 = insert(:skill_class, skill_panel: skill_panel_2, class: 1)
+
+      assert SkillPanels.list_skill_classes_by_skill_panel_id(skill_panel_1.id)
+             |> Bright.Repo.preload(:skill_panel)
+             |> Enum.sort_by(& &1.id) == [skill_class_1_1, skill_class_1_2]
+
+      assert SkillPanels.list_skill_classes_by_skill_panel_id(skill_panel_2.id)
+             |> Bright.Repo.preload(:skill_panel) == [skill_class_2_1]
+    end
   end
 end


### PR DESCRIPTION
## 対応内容

issue close #1273 

スキルクラススコアを保持するテーブルレコードを、これまでは各スキルクラスタブをクリックしたときに初めて作成していましたが、スキルパネル取得時にクラス１～３全て作成するように変更しました。

特に画面変更はありません。

スキルクラス開放判定をなくしたあとに下記課題があったのでその対応になります。

- マイページのスキルパネル一覧などに常にクラス1-3を表示しておきたい
- スキルクラスタブをクリックしないと（他の取得済みスキルパネルで習得したスキルがあっても）0%のままで表示される

なお、既にスキルパネル取得済みユーザーについては特別対応をしないということになったので、今の処理はNOTE記載してそのまま残しています。
