### PR TITLE
クラスタブのデザイン修正

### DIFF
--- a/lib/bright_web/live/graph_live/graphs.html.heex
+++ b/lib/bright_web/live/graph_live/graphs.html.heex
@@ -94,7 +94,7 @@
   </div>
 
   <div class="mx-4 pb-20 lg:mx-10 lg:pb-0 bg-white">
-    <div class="flex justify-between">
+    <div class="flex justify-between lg:px-6">
       <.class_tab
         skill_classes={@skill_classes}
         skill_class={@skill_class}

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -222,40 +222,36 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
 
   def class_tab(assigns) do
     ~H"""
-    <div class="w-full bg-white border-b border-b-brightGray-100">
-      <ul class="flex relative z-1 text-normal font-bold text-brightGray-300 text-center lg:text-md w-full lg:w-fit">
+    <div class="w-full bg-white">
+      <ul class="flex relative z-1 text-normal font-bold text-brightGray-300 text-center lg:text-md w-full">
         <%= for {skill_class, skill_class_score} <- pair_skill_class_score(@skill_classes) do %>
-          <% current = @skill_class.class == skill_class.class %>
-          <%= if !@me && is_nil(skill_class_score) do %>
-            <li id={"class_tab_#{skill_class.class}"} class="grow lg:grow-0">
-              <a href="#" class="hover:cursor-default flex items-center lg:select-none px-2 lg:px-4 py-1 lg:py-3 text-xs">
-                <span class="text-sm lg:text-normal">クラス<%= skill_class.class %></span>
-                <span class="text-lg text-right lg:text-xl min-w-[32px] lg:min-w-0 ml-1 lg:ml-4">0％</span>
-              </a>
-            </li>
-          <% else %>
-            <li id={"class_tab_#{skill_class.class}"} class={["grow", current && "text-brightGreen-300 border-b-2 border-b-brightGreen-300", !current && "hover:opacity-50 hover:text-brightGreen-300"]}>
-              <.link
-                patch={"#{@path}?#{build_query(@query, %{"class" => skill_class.class})}"}
-                class="flex justify-center items-center px-1 lg:px-4 py-1 lg:py-3"
-                aria-current={current && "page"}
-              >
-                <span class="text-sm lg:text-normal">クラス<%= skill_class.class %></span>
-                <span class="text-lg text-right lg:text-xl min-w-[32px] lg:min-w-0 ml-1 lg:ml-4">
-                  <%= if skill_class_score do %>
-                    <%= floor skill_class_score.percentage %>
-                  <% else %>
-                    0
-                  <% end %>
-                  ％
-                </span>
-              </.link>
-            </li>
-          <% end %>
+          <li class="w-1 lg:w-2 border-b-2 border-b-brightGreen-300"></li>
+          <li id={"class_tab_#{skill_class.class}"} class={["grow lg:grow-0 rounded-t", selected_skill?(@skill_class, skill_class) && "text-brightGreen-300 border-x-2 border-x-brightGreen-300 border-t-2 border-t-brightGreen-300", !selected_skill?(@skill_class, skill_class) && "hover:opacity-50 hover:text-brightGreen-300 border-x-2 border-x-brightGray-100 border-t-2 border-t-brightGray-100 border-b-2 border-b-brightGreen-300"]}>
+            <.link
+              patch={"#{@path}?#{build_query(@query, %{"class" => skill_class.class})}"}
+              class="flex justify-center items-center px-1 lg:px-10 py-2"
+              aria-current={selected_skill?(@skill_class, skill_class) && "page"}
+            >
+              <span class="text-sm lg:text-normal">クラス<%= skill_class.class %>：</span>
+              <span class="text-sm text-right lg:text-normal min-w-[32px] lg:min-w-0">
+                <%= if skill_class_score do %>
+                  <%= floor skill_class_score.percentage %>
+                <% else %>
+                  0
+                <% end %>
+                ％
+              </span>
+            </.link>
+          </li>
         <% end %>
+        <li class="grow border-b-2 border-b-brightGreen-300"></li>
       </ul>
     </div>
     """
+  end
+
+  defp selected_skill?(current_skill_class, target_skill_class) do
+    current_skill_class.class == target_skill_class.class
   end
 
   def no_skill_panel(assigns) do

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -101,8 +101,8 @@
   </ProfileComponents.profile_with_skill>
 </div>
 
-<div class="mx-4 lg:mx-10 relative">
-  <div class="flex justify-between">
+<div class="mx-4 lg:mx-10 relative lg:pb-0 bg-white">
+  <div class="flex justify-between lg:px-6">
     <.class_tab
       skill_classes={@skill_classes}
       skill_class={@skill_class}


### PR DESCRIPTION
- close: #1473 

# やったこと
- Figma に従ってクラスタブのデザイン修正
- クラス解放判定がなくなったことの対応漏れで分岐が残っていてデザイン適用が困難になっていたので削除
  - 以下でなくなった時の対応漏れの認識（違ってたら教えてください）
  - https://github.com/bright-org/bright/pull/1274
 
# スクショ
## PC
![image](https://github.com/bright-org/bright/assets/18478417/5e7da797-37f9-453f-aa8b-30d7cd039710)

## SP
スマホは現時点で優先度低いので、それっぽいデザインで対応した。

![image](https://github.com/bright-org/bright/assets/18478417/3d1774da-c407-49ab-b770-f71ce3254dc7)
