### PR TITLE
level_countの計算方法を最適化

### DIFF
--- a/lib/bright_web/live/team_live/my_team_helper.ex
+++ b/lib/bright_web/live/team_live/my_team_helper.ex
@@ -90,8 +90,7 @@ defmodule BrightWeb.TeamLive.MyTeamHelper do
 
   defp level_count(member_skill_class_scores, class, level) do
     member_skill_class_scores
-    |> Enum.filter(fn x -> x.skill_class.class == class and x.level == level end)
-    |> Enum.count()
+    |> Enum.count(fn x -> x.skill_class.class == class and x.level == level end)
   end
 
   defp get_display_skill_panel(%{"skill_panel_id" => skill_panel_id}, _display_team_members) do


### PR DESCRIPTION
 計算方法を最適化
 
 改善前
    |> Enum.filter(fn x -> x.skill_class.class == class and x.level == level end)
    |> Enum.count()
  
 改善後
|> Enum.count(fn x -> x.skill_class.class == class and x.level == level end)

関係する画面 
![image](https://github.com/bright-org/bright/assets/13599847/55984621-3f1c-4ffc-aec2-2a46ab3cfbdf)
