### PR TITLE
1on1ボタンクリック時にチーム管理者でない場合500エラーになるので修正

### DIFF
--- a/lib/bright_web/live/team_live/team_member_skill_card_component.ex
+++ b/lib/bright_web/live/team_live/team_member_skill_card_component.ex
@@ -90,7 +90,7 @@ defmodule BrightWeb.TeamMemberSkillCardComponent do
         </div>
 
         <div
-          :if={ !is_nil(@display_skill_card.user_skill_class_score)}
+          :if={!is_nil(@display_skill_card.user_skill_class_score)}
           class="hidden lg:flex w-[400px] h-[400px] justify-center mx-auto"
           >
           <.live_component
@@ -109,7 +109,7 @@ defmodule BrightWeb.TeamMemberSkillCardComponent do
         </div>
 
         <div
-          :if={ !is_nil(@display_skill_card.user_skill_class_score)}
+          :if={!is_nil(@display_skill_card.user_skill_class_score)}
           class="lg:hidden w-full h-[300px] flex justify-center mx-auto"
           >
           <.live_component
@@ -131,11 +131,10 @@ defmodule BrightWeb.TeamMemberSkillCardComponent do
         <div class="pb-2 flex w-full gap-x-1 lg:gap-x-2 justify-around">
           <button
             :if={@display_skill_card.user.id != @current_user.id}
-            class="flex gap-x-1 lg:gap-x-2 items-center text-xs lg:text-sm font-bold px-1 lg:px-3 py-2 rounded text-white bg-base"
+            class="flex gap-x-1 lg:gap-x-2 items-center text-xs lg:text-sm font-bold px-1 lg:px-3 py-2 rounded text-white bg-base hover:opacity-50"
             phx-click={
                 if @hr_enabled,
-                do: JS.show(to: "#create_interview_modal") |> JS.push("open", value: %{user: @display_skill_card.user.id, skill_params: [%{skill_panel: @display_skill_panel.id, career_field: "1on1"}]}, target: "#create_interview_modal"),
-                else: JS.push("open_free_trial",target: @myself)
+                do: JS.show(to: "#create_interview_modal") |> JS.push("open", value: %{user: @display_skill_card.user.id, skill_params: [%{skill_panel: @display_skill_panel.id, career_field: "1on1"}]}, target: "#create_interview_modal")
               }
           >
             <div


### PR DESCRIPTION
- close: #1412 

本来の要件的には以下だが、プランとチーム周りの理解が必要で、なおかつ現状があまり整理されていないため片手間ではできないと判断した。そのため一旦エラー出ないようにした。

1on1 ボタンの理想要件
- 1 HRプランを持つものがチームの管理者である場合は 1on1 を起動する
  - この判定関数が現状なさそう
  - 実装のためにはプラン・チームの理解が必要なので時間がかかる
- 2 上記以外の場合はクリック時にフリープランモーダルを出す 
  - 結局 1 が判定できないと実装できない

現状はチーム管理者で、かつHRプランが有効な時のみ 1on1 できるようになっている。