### PR TITLE
無料トライアルのモーダル(面談調整版)のチーム画面側利用のための改修

### DIFF
--- a/lib/bright_web/components/layouts/app.html.heex
+++ b/lib/bright_web/components/layouts/app.html.heex
@@ -37,6 +37,5 @@
   id="free_trial_modal_from_search"
   module={BrightWeb.SubscriptionLive.CreateFreeTrialFromSearchComponent}
   current_user={@current_user}
-  plan_code={"hr_plan"}
   :if={@current_user}
 />

--- a/lib/bright_web/live/mypage_live/index.html.heex
+++ b/lib/bright_web/live/mypage_live/index.html.heex
@@ -89,13 +89,13 @@
   on_cancel={JS.patch(~p"/mypage")}
   show
 >
-<.live_component
-  id="free_trial_modal"
-  module={BrightWeb.SubscriptionLive.CreateFreeTrialComponent}
-  current_user={@current_user}
-  plan_code={@plan}
-  patch={~p"/mypage"}
-/>
+  <.live_component
+    id="free_trial_modal"
+    module={BrightWeb.SubscriptionLive.CreateFreeTrialComponent}
+    current_user={@current_user}
+    plan_code={@plan}
+    patch={~p"/mypage"}
+  />
 </.bright_modal>
 
 

--- a/lib/bright_web/live/search_live/search_result_component.ex
+++ b/lib/bright_web/live/search_live/search_result_component.ex
@@ -157,7 +157,25 @@ defmodule BrightWeb.SearchLive.SearchResultComponent do
 
     send_update(BrightWeb.SubscriptionLive.CreateFreeTrialFromSearchComponent,
       id: "free_trial_modal_from_search",
-      open: true
+      open: true,
+      service_code: "hr_basic",
+      on_submit: fn _ ->
+        send_update(BrightWeb.SearchLive.SearchResultsComponent,
+          id: "user_search_result",
+          hr_enabled: true
+        )
+
+        send_update(BrightWeb.SearchLive.SkillSearchComponent,
+          id: "skill_search_modal",
+          click_away_disable: false
+        )
+      end,
+      on_close: fn ->
+        send_update(BrightWeb.SearchLive.SkillSearchComponent,
+          id: "skill_search_modal",
+          click_away_disable: false
+        )
+      end
     )
 
     {:noreply, socket}

