### PR TITLE
「スキル入力」の画面でジェムから知識エリアに移動したい

### DIFF
--- a/lib/bright_web/live/skill_panel_live/skills_form_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_form_component.ex
@@ -460,7 +460,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsFormComponent do
   end
 
   defp create_links(assigns) do
-    link = "/panels/" <> assigns.skill_panel.id <> "/edit?class=1&#input-unit-"
+    link = "#input-unit-"
 
     1..length(assigns.gem_labels)
     |> Enum.map(fn x -> link <> "#{x}" end)


### PR DESCRIPTION
close #1392
タイトルの通り

https://github.com/bright-org/bright/assets/13599847/bf2f6f41-57d9-48e3-89d2-90f2b1e97d69

