### PR TITLE
チャット画面のバグ修正

### DIFF
--- a/lib/bright_web/live/chat_live/chat_components.ex
+++ b/lib/bright_web/live/chat_live/chat_components.ex
@@ -111,6 +111,7 @@ defmodule BrightWeb.ChatLive.ChatComponents do
       <div class="w-full flex flex-col justify-end mt-4">
         <%= for file <- Enum.filter(@message.files, & &1.file_type == :files) do %>
           <a class="cursor-pointer hover:opacity-50 underline text-xl" href={Storage.public_url(file.file_path)} target="_blank" rel="noopener">
+            <.icon name="hero-document" class="w-24 h-24" /><br>
             <%= file.file_name %>
           </a>
         <% end %>


### PR DESCRIPTION
- #1445 

の仕様確認していて気づいたので。

# やったこと

- 画像送信時に受け手側の画像表示が二重になりバグっていたので修正
- 画像送信時に受け手側にファイルアイコンがないので修正

# 動作確認
## 送り手
![image](https://github.com/bright-org/bright/assets/18478417/7aa1e810-f6b0-4b06-8eb6-799fd6a91729)

## 受け手
![image](https://github.com/bright-org/bright/assets/18478417/0e0387e0-2398-408c-929b-b7564de54f07)

### 修正前
修正前はこのように受け手側が送信していたような画像表示があったり、ファイルアイコンが未設定だったりしている。
![image](https://github.com/bright-org/bright/assets/18478417/652b2502-39ac-41ac-912e-29aef06140be)
