### PR TITLE
チームがない場合に表示が崩れてたので修正

### DIFF
--- a/lib/bright_web/live/team_live/my_team_live.html.heex
+++ b/lib/bright_web/live/team_live/my_team_live.html.heex
@@ -1,4 +1,4 @@
-<div class="pb-12">
+<div class="pb-20 lg:pb-12">
   <div class="px-4 lg:px-10 pb-4">
     <!-- スキルと対象の切り替え -->
     <div class="flex flex-col gap-y-4 lg:gap-x-4">
@@ -127,7 +127,7 @@
 
   <div
     :if={@display_team == nil}
-    class="flex mx-10 bg-white shadow justify-center items-center min-h-[50svh]"
+    class="flex mx-4 lg:mx-10 bg-white shadow justify-center items-center min-h-[50svh]"
   >
     <div class="flex flex-col items-center text-center">
       <p class="font-bold">管理／所属しているチームはありません</p>


### PR DESCRIPTION
# before
![2024-04-08_20h18_13](https://github.com/bright-org/bright/assets/18478417/4503342d-737f-4921-a4f7-cb5bd03aabb2)

# after
![2024-04-08_20h48_46](https://github.com/bright-org/bright/assets/18478417/7e378010-a18d-4b2c-99f8-c484208a62cc)

![image](https://github.com/bright-org/bright/assets/18478417/c0c33318-6ada-4903-ada8-6b4954a2cdd6)
