### PR TITLE
無料トライアル チームメンバー上限数を超えたときのプラン取得ミスを修正

### DIFF
--- a/lib/bright_web/live/team_live/team_add_user_component.ex
+++ b/lib/bright_web/live/team_live/team_add_user_component.ex
@@ -118,17 +118,17 @@ defmodule BrightWeb.TeamLive.TeamAddUserComponent do
   defp validate_add_user({:ok, socket, user}) do
     %{users: selected_users, plan: plan, id: id} = socket.assigns
 
-    # members_count: チームメンバー数, 管理者がselected_usersには含まれないため+1をしている
-    members_count = Enum.count(selected_users) + 1
+    # current_members_count: チームメンバー数, 管理者がselected_usersには含まれないため+1をしている
+    current_members_count = Enum.count(selected_users) + 1
     limit = Subscriptions.get_team_members_limit(plan)
 
     cond do
       id_duplidated_user?(selected_users, user) ->
         {:error, assign(socket, :search_word_error, "対象のユーザーは既に追加されています")}
 
-      member_limit?(members_count, limit) ->
+      member_limit?(current_members_count, limit) ->
         message = member_limit_message(limit)
-        open_free_trial_modal(members_count, id)
+        open_free_trial_modal(current_members_count + 1, id)
         {:error, assign(socket, :search_word_error, message)}
 
       true ->

--- a/test/bright_web/live/subscription_live/free_trial_recommendation_component_test.exs
+++ b/test/bright_web/live/subscription_live/free_trial_recommendation_component_test.exs
@@ -150,8 +150,19 @@ defmodule BrightWeb.SubscriptionLive.FreeTrialRecommendationComponentTest do
 
     # データ準備: プラン
     setup do
+      _dummy_same_limit_plan =
+        insert(:subscription_plans,
+          create_teams_limit: 1,
+          team_members_limit: 5,
+          free_trial_priority: 1
+        )
+
       subscription_plan =
-        insert(:subscription_plans, create_teams_limit: 2, team_members_limit: 7)
+        insert(:subscription_plans,
+          create_teams_limit: 2,
+          team_members_limit: 7,
+          free_trial_priority: 2
+        )
 
       %{subscription_plan: subscription_plan}
     end


### PR DESCRIPTION
## 対応内容

障害表：
https://docs.google.com/spreadsheets/d/1SWBPuctl3E9-zwT1bhLy1uQgUqG0JoXt2u4Ylf3QVPA/edit#gid=0&range=37:37

チームメンバー上限数を超えたときのプラン取得ミスがあったので修正しました。