### PR TITLE
「あとxx%でyyyyです」を「現在」のみ表示する

### DIFF
--- a/lib/bright_web/live/graph_live/graphs.html.heex
+++ b/lib/bright_web/live/graph_live/graphs.html.heex
@@ -133,6 +133,7 @@
           />
         </div>
         <.next_level_announce
+          :if={@select_label == "now"}
           value={@counter.high}
           size={@num_skills}
         />


### PR DESCRIPTION
close #1440
![image](https://github.com/bright-org/bright/assets/13599847/a96916c4-ec97-4f11-91c7-6b63c475b9d5)

![image](https://github.com/bright-org/bright/assets/13599847/088cb41e-327a-40e8-9b3b-8f69b0d3562e)


