### PR TITLE
「チャットを閉じる」ボタンを削除

### DIFF
--- a/lib/bright_web/live/chat_live/index.ex
+++ b/lib/bright_web/live/chat_live/index.ex
@@ -116,11 +116,6 @@ defmodule BrightWeb.ChatLive.Index do
                       一覧に戻る
                     </button>
                   </.link>
-                  <.link phx-click="close_chat" data-confirm="このチャットを閉じますか？">
-                    <button type="button" class="text-sm font-bold lg:mr-2 px-2 py-3 rounded border bg-white w-36 lg:w-56">
-                      チャットを閉じる
-                    </button>
-                  </.link>
                 </div>
                 <div
                   :if={@chat.owner_user_id == @current_user.id and Accounts.hr_enabled?(@current_user.id)}


### PR DESCRIPTION
close #1426
「チャットを閉じる」ボタンを削除しました
![image](https://github.com/bright-org/bright/assets/13599847/d87f893e-6ba0-45ea-a552-077e60a32e97)

テスト方法
![image](https://github.com/bright-org/bright/assets/13599847/e0b6346f-8894-474b-b5ab-f0a7bee804d1)

@ hr_enabledの権限が必要で私の環境では簡単に設定できなかったため
一時的に強制で「1on1に誘う」ボタンをソース上で有効にしました
（このテストは本来は良くないが、「チャットを閉じる」ボタンと無関係なため対応速度重視で実施しました）
![image](https://github.com/bright-org/bright/assets/13599847/28084eec-9938-4ab2-88db-4c27f602a060)
