### PR TITLE
ノートパソコンで見たときにタイムラインが微妙に崩れてたので修正

### DIFF
--- a/lib/bright_web/live/chart_live/growth_graph_component.ex
+++ b/lib/bright_web/live/chart_live/growth_graph_component.ex
@@ -74,7 +74,7 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
       </div>
 
       <% # タイムライン自身 %>
-      <div class="lg:flex lg:items-center">
+      <div class="lg:flex lg:items-center justify-center 2xl:justify-normal pr-7 lg:pr-14">
         <div class="hidden lg:flex justify-center items-center mr-2" data-size="pc">
           <.btn_timeline_shift_past enabled={@timeline.past_enabled} id="myself" myself={@myself}/>
         </div>


### PR DESCRIPTION
自分使用のノートパソコンで見たときに崩れていて微妙に気になったので直しました。

# スクショ

## before
![image](https://github.com/bright-org/bright/assets/18478417/db7c1906-307e-477e-95a8-0b06adb10e8f)

## after
![2024-05-03_15h34_58](https://github.com/bright-org/bright/assets/18478417/88ce2beb-dc40-4dc1-b00a-82c173d2665d)
