### PR TITLE
面談確定時に同席依頼者にもメール路送信するように変更

### DIFF
--- a/lib/bright/accounts/user_notifier.ex
+++ b/lib/bright/accounts/user_notifier.ex
@@ -425,6 +425,33 @@ defmodule Bright.Accounts.UserNotifier do
     """)
   end
 
+  def deliver_start_interview_to_member(from_user, to_user, member) do
+    deliver(member.email, "【Bright】面談確定を候補者に連絡しました", """
+    #{member.name}さん
+
+    #{from_user.name}さんが以下の文面を#{to_user.name}(#{to_user.email})さんへ送りました。
+    別途、日程などを#{from_user.name}さんと調整してください（Bright内では日程調整は行いません）。
+
+
+    ====================================================================
+
+    #{from_user.name}から、面談が確定されました。
+
+    面談日・ツール・場所は、Brightに登録されている連絡先に対し、#{from_user.name}から別途、連絡いたします。
+
+    ====================================================================
+
+    ---------------------------------------------------------------------
+    ■本メールにお心当たりのない場合
+    ---------------------------------------------------------------------
+    お手数ですが、本メールを破棄してください。
+    もし気になる点ございましたら、下記までご連絡ください。
+    #{customer_success_email()}
+
+    #{signature()}
+    """)
+  end
+
   @doc """
   Deliver interview cancel mail to candidates_user.
   """

--- a/lib/bright/recruits.ex
+++ b/lib/bright/recruits.ex
@@ -216,7 +216,7 @@ defmodule Bright.Recruits do
       when is_function(start_interview_url_fun, 1) do
     interview =
       Interview
-      |> preload([:candidates_user, :recruiter_user])
+      |> preload([:candidates_user, :recruiter_user, interview_members: :user])
       |> Repo.get!(interview_id)
 
     UserNotifier.deliver_start_interview_to_candidates_user(
@@ -229,6 +229,15 @@ defmodule Bright.Recruits do
       interview.candidates_user,
       start_interview_url_fun.(interview_id)
     )
+
+    interview.interview_members
+    |> Enum.each(fn member ->
+      UserNotifier.deliver_start_interview_to_member(
+        interview.recruiter_user,
+        interview.candidates_user,
+        member.user
+      )
+    end)
   end
 
   def send_interview_cancel_notification_mails(interview_id) do


### PR DESCRIPTION
採用担当者、採用候補者、同席依頼先の３者にメールが送られるのを確認
![スクリーンショット 2024-05-15 22 56 36](https://github.com/bright-org/bright/assets/91950/1ce97ac6-f58b-436b-9635-fb0e841fde01)

文面
![スクリーンショット 2024-05-15 22 56 56](https://github.com/bright-org/bright/assets/91950/f3c8d155-0479-4a09-96e7-20e7686aaf2d)
