### PR TITLE
無料トライアルモーダル メールアドレスに検証追加

### DIFF
--- a/lib/bright/accounts/user.ex
+++ b/lib/bright/accounts/user.ex
@@ -11,6 +11,7 @@ defmodule Bright.Accounts.User do
   alias Bright.Accounts.UserSubEmail
   alias Bright.Accounts.User
   alias Bright.UserProfiles.UserProfile
+  alias Bright.Utils.EmailValidation
 
   @primary_key {:id, Ecto.ULID, autogenerate: true}
   @foreign_key_type Ecto.ULID
@@ -128,12 +129,7 @@ defmodule Bright.Accounts.User do
   """
   def validate_email(changeset, opts) do
     changeset
-    |> validate_required([:email])
-    |> validate_format(
-      :email,
-      ~r/^(?>[-[:alpha:][:alnum:]+_!"'#$%^&*{}\/=?`|~](?:\.?[-[:alpha:][:alnum:]+_!"'#$%^&*{}\/=?`|~]){0,63})@(?=.{1,255}$)(?:(?=[^.]{1,63}(?:\.|$))(?!.*?--.*$)[[:alnum:]](?:(?:[[:alnum:]]|-){0,61}[[:alnum:]])?\.)*(?=[^.]{1,63}(?:\.|$))(?!.*?--.*$)[[:alnum:]](?:(?:[[:alnum:]]|-){0,61}[[:alnum:]])?\.[[:alpha:]]{1,64}$/i
-    )
-    |> validate_length(:email, max: 160)
+    |> EmailValidation.validate()
     |> maybe_validate_unique_email(opts)
   end
 

--- a/lib/bright/subscriptions/free_trial_form.ex
+++ b/lib/bright/subscriptions/free_trial_form.ex
@@ -6,6 +6,8 @@ defmodule Bright.Subscriptions.FreeTrialForm do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Bright.Utils.EmailValidation
+
   embedded_schema do
     field :user_id, :string
     field :organization_plan, :boolean, default: true
@@ -27,7 +29,8 @@ defmodule Bright.Subscriptions.FreeTrialForm do
       :email,
       :pic_name
     ])
-    |> validate_required([:phone_number, :email, :pic_name])
+    |> validate_required([:phone_number, :pic_name])
+    |> EmailValidation.validate()
     |> validate_organization_required()
   end
 

--- a/lib/bright/utils/email_validation.ex
+++ b/lib/bright/utils/email_validation.ex
@@ -1,0 +1,13 @@
+defmodule Bright.Utils.EmailValidation do
+  import Ecto.Changeset
+
+  def validate(changeset) do
+    changeset
+    |> validate_required([:email])
+    |> validate_format(
+      :email,
+      ~r/^(?>[-[:alpha:][:alnum:]+_!"'#$%^&*{}\/=?`|~](?:\.?[-[:alpha:][:alnum:]+_!"'#$%^&*{}\/=?`|~]){0,63})@(?=.{1,255}$)(?:(?=[^.]{1,63}(?:\.|$))(?!.*?--.*$)[[:alnum:]](?:(?:[[:alnum:]]|-){0,61}[[:alnum:]])?\.)*(?=[^.]{1,63}(?:\.|$))(?!.*?--.*$)[[:alnum:]](?:(?:[[:alnum:]]|-){0,61}[[:alnum:]])?\.[[:alpha:]]{1,64}$/i
+    )
+    |> validate_length(:email, max: 160)
+  end
+end

--- a/test/bright_web/live/subscription_live/create_free_trial_test.exs
+++ b/test/bright_web/live/subscription_live/create_free_trial_test.exs
@@ -75,6 +75,22 @@ defmodule BrightWeb.CreateFreeTrialTest do
              }) =~ "入力してください"
     end
 
+    test "validate email format", %{conn: conn} do
+      {:ok, index_live, html} = live(conn, ~p"/free_trial")
+      assert html =~ "採用・人材育成プラン"
+
+      assert index_live
+             |> element("#free_trial_form")
+             |> render_submit(%{
+               free_trial_form: %{
+                 company_name: "hoge",
+                 phone_number: "00000",
+                 email: "hogehoge",
+                 pic_name: "PM"
+               }
+             }) =~ "無効なフォーマットです"
+    end
+
     test "NOT validate input company_name required", %{conn: conn} do
       insert(:subscription_plans, plan_code: "together", name_jp: "個人プラン")
       {:ok, index_live, html} = live(conn, ~p"/free_trial?plan=together")

--- a/test/bright_web/live/subscription_live/free_trial_recommendation_component_test.exs
+++ b/test/bright_web/live/subscription_live/free_trial_recommendation_component_test.exs
@@ -364,6 +364,17 @@ defmodule BrightWeb.SubscriptionLive.FreeTrialRecommendationComponentTest do
 
       refute has_element?(live, "#free_trial_recommendation_form", "入力してください")
     end
+
+    test "validate email format", %{
+      conn: conn
+    } do
+      insert(:subscription_plans)
+
+      live = show_component_modal(conn)
+      change_trial_form(live, %{email: "hogehoge"})
+
+      assert has_element?(live, "#free_trial_recommendation_form", "無効なフォーマットです")
+    end
   end
 
   # 指定したプランが使用できないケース確認


### PR DESCRIPTION
## 対応内容

障害表：
https://docs.google.com/spreadsheets/d/1H1EqqROC-9C76XmmmxCt-i8dxkqBNHJOETtGQ4vgXtk/edit#gid=0&range=10:10

無料トライアルモーダルのメールアドレス入力に検証を追加しています。

## 参考画像

![スクリーンショット 2024-01-29 174604](https://github.com/bright-org/bright/assets/121112529/bb211e73-de82-4ab7-8d90-fa90726ef057)
