### PR TITLE
無料トライアルモーダル 電話番号検証

### DIFF
--- a/lib/bright/subscriptions/free_trial_form.ex
+++ b/lib/bright/subscriptions/free_trial_form.ex
@@ -29,9 +29,19 @@ defmodule Bright.Subscriptions.FreeTrialForm do
       :email,
       :pic_name
     ])
-    |> validate_required([:phone_number, :pic_name])
+    |> validate_required([:pic_name])
+    |> validate_phone_number()
     |> EmailValidation.validate()
     |> validate_organization_required()
+  end
+
+  defp validate_phone_number(changeset) do
+    # フォーマットは入力間違いを検知する目的で簡易な確認をしている
+    # - 9文字以上18文字以下(国際番号15桁+ハイフン3つ込みで最大18としている)
+    # - 先頭に国際番号指定の+を許可し、その他はハイフンか数字で構成
+    changeset
+    |> validate_required([:phone_number])
+    |> validate_format(:phone_number, ~r/^\+?[-\d]{9,18}$/)
   end
 
   defp validate_organization_required(%{data: %{organization_plan: true}} = changeset) do

--- a/lib/bright/subscriptions/subscription_user_plan.ex
+++ b/lib/bright/subscriptions/subscription_user_plan.ex
@@ -52,8 +52,7 @@ defmodule Bright.Subscriptions.SubscriptionUserPlan do
   end
 
   def trial_changeset(subscription_user_plan, attrs) do
