### PR TITLE
test 時に sentry が大量の warn を出してたので修正

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -44,7 +44,7 @@ config :bright, :google_api_storage,
   public_base_url: System.get_env("GCS_PUBLIC_BASE_URL", "http://localhost:4443")
 
 # Sentry
-config :sentry, test_mode: true
+config :sentry, test_mode: true, dsn: nil, log_level: :debug
 
 # NOTE: テスト用に Bright.Ueberauth.Strategy.Test を作成して使用
 config :ueberauth, Ueberauth,


### PR DESCRIPTION
テスト実行時に以下のwarnが出ていた。

```bash
$ docker compose exec web mix test test/bright_web/live/graph_live/graph_test.exs
22:16:03.718 request_id=F7_TKqDj8CTTD8kAAADB [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:03.722 request_id=F7_TKqDj8CTTD8kAAADB [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:03.853 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:03.854 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
.....22:16:04.652 request_id=F7_TKucMUZDhF4sAAApB [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:04.653 request_id=F7_TKucMUZDhF4sAAApB [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:04.672 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:04.672 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:04.694 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:04.694 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:04.748 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:04.748 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
.22:16:04.865 request_id=F7_TKvPDwoiLIJYAAAQE [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:04.866 request_id=F7_TKvPDwoiLIJYAAAQE [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:04.884 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:04.885 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
.22:16:04.996 request_id=F7_TKvuGiDTpE5oAAAwB [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:04.997 request_id=F7_TKvuGiDTpE5oAAAwB [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:05.017 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:05.017 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
.22:16:05.136 request_id=F7_TKwN-t1BMC2EAAAxB [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:05.137 request_id=F7_TKwN-t1BMC2EAAAxB [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:05.162 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:05.163 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
.22:16:05.226 request_id=F7_TKwiU0Gzfv7IAAA1B [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:05.227 request_id=F7_TKwiU0Gzfv7IAAA1B [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:05.251 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:05.252 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
..22:16:05.436 request_id=F7_TKxS1bByE6pwAAAHC [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:05.437 request_id=F7_TKxS1bByE6pwAAAHC [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:05.464 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:05.465 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
..22:16:05.860 request_id=F7_TKy5wjTBfUTwAAA7B [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:05.861 request_id=F7_TKy5wjTBfUTwAAA7B [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:05.885 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:05.886 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
..22:16:06.181 request_id=F7_TK0Is71jKWfUAAAIC [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:06.182 request_id=F7_TK0Is71jKWfUAAAIC [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:06.205 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:06.205 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:06.247 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:06.248 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:06.307 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
22:16:06.307 [warning] Failed to send Sentry event. Cannot send Sentry event because of invalid DSN
.
Finished in 3.7 seconds (0.00s async, 3.7s sync)
16 tests, 0 failures

Randomized with seed 547339
```

- https://github.com/bright-org/bright/pull/1380

おそらくここで Sentry に投げるようになったため。
修正後は出なくなった。