### PR TITLE
サイドバーのメニュー順を修正

### DIFF
--- a/lib/bright_web/components/layout_components.ex
+++ b/lib/bright_web/components/layout_components.ex
@@ -166,12 +166,12 @@ defmodule BrightWeb.LayoutComponents do
   # {title, path, regex, img_src}
   def links() do
     [
+      {"チームを作る（β）", "/teams/new", nil, "/images/common/icons/teamAdd.svg"},
       {"マイページ", "/mypage", nil, "/images/common/icons/mypage.svg"},
       {"スキルを選ぶ", "/more_skills", nil, "/images/common/icons/skillSelect.svg"},
       {"成長パネル", "/graphs", nil, "/images/common/icons/growthPanel.svg"},
       {"スキルパネル", "/panels", nil, "/images/common/icons/skillPanel.svg"},
       {"チームスキル分析", "/teams", ~r/\/teams(?!\/new)/, "/images/common/icons/skillAnalyze.svg"},
-      {"チームを作る（β）", "/teams/new", nil, "/images/common/icons/teamAdd.svg"},
       {"面談チャット", "/recruits/chats", nil, "/images/common/icons/oneOnOneChat.svg"}
       # TODO α版はskill_upを表示しない
       # {"スキルアップする", "/skill_up"},


### PR DESCRIPTION
Figma に合わせたが、正しくは「チームを作る」が上に来るのが正しいとのことだったので

![image](https://github.com/bright-org/bright/assets/18478417/5c08d8b7-5c58-4c5a-8f6a-c8da186098ba)

![image](https://github.com/bright-org/bright/assets/18478417/8e3bcdda-4fee-49dd-91a4-46e2433dc460)
