### PR TITLE
スキルパネル更新処理 スキルクラススコアの日単位データの保存

### DIFF
--- a/docs/logics/update_skill_panels.md
+++ b/docs/logics/update_skill_panels.md
@@ -336,6 +336,20 @@ erDiagram
 
 # 更新ロジックのざっくりした流れ
 
+- 公開→履歴
+    1. 公開テーブルに入っているデータを履歴テーブルにコピーする
+        - `skill_classes` → `historical_skill_classes`
+        - `skill_class_units` → `historical_skill_class_units`
+        - `skill_units` → `historical_skill_units`
+        - `skill_categories` → `historical_skill_categories`
+        - `skills` → `historical_skills`
+        - `skill_class_scores` → `historical_skill_class_scores`
+        - `skill_scores` → `historical_skill_scores`
+        - `skill_unit_scores` → `historical_skill_unit_scores`
+        - `career_field_scores` → `historical_career_field_scores`
+        - `skill_class_score_logs` → `historical_skill_class_score_logs`
+        - `historical_skill_class_scores`, `historical_skill_unit_scores`, `historical_career_field_scores`の `locked_date` には処理を実行した日付を入れる
+    2. 1のコピー元データを公開テーブルから削除する
 - 運営下書き→公開
     1. 運営下書きテーブルに入っているデータを公開テーブルにコピーする
         - `draft_skill_classes` → `skill_classes`
@@ -351,19 +365,6 @@ erDiagram
         - `skill_exams` の外部キー(skill_id)
         - `skill_references` の外部キー(skill_id)
         - 1のコピー先データがなければ削除する
-- 公開→履歴
-    1. 公開テーブルに入っているデータを履歴テーブルにコピーする
-        - `skill_classes` → `historical_skill_classes`
-        - `skill_class_units` → `historical_skill_class_units`
-        - `skill_units` → `historical_skill_units`
-        - `skill_categories` → `historical_skill_categories`
-        - `skills` → `historical_skills`
-        - `skill_class_scores` → `historical_skill_class_scores`
-        - `skill_scores` → `historical_skill_scores`
-        - `skill_unit_scores` → `historical_skill_unit_scores`
-        - `career_field_scores` → `historical_career_field_scores`
-        - `historical_skill_class_scores`, `historical_skill_unit_scores`, `historical_career_field_scores`の `locked_date` には処理を実行した日付を入れる
-    2. 1のコピー元データを公開テーブルから削除する
 - 履歴はどこにもコピーしない
 - ユーザーのスキルスコア集計値更新
     1. 変更があったスキルユニットの把握

--- a/lib/bright/historical_skill_scores/historical_skill_class_score_log.ex
+++ b/lib/bright/historical_skill_scores/historical_skill_class_score_log.ex
@@ -1,0 +1,20 @@
+defmodule Bright.HistoricalSkillScores.HistoricalSkillClassScoreLog do
+  @moduledoc """
+  履歴のスキルスコアログを扱うスキーマ。
+  """
+
+  use Ecto.Schema
+
+  @primary_key {:id, Ecto.ULID, autogenerate: true}
+  @foreign_key_type Ecto.ULID
+
+  schema "historical_skill_class_score_logs" do
+    field :date, :date
+    field :percentage, :float, default: 0.0
+
+    belongs_to(:user, Bright.Accounts.User)
+    belongs_to(:historical_skill_class, Bright.HistoricalSkillPanels.HistoricalSkillClass)
+
+    timestamps()
+  end
+end

--- a/priv/repo/migrations/20240216014639_create_historical_skill_class_score_logs.exs
+++ b/priv/repo/migrations/20240216014639_create_historical_skill_class_score_logs.exs
@@ -1,0 +1,20 @@
+defmodule Bright.Repo.Migrations.CreateHistoricalSkillClassScoreLogs do
+  use Ecto.Migration
+
+  def change do
+    create table(:historical_skill_class_score_logs) do
+      add :user_id, references(:users, on_delete: :nothing), null: false
+
+      add :historical_skill_class_id, references(:historical_skill_classes, on_delete: :nothing),
+        null: false
+
+      add :date, :date, null: false
+      add :percentage, :float, null: false
+
+      timestamps()
+    end
+
+    create index(:historical_skill_class_score_logs, [:user_id])
+    create index(:historical_skill_class_score_logs, [:historical_skill_class_id])
+  end
+end


### PR DESCRIPTION
## 対応内容

issue close #1352

SkillClassScoreLogデータをHistoricalSkillClassScoreLogに移動する処理を追加しました。

- 現状でHistoricalSkillClassScoreLogデータを使う画面はありません。
- SkillClassScoreLogにデータが残っているとSkillClassの入れ替えに伴って、スキルパネル更新処理で外部参照エラーが発生するため、その対応という背景も含みます。（データとしては取っておく）

## 手元での確認内容（補足）

自動テスト以外に、下記については確認済みです。

- 手元でスキルクラスのスコアを変更
  - `skill_class_score_logs`にレコードAが増える
- バッチ処理を日付Dを指定して動かす
  - バッチ処理にエラーが発生しないこと
  - `historical_skill_class_score_logs`にレコードA'が増える。A'はAのコピー（情報を持つ）であること。
  - `skill_class_score_logs`からレコードAが消えていること
  - 補足: この時点で`skill_class_score_logs`にあるデータは、バッチ処理中のスコア変化で作られたもののみになる（date: バッチ処理日D）


