### PR TITLE
「βリリースから利用可能」の文言削除

### DIFF
--- a/lib/bright_web/live/card_live/related_team_card_component.ex
+++ b/lib/bright_web/live/card_live/related_team_card_component.ex
@@ -90,7 +90,6 @@ defmodule BrightWeb.CardLive.RelatedTeamCardComponent do
                  </p>
               </li>
 
-              <% # TODO ↓α版対応 %>
               <li :if={@card.selected_tab == "supporter_teams"} class="text-base text-left p-1">
                 <div class="text-base">支援を受けている採用・育成チームはありません</div>
                 <p class="my-4">
@@ -98,7 +97,6 @@ defmodule BrightWeb.CardLive.RelatedTeamCardComponent do
                     採用・育成チームに支援してもらう（β）
                   </a>
                 </p>
-                <p class="text-sm">βリリースで利用可能になります</p>
               </li>
 
               <li :if={@card.selected_tab == "supportee_teams"} class="text-base text-left p-1">


### PR DESCRIPTION
## 対応内容

マイページの「βリリースから利用可能」文言を削除しました。

障害表より：
https://docs.google.com/spreadsheets/d/1qag1sy_C9_kcTrwxMmPCRzlsObULDAvLyzwaNp4EhjI/edit#gid=0&range=17:17

## 参考画像

**修正前**

![image](https://github.com/bright-org/bright/assets/121112529/b3238f39-1213-439e-b4fc-51aea27fd7f8)

**修正後**

![スクリーンショット 2024-01-30 095800](https://github.com/bright-org/bright/assets/121112529/0d96e0ef-0dd1-4b89-a349-50ff61cea53f)
