### PR TITLE
プレースホルダー文言を「ハンドル名で絞り込みできます」、ボタン文言を「絞り込み」に変更

### DIFF
--- a/lib/bright_web/live/team_live/my_team_live.html.heex
+++ b/lib/bright_web/live/team_live/my_team_live.html.heex
@@ -148,9 +148,9 @@
       level_count={@level_count}
     />
     <form id="filter-form" phx-submit="filter">
-      <input type="text" name="filter_name" value={@filter_name} placeholder="ハンドル名" class="input">
+      <input type="text" name="filter_name" value={@filter_name} placeholder="ハンドル名で絞り込みできます" class="input w-64">
       <button class="text-sm font-bold p-2 rounded border bg-base text-white hover:opacity-50">
-        フィルター
+        絞り込み
       </button>
     </form>
     <!-- チームメンバー -->


### PR DESCRIPTION
 close #1437 
 
![image](https://github.com/bright-org/bright/assets/13599847/153aa607-824d-4dcf-97f9-9944801bc611)
