### PR TITLE
レイアウトシフトが起きないように height を設定した

### DIFF
--- a/lib/bright_web/components/profile_components.ex
+++ b/lib/bright_web/components/profile_components.ex
@@ -256,7 +256,7 @@ defmodule BrightWeb.ProfileComponents do
   defp dounat_graph_with_score_stats(assigns) do
     ~H"""
       <div class="flex gap-x-4 lg:gap-x-0">
-        <div class="w-20 lg:w-24">
+        <div class="w-20 lg:w-24 h-20 lg:h-24">
           <ChartComponents.doughnut_graph id="doughnut-graph-single" data={SkillPanelComponents.skill_score_percentages(@counter, @num_skills)} />
         </div>
 


### PR DESCRIPTION
ドーナツグラフの描画が canvas で遅く、レイアウトシフトが発生するので修正

![image](https://github.com/bright-org/bright/assets/18478417/4318f59e-a24c-4789-b5b7-16e48cc27b6e)
