### PR TITLE
面談チャットのフィルター「採用選考中」→「採用選考中／採用確定／配属調整中」に変更

### DIFF
--- a/lib/bright_web/live/chat_live/index.ex
+++ b/lib/bright_web/live/chat_live/index.ex
@@ -16,7 +16,7 @@ defmodule BrightWeb.ChatLive.Index do
     %{name: "面談打診中", value: :waiting_decision},
     %{name: "面談確定待ち", value: :consume_interview},
     %{name: "面談確定", value: :ongoing_interview},
-    %{name: "採用選考中", value: :completed_interview},
+    %{name: "採用選考中／採用確定／配属調整中", value: :completed_interview},
     %{name: "面談キャンセル", value: :cancel_interview},
     %{name: "（すべて）", value: :recruit}
   ]
@@ -305,14 +305,14 @@ defmodule BrightWeb.ChatLive.Index do
       data-dropdown-placement="bottom"
     >
       <bottun
-        class="text-left flex items-center text-base p-1 rounded border border-brightGray-100 bg-white  w-[220px] hover:bg-brightGray-50 dropdownTrigger"
+        class="text-left flex items-center text-base p-1 rounded border border-brightGray-100 bg-white  w-[270px] hover:bg-brightGray-50 dropdownTrigger"
         type="button"
       >
         <%= get_display_name(@select_filter_type) %>
       </bottun>
       <!-- menue list-->
       <div
-        class="dropdownTarget z-30 hidden bg-white rounded-sm shadow static w-[220px]"
+        class="dropdownTarget z-30 hidden bg-white rounded-sm shadow static w-[270px]"
       >
         <ul>
           <%= for filter_type <- @filter_types do %>


### PR DESCRIPTION
このPRは「文言の変更のみ」です
![image](https://github.com/bright-org/bright/assets/13599847/a38d841e-a905-4cf5-880d-9efd9ea3787f)
