### PR TITLE
無料トライアルモーダル（ブロック時） 利用可否に基づくメッセージ追加

### DIFF
--- a/test/factories/subscription_plan_factory.ex
+++ b/test/factories/subscription_plan_factory.ex
@@ -33,6 +33,23 @@ defmodule Bright.SubscriptionPlanFactory do
 
         subscription_plan
       end
+
+      def plan_with_plan_services_by_service_codes(
+            %Bright.Subscriptions.SubscriptionPlan{} = subscription_plan,
+            service_codes
+          ) do
+        subscription_plan_services =
+          service_codes
+          |> Enum.map(fn service_code ->
+            insert(
+              :subscription_plan_services,
+              %{subscription_plan: subscription_plan, service_code: service_code}
+            )
+          end)
+
+        subscription_plan
+        |> Map.put(:subscription_plan_services, subscription_plan_services)
+      end
     end
   end
 end


### PR DESCRIPTION
**前提PRに向いているので注意（自分向け）** => 解消

## 対応内容

issue close #1312 

チーム作成数制限などで表示される無料トライアルモーダルで、すでに実施済みなどで利用できないケースの表示に対応しました。

## 参考画像

**すでにトライアル済みなど利用できないケース**

![スクリーンショット 2024-01-25 100951](https://github.com/bright-org/bright/assets/121112529/2c3783e9-2257-415d-996c-7c77e3b198e3)

**利用可能なプランそのものがないケース（レア）**

![スクリーンショット 2024-01-25 101106](https://github.com/bright-org/bright/assets/121112529/9f81abd4-4b5f-4339-a583-9fedec9de719)

