### PR TITLE
管理側スキルクラスとスキルユニット作成時のlocked_dateを適当な日付に変更

### DIFF
--- a/lib/bright/skill_panels/skill_class.ex
+++ b/lib/bright/skill_panels/skill_class.ex
@@ -13,8 +13,7 @@ defmodule Bright.SkillPanels.SkillClass do
   @foreign_key_type Ecto.ULID
 
   schema "skill_classes" do
-    # NOTE: 本来はスキルパネル更新バッチによってのみ生成されるデータのためデフォルト値や自動生成は不要だが、現状では管理機能で作成することができてしまうため便宜上残している
-    field :locked_date, :date, default: ~D[2023-07-01]
+    field :locked_date, :date
     field :trace_id, Ecto.ULID, autogenerate: {Ecto.ULID, :generate, []}
 
     field :name, :string
@@ -36,7 +35,7 @@ defmodule Bright.SkillPanels.SkillClass do
   @doc false
   def changeset(skill_class, attrs) do
     skill_class
-    |> cast(attrs, [:name])
+    |> cast(attrs, [:name, :locked_date])
     |> validate_required([:name])
   end
 end

--- a/lib/bright/skill_units/skill_unit.ex
+++ b/lib/bright/skill_units/skill_unit.ex
@@ -13,8 +13,7 @@ defmodule Bright.SkillUnits.SkillUnit do
   @foreign_key_type Ecto.ULID
 
   schema "skill_units" do
-    # NOTE: 本来はスキルパネル更新バッチによってのみ生成されるデータのためデフォルト値や自動生成は不要だが、現状では管理機能で作成することができてしまうため便宜上残している
-    field :locked_date, :date, default: ~D[2023-07-01]
+    field :locked_date, :date
     field :trace_id, Ecto.ULID, autogenerate: {Ecto.ULID, :generate, []}
 
     field :name, :string
@@ -37,7 +36,7 @@ defmodule Bright.SkillUnits.SkillUnit do
   @doc false
   def changeset(skill_unit, attrs) do
     skill_unit
-    |> cast(attrs, [:name])
+    |> cast(attrs, [:name, :locked_date])
     |> cast_assoc(:skill_categories,
       with: &SkillCategory.changeset/2,
       sort_param: :skill_categories_sort,

--- a/lib/bright_web/live/admin/skill_panel_live/form_component.ex
+++ b/lib/bright_web/live/admin/skill_panel_live/form_component.ex
@@ -1,6 +1,7 @@
 defmodule BrightWeb.Admin.SkillPanelLive.FormComponent do
   use BrightWeb, :live_component
 
+  alias BrightWeb.TimelineHelper
   alias Bright.SkillPanels
 
   @impl true
@@ -24,6 +25,7 @@ defmodule BrightWeb.Admin.SkillPanelLive.FormComponent do
         <.inputs_for :let={scf} field={@form[:skill_classes]}>
           <input type="hidden" name="skill_panel[skill_classes_sort][]" value={scf.index} />
           <.input field={scf[:name]} type="text" label="Name" />
+          <.input field={scf[:locked_date]} type="hidden" value={scf[:locked_date].value || @locked_date} />
           <label class="cursor-pointer">
             <input
               type="checkbox"
@@ -35,7 +37,7 @@ defmodule BrightWeb.Admin.SkillPanelLive.FormComponent do
         </.inputs_for>
         <label class="block cursor-pointer">
           <input type="checkbox" name="skill_panel[skill_classes_sort][]" class="hidden" />
-          add skill class
+          add skill class (locked_date: <%= @locked_date %>)
         </label>
         <:actions>
           <.button phx-disable-with="Saving...">Save Skill panel</.button>
@@ -47,6 +49,10 @@ defmodule BrightWeb.Admin.SkillPanelLive.FormComponent do
 
   @impl true
   def update(%{skill_panel: skill_panel} = assigns, socket) do
+    # 現スキルパネルを操作しているためlocked_dateを1つ前のバッチ更新日相当日付としている
+    timeline = TimelineHelper.get_current()
+    locked_date = TimelineHelper.get_shift_date_from_date(timeline.future_date, -1)
+
     changeset =
       skill_panel
       |> preload_assoc()
@@ -55,7 +61,8 @@ defmodule BrightWeb.Admin.SkillPanelLive.FormComponent do
     {:ok,
      socket
      |> assign(assigns)
-     |> assign_form(changeset)}
+     |> assign_form(changeset)
+     |> assign(:locked_date, locked_date)}
   end
 
   @impl true

