### PR TITLE
チームスキル分析 クラスタブのcursor-pointer化

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -282,7 +282,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
           <% current = @select_skill_class.class == skill_class.class %>
           <%= if @select_skill_class.class == skill_class.class do %>
             <li
-              class={"bg-white text-base w-full"}
+              class={"bg-white text-base w-full cursor-pointer"}
               phx-click="skill_class_tab_click"
               phx-target={@skill_class_tab_click_target}
               phx-value-user_id={@user.id}
@@ -301,7 +301,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
           <% else %>
 
             <li
-              class={"w-full bg-brightGreen-50 text-brightGray-500"}
+              class={"w-full bg-brightGreen-50 text-brightGray-500 cursor-pointer"}
               phx-click="skill_class_tab_click"
               phx-target={@skill_class_tab_click_target}
               phx-value-user_id={@user.id}


### PR DESCRIPTION
## 対応内容

チームスキル分析画面のクラス切り替え部分のマウスカーソルがクリック可能な形で見えなかったので対応しました。

## 参考画像

![image](https://github.com/bright-org/bright/assets/121112529/6bbca65b-6c84-4687-afd0-9b998590b98c)
