### PR TITLE
チーム編集画面 プラン名を修正

### DIFF
--- a/lib/bright_web/live/team_live/team_create_live_component.html.heex
+++ b/lib/bright_web/live/team_live/team_create_live_component.html.heex
@@ -78,7 +78,7 @@
               <%= @submit %>
             </button>
           </div>
-          <span :if={@action == :edit} class="text-attention-600">※「チームアッププラン」以上をご購入いただくと、削除したチームを復旧できます</span>
+          <span :if={@action == :edit} class="text-attention-600">※「チームの価値を発掘」プラン以上をご購入いただくと、削除したチームを復旧できます</span>
         </.team_form>
       </div>
     </div>


### PR DESCRIPTION
## 対応内容

「チームアッププラン」のリネーム対応です。

障害表：
https://docs.google.com/spreadsheets/d/1SWBPuctl3E9-zwT1bhLy1uQgUqG0JoXt2u4Ylf3QVPA/edit#gid=0&range=39:39

## 参考画像

![image](https://github.com/bright-org/bright/assets/121112529/4c85b1c9-a1a1-4c37-8c5c-01aa4971792a)
