### PR TITLE
スキル検索時に背景のグレーがヘッダーにかかってなかったので修正

### DIFF
--- a/lib/bright_web/live/search_live/skill_saerch_component.ex
+++ b/lib/bright_web/live/search_live/skill_saerch_component.ex
@@ -16,7 +16,7 @@ defmodule BrightWeb.SearchLive.SkillSearchComponent do
   def render(assigns) do
     ~H"""
     <div id="skill_search_modal" class="hidden">
-      <div class="bg-pureGray-600/90 fixed inset-0 transition-opacity z-20" />
+      <div class="bg-pureGray-600/90 fixed inset-0 transition-opacity z-50" />
       <div class="fixed inset-0 overflow-y-auto z-50">
         <section
           id="user_search" class="absolute bg-white min-h-[600px] p-4 right-0 shadow text-sm top-[60px] w-[1024px]"


### PR DESCRIPTION
UX改善してたらついでに気づいたので修正

# before
![image](https://github.com/bright-org/bright/assets/18478417/fbfcfb9c-65c3-43ae-b7cf-b5cc66d3b3fa)

# after
![2024-03-04_01h55_48](https://github.com/bright-org/bright/assets/18478417/9c901755-1709-4b1d-aa00-eb8b5dc2d21f)
