### PR TITLE
ユーザー設定のタブ移動時に modal_flash を削除する

### DIFF
--- a/lib/bright_web/live/user_settings_live/user_setting_component.ex
+++ b/lib/bright_web/live/user_settings_live/user_setting_component.ex
@@ -78,6 +78,7 @@ defmodule BrightWeb.UserSettingsLive.UserSettingComponent do
     |> assign(:selected_tab, tab_name)
     |> assign(:module, Map.get(@tab_module, tab_name))
     |> assign(:action, tab_name)
+    |> assign(:modal_flash, %{})
     |> then(&{:noreply, &1})
   end
 end


### PR DESCRIPTION
- close: #1295 

タブ移動時に modal_flash が残っていたことにより、一度 display: hidden で消えてもタブ移動すると復活していた。
タブ移動時に明示的に削除する。

# 動作確認

https://github.com/bright-org/bright/assets/18478417/91ea8fe0-3cf8-42b5-b001-0bd4d961a903