--- a/lib/bright_web/live/subscription_live/create_free_trial_from_search_component.ex
+++ b/lib/bright_web/live/subscription_live/create_free_trial_from_search_component.ex
@@ -11,7 +11,7 @@ defmodule BrightWeb.SubscriptionLive.CreateFreeTrialFromSearchComponent do
     ~H"""
     <div>
       <main
-        id="free_trial_modal"
+        id={@id}
         class={"flex h-screen items-center justify-center p-10 w-screen #{if !@open, do: "hidden"}"}
         :if={@plan}
       >
@@ -125,23 +125,32 @@ defmodule BrightWeb.SubscriptionLive.CreateFreeTrialFromSearchComponent do
 
   @impl true
   def mount(socket) do
-    {:ok, assign(socket, :plan, nil)}
+    {:ok,
+     socket
+     |> assign(:plan, nil)
+     |> assign(on_submit: nil, on_close: nil)}
   end
 
   @impl true
-  def update(%{open: true}, socket), do: {:ok, assign(socket, :open, true)}
+  def update(%{open: true, service_code: service_code} = assigns, socket) do
+    # モーダルを開く際にどの無料トライアルプランが対象かを決定する
+    # TODO: plan取得とfree_trial可能かどうかは別途判定が必要
+    user = socket.assigns.current_user
+    plan = get_plan_by_service(user, service_code)
+
+    {:ok,
+     socket
+     |> assign(:plan, plan)
+     |> assign(Map.take(assigns, ~w(on_submit on_close)a))
+     |> assign(:open, true)}
+  end
 
   def update(assigns, socket) do
-    # TODO: plan_codeではなく厳密にはservice_codeをもとに適切なプランを取ること
-    # `Subscriptions.get_most_priority_free_trial_subscription_plan(service_code)`を用いること
-    # 現契約プランと比較してチーム作成数などの制限数が落ちないプランを取ること
-    plan = Subscriptions.get_plan_by_plan_code(assigns.plan_code)
     free_trial = %FreeTrial{}
     changeset = FreeTrial.changeset(free_trial, %{})
 
     socket
     |> assign(assigns)
-    |> assign(:plan, plan)
     |> assign(:changeset, changeset)
     |> assign(:free_trial, free_trial)
     |> assign(:open, false)
@@ -150,7 +159,7 @@ defmodule BrightWeb.SubscriptionLive.CreateFreeTrialFromSearchComponent do
   end
 
   @impl true
-  def handle_event("validate", %{"free_trial_form_from_search" => params}, socket) do
+  def handle_event("validate", %{"free_trial_form" => params}, socket) do
     changeset =
       socket.assigns.free_trial
       |> FreeTrial.changeset(params)
@@ -171,28 +180,18 @@ defmodule BrightWeb.SubscriptionLive.CreateFreeTrialFromSearchComponent do
     {:noreply, assign_form(socket, changeset)}
   end
 
-  def handle_event(
-        "submit",
-        %{"free_trial_form_from_search" => params},
-        %{assigns: %{plan: plan, current_user: user}} = socket
-      ) do
+  def handle_event("submit", %{"free_trial_form" => params}, socket) do
+    %{plan: plan, current_user: user, on_submit: on_submit} = socket.assigns
+
     case Subscriptions.start_free_trial(user.id, plan.id) do
-      {:ok, _subscription_user_plan} ->
+      {:ok, subscription_user_plan} ->
         params = Map.merge(params, %{"user_id" => user.id, "plan_name" => plan.name_jp})
         Subscriptions.deliver_free_trial_apply_instructions(user, params)
-
-        send_update(BrightWeb.SearchLive.SearchResultsComponent,
-          id: "user_search_result",
-          hr_enabled: true
-        )
-
-        send_update(BrightWeb.SearchLive.SkillSearchComponent,
-          id: "skill_search_modal",
-          click_away_disable: false
-        )
+        on_submit && on_submit.(subscription_user_plan)
 
         socket
         |> assign(:open, false)
+        |> assign(:plan, nil)
         |> then(&{:noreply, &1})
 
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -201,15 +200,25 @@ defmodule BrightWeb.SubscriptionLive.CreateFreeTrialFromSearchComponent do
   end
 
   def handle_event("close", _params, socket) do
-    send_update(BrightWeb.SearchLive.SkillSearchComponent,
-      id: "skill_search_modal",
-      click_away_disable: false
-    )
+    on_close = socket.assigns.on_close
+    on_close && on_close.()
 
     {:noreply, assign(socket, :open, false)}
   end
 
   defp assign_form(socket, %Ecto.Changeset{} = changeset) do
     assign(socket, :form, to_form(changeset))
+  end
+
+  defp get_plan_by_service(user, service_code) do
+    current_user_plan =
+      Subscriptions.get_users_subscription_status(user.id, NaiveDateTime.utc_now())
+
+    current_plan = current_user_plan && current_user_plan.subscription_plan
+
+    Subscriptions.get_most_priority_free_trial_subscription_plan_by_service(
+      service_code,
+      current_plan
+    )
   end
 end

--- a/test/bright_web/live/subscription_live/create_free_trial_from_search_component_test.exs
+++ b/test/bright_web/live/subscription_live/create_free_trial_from_search_component_test.exs
@@ -1,0 +1,127 @@
+defmodule BrightWeb.SubscriptionLive.CreateFreeTrialFromSearchComponentTest do
+  use BrightWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Bright.Factory
+
+  def submit_trial_form(live) do
+    params = %{
+      free_trial_form: %{
+        company_name: "dummy",
+        phone_number: "0000000000",
+        email: "test@example.com",
+        pic_name: "dummy"
+      }
+    }
+
+    live
+    |> form("#free_trial_form_from_search", params)
+    |> render_change()
+
+    live
+    |> form("#free_trial_form_from_search", params)
+    |> render_submit()
+  end
+
+  # 「スキル検索」からの表示確認
+  describe "shows on search_result page" do
+    setup [:register_and_log_in_user]
+
+    # データ準備: プラン
+    setup do
+      subscription_plan =
+        insert(:subscription_plans, plan_code: "hr_plan")
+        |> plan_with_plan_service_by_service_code("hr_basic")
+
+      %{subscription_plan: subscription_plan}
+    end
+
+    # データ準備: スキル
+    setup do
+      skill_panel = insert(:skill_panel)
+      skill_class = insert(:skill_class, skill_panel: skill_panel, class: 1)
+      skill_unit = insert(:skill_unit)
+      insert(:skill_class_unit, skill_class: skill_class, skill_unit: skill_unit)
+      [%{skills: [skill]}] = insert_skill_categories_and_skills(skill_unit, [1])
+
+      career_field = insert(:career_field)
+      job = insert(:job)
+      insert(:career_field_job, career_field: career_field, job: job)
+      insert(:job_skill_panel, job: job, skill_panel: skill_panel)
+
+      %{
+        skill_panel: skill_panel,
+        skill_class: skill_class,
+        skill: skill,
+        career_field: career_field
+      }
+    end
+
+    # データ準備: スキル保有者
+    setup %{skill_class: skill_class, skill: skill} do
+      user = insert(:user) |> insert_user_relations()
+      insert(:skill_class_score, user: user, skill_class: skill_class)
+      insert(:skill_score, user: user, skill: skill)
+      :ok
+    end
+
+    # スキル検索フォームのサブミット
+    def submit_search_form(live, career_field, skill_panel) do
+      live
+      |> form("#user_search_form",
+        user_search: %{
+          skills: %{0 => %{career_field: career_field.name_en}}
+        }
+      )
+      |> render_change(%{_target: ["user_search", "skills", "0", "career_field"]})
+
+      live
+      |> form("#user_search_form",
+        user_search: %{
+          skills: %{0 => %{skill_panel: skill_panel.id}}
+        }
+      )
+      |> render_change(%{_target: ["user_search", "skills", "0", "skill_panel"]})
+
+      live
+      |> form("#user_search_form",
+        user_search: %{
+          skills: %{
+            0 => %{
+              career_field: career_field.name_en,
+              skill_panel: skill_panel.id
+            }
+          }
+        }
+      )
+      |> render_submit()
+    end
+
+    test "open modal and recommend hr plan", %{
+      conn: conn,
+      career_field: career_field,
+      skill_panel: skill_panel,
+      subscription_plan: subscription_plan
+    } do
+      {:ok, live, _html} = live(conn, ~p"/mypage")
+      submit_search_form(live, career_field, skill_panel)
+
+      live
+      |> element("a", "面談調整")
+      |> render_click()
+
+      assert live
+             |> element("#free_trial_modal_from_search")
+             |> render() =~ subscription_plan.name_jp
+
+      submit_trial_form(live)
+
+      # 申し込み後に改めてクリックした場合は無料トライアルモーダルは開かれない
+      live
+      |> element("a", "面談調整")
+      |> render_click()
+
+      refute has_element?(live, "#free_trial_modal_from_search")
+    end
+  end
+end

--- a/test/bright_web/live/subscription_live/create_free_trial_test.exs
+++ b/test/bright_web/live/subscription_live/create_free_trial_test.exs
@@ -59,7 +59,7 @@ defmodule BrightWeb.CreateFreeTrialTest do
       )
 
       {:ok, index_live, html} = live(conn, ~p"/free_trial?plan=team_up_plan")
-      assert html =~ "採用・人材育成プラン"
+      assert html =~ "チームアッププラン"
       assert index_live |> has_element?("p", "このプランはすでに選択済みです")
     end
 
@@ -81,7 +81,7 @@ defmodule BrightWeb.CreateFreeTrialTest do
       )
 
       {:ok, index_live, html} = live(conn, ~p"/free_trial?plan=team_up_plan")
-      assert html =~ "採用・人材育成プラン"
+      assert html =~ "チームアッププラン"
       assert index_live |> has_element?("p", "このプランはすでに選択済みです")
     end
 


### PR DESCRIPTION
## 対応内容

issue #1284 の一部です。

前段階として、いまのスキル検索で面談調整する際に表示される無料トライアルモーダルを改修しています。
主な点は以下です。

- plan_codeではなくservice_codeからplanを決めるように対応
  - （もう１つあるマイページの方はURLがplan_codeみたいなので現状未対応&対応必要が不明で未着手）
- 無料トライアル申し込み後の処理を、コンポーネントに渡せるように対応

また１つバグフィックス（面談調整から無料トライアル申し込みができなくなっている）を含みます。