### PR TITLE
スキルパネル画面 初回時メッセージが3秒で消える現象対応

### DIFF
--- a/assets/js/hooks/HideFlashTimeout.js
+++ b/assets/js/hooks/HideFlashTimeout.js
@@ -5,7 +5,7 @@ const HideFlashTimeout = {
     timeout = this.el.dataset.timeout || 3000
     kind = this.el.dataset.kind || 'info'
     setTimeout(() => {
-      this.pushEvent('lv:clear-flash', {value: {key: kind}})
+      this.pushEvent('lv:clear-flash', {key: kind})
       this.el.classList.add("hidden")
     }, timeout)
   }

--- a/lib/bright_web/components/bright_core_components.ex
+++ b/lib/bright_web/components/bright_core_components.ex
@@ -27,6 +27,7 @@ defmodule BrightWeb.BrightCoreComponents do
   attr :flash, :map, default: %{}, doc: "the map of flash messages to display"
   attr :title, :string, default: nil
   attr :kind, :atom, values: [:info, :error], doc: "used for styling and flash lookup"
+  attr :hide_timeout, :boolean, default: true
   attr :rest, :global, doc: "the arbitrary HTML attributes to add to the flash container"
 
   slot :inner_block, doc: "the optional inner block that renders the flash message"
@@ -36,7 +37,7 @@ defmodule BrightWeb.BrightCoreComponents do
     <div
       :if={msg = render_slot(@inner_block) || Map.get(@flash, @kind)}
       id={@id}
-      phx-hook="HideFlashTimeout"
+      phx-hook={@hide_timeout && "HideFlashTimeout"}
       data-kind={Atom.to_string(@kind)}
       phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("##{@id}")}
       role="alert"

--- a/lib/bright_web/components/core_components.ex
+++ b/lib/bright_web/components/core_components.ex
@@ -101,6 +101,7 @@ defmodule BrightWeb.CoreComponents do
   attr :flash, :map, default: %{}, doc: "the map of flash messages to display"
   attr :title, :string, default: nil
   attr :kind, :atom, values: [:info, :error], doc: "used for styling and flash lookup"
+  attr :hide_timeout, :boolean, default: true
   attr :rest, :global, doc: "the arbitrary HTML attributes to add to the flash container"
 
   slot :inner_block, doc: "the optional inner block that renders the flash message"
@@ -110,7 +111,7 @@ defmodule BrightWeb.CoreComponents do
     <div
       :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}
       id={@id}
-      phx-hook="HideFlashTimeout"
+      phx-hook={@hide_timeout && "HideFlashTimeout"}
       data-kind={Atom.to_string(@kind)}
       phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("##{@id}")}
       role="alert"
@@ -150,6 +151,7 @@ defmodule BrightWeb.CoreComponents do
     <.flash
       id="disconnected"
       kind={:error}
+      hide_timeout={false}
       title="We can't find the internet"
       phx-disconnected={show("#disconnected")}
       phx-connected={hide("#disconnected")}

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -177,7 +177,7 @@ defmodule BrightWeb.SkillPanelLive.Skills do
 
     (skill_class.class == 1 && Enum.all?(skill_scores, &(&1.id == nil)))
     |> if do
-      update(socket, :flash, &Map.put(&1, "first_skills_edit", true))
+      put_flash(socket, :first_skills_edit, true)
     else
       socket
     end


### PR DESCRIPTION
## 対応内容

障害表：
https://docs.google.com/spreadsheets/d/1EFC-ecEGb0XHsH_1mrKtzkaJIv57DIqJgCOD9E-CNsk/edit#gid=0&range=6:6

スキル初回入力時ヘルプが3秒で消える、現象の対応です。
