### PR TITLE
 関わっているチーム SPで表示崩れしている現象対応

### DIFF
--- a/lib/bright_web/live/card_live/related_team_card_component.ex
+++ b/lib/bright_web/live/card_live/related_team_card_component.ex
@@ -65,46 +65,52 @@ defmodule BrightWeb.CardLive.RelatedTeamCardComponent do
             </ul>
           <% else %>
             <% # 表示内容がないときの表示 %>
-            <ul class="flex gap-y-2 flex-col">
-              <li :if={@card.selected_tab == "joined_teams"} class="flex items-center text-base p-1 rounded">
-                <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">所属しているチームはありません</div>
-                <a
-                   href="/teams/new"
-                   class="text-sm font-bold px-5 py-3 rounded text-white bg-base"
-                 >
-                  チームを作る（β）
-                 </a>
+            <ul>
+              <li :if={@card.selected_tab == "joined_teams"} class="text-base text-left p-1">
+                <div class="text-base">所属しているチームはありません</div>
+                <p class="my-4">
+                  <a
+                     href="/teams/new"
+                     class="text-sm font-bold px-5 py-3 rounded text-white bg-base"
+                   >
+                    チームを作る（β）
+                   </a>
+                 </p>
               </li>
 
-              <li :if={@card.selected_tab == "custom_groups"} class="flex items-center text-base p-1 rounded">
-                <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">カスタムグループはありません</div>
-                <a
-                   href="/panels"
-                   class="hidden lg:inline text-sm font-bold px-5 py-3 rounded text-white bg-base"
-                 >
-                   カスタムグループを作る
-                 </a>
+              <li :if={@card.selected_tab == "custom_groups"} class="text-base text-left p-1">
+                <div class="text-base">カスタムグループはありません</div>
+                <p class="my-4">
+                  <a
+                     href="/panels"
+                     class="hidden lg:inline text-sm font-bold px-5 py-3 rounded text-white bg-base"
+                   >
+                     カスタムグループを作る
+                   </a>
+                 </p>
               </li>
 
               <% # TODO ↓α版対応 %>
-              <li :if={@card.selected_tab == "supporter_teams"} class="flex items-center text-base p-1 rounded">
-                <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">支援を受けている採用・育成チームはありません</div>
-                <a class="text-sm font-bold px-5 py-3 rounded text-white bg-brightGray-200">
-                  採用・育成チームに支援してもらう（β）
-                </a>
+              <li :if={@card.selected_tab == "supporter_teams"} class="text-base text-left p-1">
+                <div class="text-base">支援を受けている採用・育成チームはありません</div>
+                <p class="my-4">
+                  <a class="text-sm font-bold px-3 py-3 rounded text-white bg-brightGray-200">
+                    採用・育成チームに支援してもらう（β）
+                  </a>
+                </p>
+                <p class="text-sm">βリリースで利用可能になります</p>
               </li>
-              <p :if={@card.selected_tab == "supporter_teams"}>
-                βリリース（11月予定）で利用可能になります
-              </p>
 
-              <li :if={@card.selected_tab == "supportee_teams"} class="flex items-center text-base p-1 rounded">
-                <div class="text-left flex items-center text-base px-1 py-1 flex-1 mr-2">支援中の採用・育成先チームはありません</div>
-                <a href="https://bright-fun.org/plan" class="w-[calc(45%-6px)] lg:w-56" rel="noopener noreferrer" target="_blank">
-                  <button type="button" class="text-white bg-planUpgrade-600 px-1 inline-flex justify-center rounded-md text-xs items-center font-bold h-9 w-full hover:opacity-70 lg:px-2 lg:text-sm">
-                    <span class="bg-white material-icons mr-1 !text-sm !text-planUpgrade-600 rounded-full h-5 w-5 !font-bold material-icons-outlined lg:mr-2 lg:h-6 lg:w-6">upgrade</span>
-                    アップグレード
-                  </button>
-                </a>
+              <li :if={@card.selected_tab == "supportee_teams"} class="text-base text-left p-1">
+                <div class="text-base">支援中の採用・育成先チームはありません</div>
+                <p class="my-4">
+                  <a href="https://bright-fun.org/plan" class="w-[calc(45%-6px)] lg:w-56" rel="noopener noreferrer" target="_blank">
+                    <button type="button" class="text-white bg-planUpgrade-600 px-1 inline-flex justify-center rounded-md text-xs items-center font-bold h-9 w-full hover:opacity-70 lg:px-2 lg:text-sm">
+                      <span class="bg-white material-icons mr-1 !text-sm !text-planUpgrade-600 rounded-full h-5 w-5 !font-bold material-icons-outlined lg:mr-2 lg:h-6 lg:w-6">upgrade</span>
+                      アップグレード
+                    </button>
+                  </a>
+                </p>
               </li>
             </ul>
           <% end %>


### PR DESCRIPTION
## 対応内容

障害表：
https://docs.google.com/spreadsheets/d/1qag1sy_C9_kcTrwxMmPCRzlsObULDAvLyzwaNp4EhjI/edit#gid=0&range=12:12

スマートホン表示でボタンを横並びにしていると圧迫するので縦並びにして解消しました。

## 参考画像

以下、採用育成チームのタブのみですが各タブ共通で、文言とボタンを縦置きにしています。

**修正前**

![スクリーンショット 2024-01-10 092137](https://github.com/bright-org/bright/assets/121112529/24e1bc31-19c0-4a93-b955-2cbc42aeca61)

![スクリーンショット 2024-01-10 092113](https://github.com/bright-org/bright/assets/121112529/0a8af946-2104-4648-a3de-53c7c1005a1a)


**修正後**

![image](https://github.com/bright-org/bright/assets/121112529/5ecab2f5-f8fd-4c08-b0f6-b8009c54a272)

![image](https://github.com/bright-org/bright/assets/121112529/9a471f72-81e9-44c3-b4e0-b4c598aa2f74)
