### PR TITLE
タイムラインの過去・未来へ移動するボタンのスタイル修正

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -33,17 +33,17 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
     <div class="w-full mb-8 lg:mb-0 lg:mr-8 lg:max-w-[566px] lg:w-[566px]">
       <div class="flex flex-wrap justify-center lg:flex-nowrap lg:justify-start">
         <% # 過去方向ボタン %>
-        <div class="order-2 flex justify-center items-center ml-1 mr-2 lg:order-1">
+        <div class="flex justify-center items-center ml-1 mr-2">
           <%= if @timeline.past_enabled do %>
             <button
-              class="w-6 h-8 bg-brightGray-900 flex justify-center items-center rounded absolute left-4 lg:left-0 lg:relative"
+              class="w-6 h-10 bg-brightGreen-300 flex justify-center items-center rounded absolute left-4 lg:left-0 lg:relative"
               phx-click="shift_timeline_past"
               phx-target={@myself}
             >
               <span class="material-icons text-white !text-3xl">arrow_left</span>
             </button>
           <% else %>
-            <button class="w-6 h-8 bg-brightGray-300 flex justify-center items-center rounded absolute left-4 lg:left-0 lg:relative">
+            <button class="w-6 h-10 bg-brightGray-300 flex justify-center items-center rounded absolute left-4 lg:left-0 lg:relative">
               <span class="material-icons text-white !text-3xl">arrow_left</span>
             </button>
           <% end %>
@@ -61,10 +61,10 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
         />
 
         <% # 未来方向ボタン %>
-        <div class="order-3 flex justify-center items-center ml-2">
+        <div class="flex justify-center items-center ml-2">
           <%= if @timeline.future_enabled do %>
             <button
-              class="w-6 h-8 bg-brightGray-900 flex justify-center items-center rounded absolute right-4 lg:right-0 lg:relative"
+              class="w-6 h-10 bg-brightGreen-300 flex justify-center items-center rounded absolute right-4 lg:right-0 lg:relative"
               phx-click="shift_timeline_future"
               phx-target={@myself}
               disabled={!@timeline.future_enabled}
@@ -72,7 +72,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
               <span class="material-icons text-white !text-3xl">arrow_right</span>
             </button>
           <% else %>
-            <button class="w-6 h-8 bg-brightGray-300 flex justify-center items-center rounded absolute right-4 lg:right-0 lg:relative">
+            <button class="w-6 h-10 bg-brightGray-300 flex justify-center items-center rounded absolute right-4 lg:right-0 lg:relative">
               <span class="material-icons text-white !text-3xl">arrow_right</span>
             </button>
           <% end %>


### PR DESCRIPTION
- #1350 

# 概要
- ボタンの位置を Figma に揃える
- アクティブな場合の色を brightGreen-300 にする
- ボタンの縦幅を少し大きく

# スクショ
## before
![image](https://github.com/bright-org/bright/assets/18478417/e414989b-da89-474d-b5a2-fdf1307bc184)

## after
![image](https://github.com/bright-org/bright/assets/18478417/22068213-b4a4-4171-b7e3-ebce58b4ba89)