-    # company_name:
-    #   必須有無はplanによるためrequiredをつけていない。FreeTrialForm側で確認している。
+    # Subscriptions.FreeTrialForm側で確認済みの検証はこちらでは未実施
     subscription_user_plan
     |> cast(attrs, [
       :user_id,

--- a/test/bright/subscriptions/free_trial_form_test.exs
+++ b/test/bright/subscriptions/free_trial_form_test.exs
@@ -1,0 +1,35 @@
+defmodule Bright.Subscriptions.FreeTrialFormTest do
+  use ExUnit.Case, async: true
+  use ExUnit.Parameterized
+
+  alias Bright.Subscriptions.FreeTrialForm
+
+  describe "phone_number validation" do
+    test_with_params "check format",
+                     fn value, expected ->
+                       %{errors: errors} =
+                         FreeTrialForm.changeset(%FreeTrialForm{}, %{phone_number: value})
+
+                       if expected == :ng do
+                         assert :phone_number in Keyword.keys(errors)
+                       else
+                         refute :phone_number in Keyword.keys(errors)
+                       end
+                     end do
+      [
+        {"03-5321-1111", :ok},
+        {"12345678901", :ok},
+        {"+1-90-8561-2341", :ok},
+        {"123456789", :ok},
+        {"12345678", :ng},
+        {"あいうえお", :ng},
+        {"+1 90-8561-2341", :ng},
+        {"0a-5321-1111", :ng},
+        {"03-532a-1111", :ng},
+        {"03-5321-111a", :ng},
+        {"0あ-5321-1111", :ng},
+        {"０3-5321-1111", :ng}
+      ]
+    end
+  end
+end

--- a/test/bright_web/live/subscription_live/create_free_trial_test.exs
+++ b/test/bright_web/live/subscription_live/create_free_trial_test.exs
@@ -68,7 +68,7 @@ defmodule BrightWeb.CreateFreeTrialTest do
              |> element("#free_trial_form")
              |> render_submit(%{
                free_trial_form: %{
-                 phone_number: "00000",
+                 phone_number: "000000000",
                  email: "hoge@email.com",
                  pic_name: "PM"
                }
@@ -84,8 +84,24 @@ defmodule BrightWeb.CreateFreeTrialTest do
              |> render_submit(%{
                free_trial_form: %{
                  company_name: "hoge",
-                 phone_number: "00000",
+                 phone_number: "000000000",
                  email: "hogehoge",
+                 pic_name: "PM"
+               }
+             }) =~ "無効なフォーマットです"
+    end
+
+    test "validate phone_number format", %{conn: conn} do
+      {:ok, index_live, html} = live(conn, ~p"/free_trial")
+      assert html =~ "採用・人材育成プラン"
+
+      assert index_live
+             |> element("#free_trial_form")
+             |> render_submit(%{
+               free_trial_form: %{
+                 company_name: "hoge",
+                 phone_number: "hoge",
+                 email: "hoge@email.com",
                  pic_name: "PM"
                }
              }) =~ "無効なフォーマットです"
@@ -100,7 +116,7 @@ defmodule BrightWeb.CreateFreeTrialTest do
       |> element("#free_trial_form")
       |> render_submit(%{
         free_trial_form: %{
-          phone_number: "00000",
+          phone_number: "000000000",
           email: "hoge@email.com",
           pic_name: "PM"
         }
@@ -121,7 +137,7 @@ defmodule BrightWeb.CreateFreeTrialTest do
       |> render_submit(%{
         free_trial_form: %{
           company_name: "sample company",
-          phone_number: "00000",
+          phone_number: "000000000",
           email: "hoge@email.com",
           pic_name: "PM"
         }
@@ -155,7 +171,7 @@ defmodule BrightWeb.CreateFreeTrialTest do
       |> render_submit(%{
         free_trial_form: %{
           company_name: "sample company",
-          phone_number: "00000",
+          phone_number: "000000000",
           email: "hoge@email.com",
           pic_name: "PM"
         }

--- a/test/bright_web/live/subscription_live/free_trial_recommendation_component_test.exs
+++ b/test/bright_web/live/subscription_live/free_trial_recommendation_component_test.exs
@@ -423,6 +423,17 @@ defmodule BrightWeb.SubscriptionLive.FreeTrialRecommendationComponentTest do
 
       assert has_element?(live, "#free_trial_recommendation_form", "無効なフォーマットです")
     end
+
+    test "validate phone_number format", %{
+      conn: conn
+    } do
+      insert(:subscription_plans)
+
+      live = show_component_modal(conn)
+      change_trial_form(live, %{phone_number: "hogehoge"})
+
+      assert has_element?(live, "#free_trial_recommendation_form", "無効なフォーマットです")
+    end
   end
 
   # 指定したプランが使用できないケース確認


### PR DESCRIPTION
## 対応内容

無料トライアルモーダルに、電話番号検証を入れました。
偽装自体は防げないので、ユーザーが入力間違いに気づけることを目的として、厳密なものではありません。

コードコメント抜粋

```
    # フォーマットは入力間違いを検知する目的で簡易な確認をしている
    # - 9文字以上18文字以下(国際番号15桁+ハイフン3つ込みで最大18としている)
    # - 先頭に国際番号指定の+を許可し、その他はハイフンか数字で構成
```

障害表：
https://docs.google.com/spreadsheets/d/1H1EqqROC-9C76XmmmxCt-i8dxkqBNHJOETtGQ4vgXtk/edit#gid=0&range=9:9

## 参考画像

![スクリーンショット 2024-01-30 165640](https://github.com/bright-org/bright/assets/121112529/aa56dee9-9e52-42a2-8edb-68c0c5dd5391)

## 備考

ランチMTGで話題に上がったライブラリは英字を入れれたのでパスしました。

```
iex(53)> {:ok, phone_number} = ExPhoneNumber.parse("03-5321-abc1", "JP")
{:ok,
 %ExPhoneNumber.Model.PhoneNumber{
   country_code: 81,
   national_number: 353212221,
   extension: nil,
   italian_leading_zero: nil,
   number_of_leading_zeros: nil,
   raw_input: nil,
   country_code_source: nil,
   preferred_domestic_carrier_code: nil
 }}
iex(54)> ExPhoneNumber.is_valid_number?(phone_number)
true
```