### PR TITLE
管理画面 2FA 一覧の横並びを縦並びに変更

### DIFF
--- a/lib/bright_web/live/admin/user_token_live/index.html.heex
+++ b/lib/bright_web/live/admin/user_token_live/index.html.heex
@@ -46,11 +46,11 @@
     <th>email</th>
     <th>code</th>
   </tr>
-  <tr>
-    <%= for code <- @user_2fa_codes do %>
+  <%= for code <- @user_2fa_codes do %>
+    <tr>
       <td><%= code.sent_to %></td>
       <td><%= code.code %></td>
-    <% end %>
-  </tr>
+    </tr>
+  <% end %>
 </table>
 


### PR DESCRIPTION
## 対応内容

管理画面のログインなどの2段階認証がでるところが横長で見にくかったので、縦にしました。
3つある項目で2FAだけ横並びになっていました。

不都合あればcloseをお願いします。


## 参考画面

（テスト用ではないメールアドレスが2つあったので消しています、一応です）

![image](https://github.com/bright-org/bright/assets/121112529/be930d14-de25-4ab1-a193-bd6f29e5054f)
