### PR TITLE
①未承認のみ/チーム招待期間過ぎても承認していない人を見分けられるようにしたい

### DIFF
--- a/lib/bright_web/components/profile_components.ex
+++ b/lib/bright_web/components/profile_components.ex
@@ -347,7 +347,7 @@ defmodule BrightWeb.ProfileComponents do
         user_id="1234"
         title="リードプログラマー"
         icon_file_path="/images/sample/sample-image.png"
-        invitation_confirmed=""
+        invitation_not_confirmed={false}
       />
   """
   attr :remove_user_target, :any
@@ -355,7 +355,7 @@ defmodule BrightWeb.ProfileComponents do
   attr :user_id, :string, required: true
   attr :title, :string, default: ""
   attr :icon_file_path, :string, default: ""
-  attr :invitation_confirmed, :any, default: ""
+  attr :invitation_not_confirmed, :boolean, default: false
 
   def profile_small_with_remove_button(assigns) do
     ~H"""
@@ -370,7 +370,7 @@ defmodule BrightWeb.ProfileComponents do
           <p class="text-brightGray-300"><%= @title %></p>
         </div>
         <span
-        :if={@invitation_confirmed == nil}
+        :if={@invitation_not_confirmed}
         class="text-white text-xs font-bold ml-1 px-1 py-1 inline-block bg-lapislazuli-300 rounded min-w-[43px]"
         >
           未承認

--- a/lib/bright_web/live/team_live/team_create_live_component.ex
+++ b/lib/bright_web/live/team_live/team_create_live_component.ex
@@ -74,7 +74,7 @@ defmodule BrightWeb.TeamCreateLiveComponent do
     |> assign(:submit, "チームを更新し、新規メンバーに招待メールを送る")
     |> assign(:selected_team_type, Teams.get_team_type_by_team(team))
     |> assign_team_form(Teams.change_team(team))
-    |> assign(:invitation_confirmed, invitation_confirmed(team.member_users))
+    |> assign(:not_invitation_confirmed_users, not_invitation_confirmed_users(team.member_users))
     |> then(&{:ok, &1})
   end
 
@@ -88,7 +88,7 @@ defmodule BrightWeb.TeamCreateLiveComponent do
     |> assign(:submit, "チームを作成し、上記メンバーに招待を送る")
     |> assign(:selected_team_type, :general_team)
     |> assign_team_form(team_changeset)
-    |> assign(:invitation_confirmed, %{})
+    |> assign(:not_invitation_confirmed_users, [])
     |> then(&{:ok, &1})
   end
 
@@ -354,10 +354,6 @@ defmodule BrightWeb.TeamCreateLiveComponent do
     end
   end
 
-  defp invitation_confirmed(member_users) do
-    member_users
-    |> Enum.reduce(%{}, fn x, acc ->
-      Map.put(acc, Map.get(x, :user_id), Map.get(x, :invitation_confirmed_at))
-    end)
-  end
+  def not_invitation_confirmed_users(member_users),
+    do: Enum.filter(member_users, &is_nil(&1.invitation_confirmed_at)) |> Enum.map(& &1.user_id)
 end

--- a/lib/bright_web/live/team_live/team_create_live_component.html.heex
+++ b/lib/bright_web/live/team_live/team_create_live_component.html.heex
@@ -60,7 +60,7 @@
                         user_id={user.id} user_name={user.name}
                         title={user.user_profile.title}
                         icon_file_path={user.user_profile.icon_file_path}
-                        invitation_confirmed={Map.get(@invitation_confirmed, user.id)}
+                        invitation_not_confirmed={Enum.member?(@not_invitation_confirmed_users, user.id)}
                         />
                     <% end %>
                   </ul>


### PR DESCRIPTION
タイトルどおり
まず、「未承認のみ」の対応

close #1403

![image](https://github.com/bright-org/bright/assets/13599847/f1e50d64-8c66-43a8-b0f3-e326135b05a0)
