### PR TITLE
チーム作成への導線強調, オンボーディング リンク設置, サイドメニュー 位置変更

### DIFF
--- a/lib/bright_web/components/layout_components.ex
+++ b/lib/bright_web/components/layout_components.ex
@@ -161,12 +161,12 @@ defmodule BrightWeb.LayoutComponents do
 
   def links() do
     [
+      {"チームを作る（β）", "/teams/new", nil},
       {"マイページ", "/mypage", nil},
       {"スキルを選ぶ", "/more_skills?open=want_todo_panel", nil},
       {"成長パネル", "/graphs", nil},
       {"スキルパネル", "/panels", nil},
       {"チームスキル分析", "/teams", ~r/\/teams(?!\/new)/},
-      {"チームを作る（β）", "/teams/new", nil},
       {"面談チャット", "/recruits/chats", nil}
       # TODO α版はskill_upを表示しない
       # {"スキルアップする", "/skill_up"},

--- a/lib/bright_web/live/onboarding_live/index.ex
+++ b/lib/bright_web/live/onboarding_live/index.ex
@@ -42,7 +42,7 @@ defmodule BrightWeb.OnboardingLive.Index do
 
     socket
     |> put_flash(:info, "オンボーディングをスキップしました")
-    |> redirect(to: ~p"/searches")
+    |> redirect(to: ~p"/teams/new")
     |> then(&{:noreply, &1})
   end
 

--- a/lib/bright_web/live/onboarding_live/index.html.heex
+++ b/lib/bright_web/live/onboarding_live/index.html.heex
@@ -19,12 +19,13 @@
     </section>
   </div>
 
-  <div class="mt-8 max-w-[1236px]" :if={@current_user.user_onboardings == nil}>
+  <div class="mt-8 max-w-[1236px] text-base" :if={@current_user.user_onboardings == nil}>
+    <p>スキル評価やチーム育成、スカウトを行う方は、まずチームを作成してください</p>
     <a
       id="skip_onboarding"
-      class="w-full white cursor-pointer font-bold px-4 py-2 relative select-none hover:opacity-50 underline text-blue-600"
+      class="w-full white cursor-pointer font-bold py-2 relative select-none hover:opacity-50 underline text-blue-600"
       phx-click="skip_onboarding">
-      スカウトやチーム育成を行う方はこちら
+      チームを作る
     </a>
   </div>
 </section>

--- a/test/bright_web/live/onboarding_live_test.exs
+++ b/test/bright_web/live/onboarding_live_test.exs
@@ -16,7 +16,7 @@ defmodule BrightWeb.OnboardingLiveTest do
         index_live
         |> element("#skip_onboarding")
         |> render_click()
-        |> follow_redirect(conn, "/searches")
+        |> follow_redirect(conn, "/teams/new")
 
       assert conn.resp_body =~ "オンボーディングをスキップしました"
     end


### PR DESCRIPTION
## 対応内容

issue #1284 から下記に対応しました。

>♪④オンボーディングの人事用リンクを「チームを作る」ボタンにすげ替える
>　　→その直上に「スキル評価やチーム育成、スカウトを行う方は、まずチームを作成してください」文言も追加
> ♪⑤メニューの「チームを作る（β）」を「マイページ」よりも上に移動

## 参考画像

**オンボーディング 変更前**

![スクリーンショット 2024-01-17 175929](https://github.com/bright-org/bright/assets/121112529/e51c0c78-3dcf-4ca7-9343-9ea80dd3e543)


**オンボーディング 変更後**

少し文字大きくしました。

![スクリーンショット 2024-01-17 180621](https://github.com/bright-org/bright/assets/121112529/88f7ca2f-bafa-4fa5-8f00-d84ea9ea5716)


**サイドメニュー**

![スクリーンショット 2024-01-17 180814](https://github.com/bright-org/bright/assets/121112529/a25b6014-7d5b-4a19-9f5c-be881bd7e7ab)
