### PR TITLE
無料トライアルモーダル 会社名の必須有無 プランによる対応

### DIFF
--- a/lib/bright/subscriptions.ex
+++ b/lib/bright/subscriptions.ex
@@ -697,4 +697,17 @@ defmodule Bright.Subscriptions do
       application_detail
     )
   end
+
+  @doc """
+  組織プランかどうかを返す
+
+  申し込み時に会社名を必要とするかといった判断で利用
+  サービス内容の実態はsubscription_plan_servicesでもつため、service_codeの有無で判定する
+  """
+  def organization_plan?(subscription_plan) do
+    subscription_plan
+    |> Repo.preload(:subscription_plan_services)
+    |> Map.get(:subscription_plan_services)
+    |> Enum.any?(&(&1.service_code == "team_up"))
+  end
 end

--- a/lib/bright/subscriptions/free_trial_form.ex
+++ b/lib/bright/subscriptions/free_trial_form.ex
@@ -8,6 +8,7 @@ defmodule Bright.Subscriptions.FreeTrialForm do
 
   embedded_schema do
     field :user_id, :string
+    field :organization_plan, :boolean, default: true
     field :plan_name, :string
     field :company_name, :string
     field :phone_number, :string
@@ -26,6 +27,14 @@ defmodule Bright.Subscriptions.FreeTrialForm do
       :email,
       :pic_name
     ])
-    |> validate_required([:company_name, :phone_number, :email, :pic_name])
+    |> validate_required([:phone_number, :email, :pic_name])
+    |> validate_organization_required()
   end
+
+  defp validate_organization_required(%{data: %{organization_plan: true}} = changeset) do
+    changeset
+    |> validate_required([:company_name])
+  end
+
+  defp validate_organization_required(changeset), do: changeset
 end

--- a/lib/bright/subscriptions/subscription_user_plan.ex
+++ b/lib/bright/subscriptions/subscription_user_plan.ex
@@ -53,6 +53,8 @@ defmodule Bright.Subscriptions.SubscriptionUserPlan do
   end
 
   def trial_changeset(subscription_user_plan, attrs) do
+    # company_name:
+    #   必須有無はplanによるためrequiredをつけていない。FreeTrialForm側で確認している。
     subscription_user_plan
     |> cast(attrs, [
       :user_id,
@@ -70,7 +72,6 @@ defmodule Bright.Subscriptions.SubscriptionUserPlan do
       :subscription_status,
       :subscription_start_datetime,
       :trial_start_datetime,
-      :company_name,
       :phone_number,
       :pic_name
     ])

--- a/lib/bright_web/live/subscription_live/create_free_trial_component.ex
+++ b/lib/bright_web/live/subscription_live/create_free_trial_component.ex
@@ -147,9 +147,7 @@ defmodule BrightWeb.SubscriptionLive.CreateFreeTrialComponent do
 
   @impl true
   def update(assigns, socket) do
-    # TODO: plan_codeではなく厳密にはservice_codeをもとに適切なプランを取ること
-    # `Subscriptions.get_most_priority_free_trial_subscription_plan(service_code)`を用いること
-    # 現契約プランと比較してチーム作成数などの制限数が落ちないプランを取ること
+    # TODO: 現契約プランと比較してチーム作成数などの制限数が落ちないプラン(かつ、URL指定されたplanに属するservice_codeを全て持つ）を取ること
     user = assigns.current_user
 
     plan =
@@ -160,7 +158,7 @@ defmodule BrightWeb.SubscriptionLive.CreateFreeTrialComponent do
 
     status = Subscriptions.get_users_subscription_status(user.id, NaiveDateTime.utc_now())
 
-    free_trial = %FreeTrial{}
+    free_trial = %FreeTrial{organization_plan: Subscriptions.organization_plan?(plan)}
     changeset = FreeTrial.changeset(free_trial, %{})
 
     socket

--- a/test/bright_web/live/subscription_live/create_free_trial_test.exs
+++ b/test/bright_web/live/subscription_live/create_free_trial_test.exs
@@ -17,6 +17,11 @@ defmodule BrightWeb.CreateFreeTrialTest do
           authorization_priority: 20
         )
 
+      insert(:subscription_plan_services,
+        subscription_plan: plan,
+        service_code: "team_up"
+      )
+
       %{plan: plan}
     end
 
@@ -163,9 +168,25 @@ defmodule BrightWeb.CreateFreeTrialTest do
              |> element("#free_trial_form")
              |> render_submit(%{
                free_trial_form: %{
-                 company_name: "sample company",
                  phone_number: "00000",
-                 email: "hoge@email.com"
+                 email: "hoge@email.com",
+                 pic_name: "PM"
+               }
+             }) =~ "入力してください"
+    end
+
+    test "NOT validate input company_name required", %{conn: conn} do
+      insert(:subscription_plans, plan_code: "together", name_jp: "個人プラン")
+      {:ok, index_live, html} = live(conn, ~p"/free_trial?plan=together")
+      assert html =~ "個人プラン"
+
+      refute index_live
+             |> element("#free_trial_form")
+             |> render_submit(%{
+               free_trial_form: %{
+                 phone_number: "00000",
+                 email: "hoge@email.com",
+                 pic_name: "PM"
                }
              }) =~ "入力してください"
     end


### PR DESCRIPTION
## 対応内容

issue #1284 

個人プラン相当では、会社名が必須になっていると何を入力していいかわからないため、必須入力を外しています。
個人プラン相当とは、プランが service_code: `team_up` をもっているかで判定しています。

## 参考画像

![スクリーンショット 2024-01-17 102515](https://github.com/bright-org/bright/assets/121112529/324d9328-ab6e-4853-83f6-65a57e81716d)
