### PR TITLE
チーム管理者と個人のプランの有効かの論理和を判定する関数実装

### DIFF
--- a/lib/bright/accounts.ex
+++ b/lib/bright/accounts.ex
@@ -920,4 +920,15 @@ defmodule Bright.Accounts do
 
     primary_emails ++ sub_emails
   end
+
+  def hr_enabled?(user_id) do
+    case Bright.Subscriptions.service_hr_basic_enabled?(user_id) do
+      true ->
+        true
+
+      false ->
+        Bright.Teams.joined_supporter_teams_owner_ids(user_id)
+        |> Bright.Subscriptions.service_enabled?("hr_basic")
+    end
+  end
 end

--- a/lib/bright/subscriptions.ex
+++ b/lib/bright/subscriptions.ex
@@ -442,7 +442,30 @@ defmodule Bright.Subscriptions do
       %Bright.Subscriptions.SubscriptionUserPlan{}
       iex> get_user_subscription_user_plan("01H7W3BZQY7CZVM5Q66T4EWEVC")
       nil
+      iex> get_user_subscription_user_plan(["01H7W3BZQY7CZVM5Q66T4EWEVC"])
+      [%Bright.Subscriptions.SubscriptionUserPlan{}]
+      iex> get_user_subscription_user_plan(["01H7W3BZQY7CZVM5Q66T4EWEVC"])
+      []
+
   """
+  def get_user_subscription_user_plan(user_ids) when is_list(user_ids) do
+    current_datetime = NaiveDateTime.utc_now()
+    limit = length(user_ids)
+
+    from(sup in SubscriptionUserPlan,
+      where: sup.user_id in ^user_ids,
+      where:
+        (sup.subscription_start_datetime <= ^current_datetime and
+           is_nil(sup.subscription_end_datetime)) or
+          (sup.trial_start_datetime <= ^current_datetime and is_nil(sup.trial_end_datetime)),
+      join: sp in assoc(sup, :subscription_plan),
+      order_by: {:desc, sp.authorization_priority},
+      preload: [subscription_plan: {sp, [:subscription_plan_services]}],
+      limit: ^limit
+    )
+    |> Repo.all()
+  end
+
   def get_user_subscription_user_plan(user_id) do
     current_datetime = NaiveDateTime.utc_now()
 
@@ -493,7 +516,29 @@ defmodule Bright.Subscriptions do
       false
       iex> service_enabled?("01H7W3BZQY7CZVM5Q66T4EWEVC", "skill_up")
       true
+      iex> service_enabled?(["01H7W3BZQY7CZVM5Q66T4EWEVC"], "hogehoge")
+      false
+      iex> service_enabled?(["01H7W3BZQY7CZVM5Q66T4EWEVC"], "skill_up")
+      true
   """
+
+  def service_enabled?(user_ids, service_code) when is_list(user_ids) do
+    subscription_user_plans = get_user_subscription_user_plan(user_ids)
+
+    case subscription_user_plans do
+      [] ->
+        false
+
+      _ ->
+        subscription_user_plans
+        |> Enum.map(fn plan ->
+          plan.subscription_plan.subscription_plan_services
+          |> Enum.any?(&(&1.service_code == service_code))
+        end)
+        |> Enum.any?()
+    end
+  end
+
   def service_enabled?(user_id, service_code) do
     subscription_user_plan = get_user_subscription_user_plan(user_id)
 

--- a/lib/bright/teams.ex
+++ b/lib/bright/teams.ex
@@ -1289,6 +1289,24 @@ defmodule Bright.Teams do
     )
   end
 
+  def joined_supporter_teams_owner_ids(user_id) do
+    from(tmu in TeamMemberUsers,
+      where:
+        tmu.is_admin == true and
+          tmu.team_id in subquery(
+            from(tmu in TeamMemberUsers,
+              left_join: t in assoc(tmu, :team),
+              where:
+                tmu.user_id == ^user_id and not is_nil(tmu.invitation_confirmed_at) and
+                  is_nil(t.disabled_at) and t.enable_hr_functions == true,
+              select: t.id
+            )
+          ),
+      select: tmu.user_id
+    )
+    |> Repo.all()
+  end
+
   @doc """
   管理者になっているチーム数を返す
 

--- a/lib/bright_web/live/search_live/search_results_component.ex
+++ b/lib/bright_web/live/search_live/search_results_component.ex
@@ -3,8 +3,7 @@ defmodule BrightWeb.SearchLive.SearchResultsComponent do
 
   alias Bright.Repo
   alias Bright.SkillPanels
-  alias Bright.Subscriptions
-  alias Bright.Teams
+  alias Bright.Accounts
 
   def render(assigns) do
     ~H"""
@@ -32,10 +31,7 @@ defmodule BrightWeb.SearchLive.SearchResultsComponent do
   def update(%{skill_params: skill_params, current_user: user} = assigns, socket) do
     socket
     |> assign(assigns)
-    |> assign(
-      :hr_enabled,
-      Subscriptions.service_enabled?(user.id, "hr_basic") || Teams.enable_hr_functions?(user.id)
-    )
+    |> assign(:hr_enabled, Accounts.hr_enabled?(user.id))
     |> assign(:skill_params, put_skill_panel_name(skill_params))
     |> then(&{:ok, &1})
   end


### PR DESCRIPTION
スキル検索からの面談調整を行う際の権限チェック関数を実装
以下をチェックしている
①採用チームリーダー：「ユーザー → サブスク課金有効チェック」
②採用チームメンバー：「所属HRチームの管理者 → サブスク課金有効チェック」


https://github.com/bright-org/bright/assets/91950/b39c65a8-a870-410d-8f9c-331ac1066170

