### PR TITLE
HRプラン時にストックしたユーザーから採用打診をできる機能を実装

### DIFF
--- a/lib/bright/user_searches.ex
+++ b/lib/bright/user_searches.ex
@@ -94,17 +94,15 @@ defmodule Bright.UserSearches do
 
   def get_user_by_id_with_job_profile_and_skill_score(
         user_id,
-        skill_params
+        [%{skill_panel: skill_panel_id} | _]
       ) do
-    # user_job_profileとskill_paramsのskill_panel_idで絞り込んだ skill_scoreの一覧
-    skill_scores =
-      skill_score_query([], [job_searching: true], %{})
-      |> skill_query(skill_params)
-      |> Repo.all()
-
-    # ソート用の1つ目のskill_paramsのskill_classのidを取得
     skill_class_id =
-      get_first_skill_query_params_skill_class_id(skill_scores, List.first(skill_params))
+      from(
+        sc in SkillClass,
+        where: sc.skill_panel_id == ^skill_panel_id and sc.class == 1,
+        select: sc.id
+      )
+      |> Repo.all()
 
     from(
       u in User,
@@ -124,6 +122,19 @@ defmodule Bright.UserSearches do
       }
     )
     |> Repo.all()
+  end
+
+  def generate_search_params_from_skill_panel_name(skill_panel_name) do
+    skill_panel =
+      Bright.SkillPanels.SkillPanel
+      |> Repo.get_by(name: skill_panel_name)
+
+    [
+      %{
+        skill_panel_name: skill_panel_name,
+        skill_panel: skill_panel.id
+      }
+    ]
   end
 
   # joinしたデータで動的なorderを設定する場合は fragment asでschemaのvirtual fieldのカラム名を指定する

--- a/lib/bright_web/components/profile_components.ex
+++ b/lib/bright_web/components/profile_components.ex
@@ -261,14 +261,16 @@ defmodule BrightWeb.ProfileComponents do
   """
   attr :remove_user_target, :any
   attr :stock_id, :string, required: true
+  attr :user_id, :string, default: ""
   attr :stock_date, :string, required: true
   attr :skill_panel, :string, required: true
   attr :desired_income, :string, default: ""
   attr :encrypt_user_name, :string, required: true
   attr :click_event, :string, default: ""
   attr :click_target, :string, default: nil
+  attr :hr_enabled, :boolean, default: false
 
-  def profile_stock_small_with_remove_button(assigns) do
+  def profile_stock_small_with_remove_button(%{hr_enabled: false} = assigns) do
     ~H"""
     <li class="relative text-left flex items-center text-base p-1  bg-white w-full lg:w-1/2">
       <.profile_stock_small_link click_event={@click_event} click_target={@click_target} encrypt_user_name={@encrypt_user_name}>
@@ -282,6 +284,46 @@ defmodule BrightWeb.ProfileComponents do
           <span class="text-brightGray-300">希望年収：<%= @desired_income %></span>
         </div>
       </.profile_stock_small_link>
+      <button
+        phx-click={JS.push("remove_user", value: %{stock_id: @stock_id})}
+        phx-target={@remove_user_target}
+        class="absolute top-0 -right-4 lg:right-2"
+      >
+        <span class="material-icons bg-brightGray-900 !text-sm rounded-full !inline-flex w-4 h-4 !items-center !justify-center text-white">
+          close
+        </span>
+      </button>
+    </li>
+    """
+  end
+
+  def profile_stock_small_with_remove_button(%{hr_enabled: true} = assigns) do
+    assigns =
+      Map.put(
+        assigns,
+        :skill_params,
+        Bright.UserSearches.generate_search_params_from_skill_panel_name(assigns.skill_panel)
+      )
+
+    ~H"""
+    <li class="relative text-left flex items-center text-base p-1  bg-white w-full lg:w-1/2">
+      <.link
+        phx-click={
+          JS.show(to: "#create_interview_modal")
+          |> JS.push("open", value: %{user: @user_id, skill_params: @skill_params}, target: "#create_interview_modal")
+        }
+        class="cursor-pointer w-full inline-flex items-center gap-x-6"
+      >
+        <img
+          class="inline-block h-10 w-10 rounded-full"
+          src="/images/avatar.png"
+        />
+        <div class="flex-auto gap-x-2">
+          <p class="truncate max-w-[240px]">検索：<%= @skill_panel %></p>
+          <span class="text-brightGray-300">(<%= @stock_date %>)</span>
+          <span class="text-brightGray-300">希望年収：<%= @desired_income %></span>
+        </div>
+      </.link>
       <button
         phx-click={JS.push("remove_user", value: %{stock_id: @stock_id})}
         phx-target={@remove_user_target}

--- a/lib/bright_web/live/card_live/related_user_card_component.ex
+++ b/lib/bright_web/live/card_live/related_user_card_component.ex
@@ -7,6 +7,7 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
   import BrightWeb.TabComponents
   import BrightWeb.DisplayUserHelper, only: [encrypt_user_name: 1]
 
+  alias Bright.Accounts
   alias Bright.Teams
   alias Bright.CustomGroups
   alias Bright.UserProfiles
@@ -49,6 +50,7 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
       |> assign(:page_size, @page_size)
       |> assign(:card_row_click_target, nil)
       |> assign(:purpose, nil)
+      |> assign(:hr_enabled, false)
 
     {:ok, socket}
   end
@@ -107,11 +109,13 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
               <% else %>
                 <.profile_stock_small_with_remove_button
                   stock_id={user_profile.id}
+                  user_id={user_profile.user_id}
                   stock_date={Date.to_iso8601(user_profile.inserted_at)}
                   skill_panel={user_profile.skill_panel}
                   desired_income={if user_profile.desired_income == 0, do: "-" ,else: user_profile.desired_income}
                   encrypt_user_name={encrypt_user_name(user_profile.user)}
                   remove_user_target={@myself}
+                  hr_enabled={@hr_enabled}
                   click_event={click_event(@purpose)}
                   click_target={@card_row_click_target}
                 />
@@ -129,6 +133,7 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
     socket =
       socket
       |> assign(assigns)
+      |> assign(:hr_enabled, Accounts.hr_enabled?(assigns.current_user.id))
       # 初期表示データの取得 mount時に設定したselected_tabの選択処理を実行
       |> assign_with_seleted_tab()
 

--- a/lib/bright_web/live/recruit_interview_live/create_component.ex
+++ b/lib/bright_web/live/recruit_interview_live/create_component.ex
@@ -149,11 +149,11 @@ defmodule BrightWeb.RecruitInterviewLive.CreateComponent do
   end
 
   def handle_event("open", %{"user" => user_id, "skill_params" => skill_params}, socket) do
-    user = UserSearches.get_user_by_id_with_job_profile_and_skill_score(user_id, skill_params)
-
     skill_params =
       skill_params
       |> Enum.map(&(Enum.map(&1, fn {k, v} -> {String.to_atom(k), v} end) |> Enum.into(%{})))
+
+    user = UserSearches.get_user_by_id_with_job_profile_and_skill_score(user_id, skill_params)
 
     socket
     |> assign(:candidates_user, user)


### PR DESCRIPTION
HRプラン有効時にマイページの採用候補者のタブから面談の打診を行えるようにしました

HRプラン有効時

https://github.com/bright-org/bright/assets/91950/1f3ca01b-525e-41ed-87d4-877f62e37bc4

HRプラン無効時

https://github.com/bright-org/bright/assets/91950/7f561c00-fb8e-4de8-a35f-492e4f8d801c

