### PR TITLE
 LIVE STORYBOOKのUser Headerのicon_file_pathの変更とcurrent_userのnil対策

### DIFF
--- a/storybook/layout_components/user_header.story.exs
+++ b/storybook/layout_components/user_header.story.exs
@@ -12,8 +12,9 @@ defmodule Storybook.Components.UserHeader do
           profile: %{
             user_name: "piacere",
             title: "リードプログラマー",
-            icon_file_path: "/images/sample/sample-image.png"
+            icon_file_path: "default_icon/default_avatar_engineer.png"
           },
+          current_user: %Bright.Accounts.User{},
           page_title: "タイトル"
         }
       }


### PR DESCRIPTION
改善前
![image](https://github.com/bright-org/bright/assets/13599847/84a3bccd-6ba7-464e-a133-966ca2c7d263)

改善後
![image](https://github.com/bright-org/bright/assets/13599847/d8550a91-5d71-4931-ab14-e4ea42e3bb8c)

current_userがnilの為落ちてました
icon_file_pathは該当のファイルが無いため変更しました

current_userの詳細のパターンは作ってません
このプルリクは LIVE STORYBOOKのUser Headerが表示することを目的にしてます

close #1372
