### PR TITLE
メガメニュー チーム横スクロールが表示されない現象対応のため幅指定

### DIFF
--- a/assets/js/hooks/TabSlideScroll.js
+++ b/assets/js/hooks/TabSlideScroll.js
@@ -21,7 +21,7 @@ const setElementMargin = function(element, property, value) {
 
 const setButtonsDisplay = function(scrollerEl, thisEl, itemsSumWidth) {
   // 表示幅からスクロール操作ボタンを出すかを決定
-  const width = getElWidth(thisEl)
+  const width = getWidth(thisEl)
 
   if (itemsSumWidth > width) {
     scrollerEl.style.display = "flex"
@@ -30,24 +30,18 @@ const setButtonsDisplay = function(scrollerEl, thisEl, itemsSumWidth) {
   }
 }
 
-// 引数elの要素幅を取得する。autoなどの場合は親要素にさかのぼる
-const getElWidth = function(el) {
+const getWidth = function(el) {
   let width = 0
 
-  // 幅取得できたときか、全要素を遡ったら終了する
-  while(width == 0 && el != null) {
-    width_value = el.clientWidth
-    width_style = window.getComputedStyle(el).width
-
-    if(width_value != 0) {
-      width = width_value
-    } else if(typeof width_style === 'string' && width_style.endsWith('px')) {
-      width = parseInt(width_style)
-    }
-
-    el = el.parentElement
+  // 要素にスタイルとして設定されている値を取得
+  // `clientWidth`は表示状況によって取得できないケースがあったため本対応としている
+  const width_style = window.getComputedStyle(el).width
+  if(typeof width_style === 'string' && width_style.endsWith('px')) {
+    width = parseInt(width_style)
   }
-  return width
+
+  // 設定されていない場合（SP）は全体幅で扱う
+  return (width != 0) ? width : document.body.clientWidth
 }
 
 const TabSlideScroll = {

--- a/lib/bright_web/live/card_live/related_recruit_user_card_component.ex
+++ b/lib/bright_web/live/card_live/related_recruit_user_card_component.ex
@@ -1,6 +1,6 @@
 defmodule BrightWeb.CardLive.RelatedRecruitUserCardComponent do
   @moduledoc """
-  Related Users Card Components
+  Related Recruit Users Card Components
   """
   use BrightWeb, :live_component
   import BrightWeb.ProfileComponents
@@ -201,7 +201,7 @@ defmodule BrightWeb.CardLive.RelatedRecruitUserCardComponent do
 
   defp inner_tab(assigns) do
     ~H"""
-    <div id={@id} class="flex border-b border-brightGray-50" phx-hook="TabSlideScroll">
+    <div id={@id} class="flex border-b border-brightGray-50 lg:w-[750px]" phx-hook="TabSlideScroll">
       <div class="overflow-hidden">
         <ul class="inner_tab_list overflow-hidden flex text-base !text-sm w-[99999px]">
           <%= for {key, value} <- @inner_tab do %>

--- a/lib/bright_web/live/card_live/related_user_card_component.ex
+++ b/lib/bright_web/live/card_live/related_user_card_component.ex
@@ -218,7 +218,7 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
 
   defp inner_tab(assigns) do
     ~H"""
-    <div id={"#{@id}-#{@selected_tab}"} class="flex border-b border-brightGray-50" phx-hook="TabSlideScroll">
+    <div id={"#{@id}-#{@selected_tab}"} class="flex border-b border-brightGray-50 lg:w-[750px]" phx-hook="TabSlideScroll">
       <div class="overflow-hidden">
         <ul class="inner_tab_list overflow-hidden flex text-base !text-sm w-[99999px]">
           <%= for {key, value} <- @inner_tab do %>


### PR DESCRIPTION
## 対応内容

不具合修正：
https://docs.google.com/spreadsheets/d/1a4P6ojk6Pn1_FecGAtmOFjRgtnKAaY4qLZT1FCE4XO0/edit#gid=0&range=11:11

状況によって、メガメニューの横スクロールが表示されないケース（厳密にはわからず）が発見されたので、その対応になります。手元で再現したケースは解消しました。

幅を明示してしまうことでロジカルな取得をやめています。