--- a/lib/bright_web/live/admin/skill_unit_live/form_component.ex
+++ b/lib/bright_web/live/admin/skill_unit_live/form_component.ex
@@ -1,6 +1,7 @@
 defmodule BrightWeb.Admin.SkillUnitLive.FormComponent do
   use BrightWeb, :live_component
 
+  alias BrightWeb.TimelineHelper
   alias Bright.SkillUnits
 
   @impl true
@@ -20,6 +21,10 @@ defmodule BrightWeb.Admin.SkillUnitLive.FormComponent do
         phx-submit="save"
       >
         <.input field={@form[:name]} type="text" label="Name" />
+        <label class="block text-sm font-semibold leading-6 text-zinc-800 !mt-2">LockedDate</label>
+        <p class="!mt-2 ml-2"><%= @form[:locked_date].value || @locked_date %></p>
+        <.input field={@form[:locked_date]} type="hidden" value={@form[:locked_date].value || @locked_date} />
+
         <.label>Skill categories</.label>
         <.inputs_for :let={scf} field={@form[:skill_categories]}>
           <input type="hidden" name="skill_unit[skill_categories_sort][]" value={scf.index} />
@@ -71,6 +76,10 @@ defmodule BrightWeb.Admin.SkillUnitLive.FormComponent do
 
   @impl true
   def update(%{skill_unit: skill_unit} = assigns, socket) do
+    # 現スキルパネルを操作しているためlocked_dateを1つ前のバッチ更新日相当日付としている
+    timeline = TimelineHelper.get_current()
+    locked_date = TimelineHelper.get_shift_date_from_date(timeline.future_date, -1)
+
     skill_class_options =
       Bright.SkillPanels.list_skill_classes()
       |> Bright.Repo.preload(:skill_panel)
@@ -87,7 +96,8 @@ defmodule BrightWeb.Admin.SkillUnitLive.FormComponent do
      socket
      |> assign(assigns)
      |> assign(:skill_class_options, skill_class_options)
-     |> assign_form(changeset)}
+     |> assign_form(changeset)
+     |> assign(:locked_date, locked_date)}
   end
 
   @impl true

--- a/lib/bright_web/live/admin/skill_unit_live/index.ex
+++ b/lib/bright_web/live/admin/skill_unit_live/index.ex
@@ -20,19 +20,19 @@ defmodule BrightWeb.Admin.SkillUnitLive.Index do
 
   defp apply_action(socket, :edit, %{"id" => id}) do
     socket
-    |> assign(:page_title, "Edit Skill panel")
+    |> assign(:page_title, "Edit Skill unit")
     |> assign(:skill_unit, SkillUnits.get_skill_unit!(id))
   end
 
   defp apply_action(socket, :new, _params) do
     socket
-    |> assign(:page_title, "New Skill panel")
+    |> assign(:page_title, "New Skill unit")
     |> assign(:skill_unit, %SkillUnit{})
   end
 
   defp apply_action(socket, :index, _params) do
     socket
-    |> assign(:page_title, "Listing Skill panels")
+    |> assign(:page_title, "Listing Skill units")
     |> assign(:skill_unit, nil)
   end
 

--- a/test/factories/skill_unit_factory.ex
+++ b/test/factories/skill_unit_factory.ex
@@ -7,7 +7,8 @@ defmodule Bright.SkillUnitFactory do
     quote do
       def skill_unit_factory do
         %Bright.SkillUnits.SkillUnit{
-          name: Faker.Lorem.word()
+          name: Faker.Lorem.word(),
+          locked_date: ~D[2023-07-01]
         }
       end
 


### PR DESCRIPTION
## 対応内容

close #1478 

管理側スキルクラスとスキルユニット作成時のlocked_dateを適当な日付に変更しました。
詳細はissueをご参照ください。

## 周知事項

既存データにおいて古い日付が入っている可能性があります。
本PRマージで今後は対応不要になりますが、最後に一度 locked_dateを2024-04-01にしてください。

## 参考画像

**管理側、スキルクラスの作成画面**

![スクリーンショット 2024-05-27 104229](https://github.com/bright-org/bright/assets/121112529/64b50213-0a89-47f8-a44a-a59c02f1ee55)

**管理側、スキルユニットの作成画面**

![スクリーンショット 2024-05-27 103605](https://github.com/bright-org/bright/assets/121112529/1ae44b8d-6857-4087-91e9-4bd3c39dae94)
