### PR TITLE
チャット右側の人アイコンをクリックしたら、その人の成長パネルに飛ぶようにしたい

### DIFF
--- a/lib/bright_web/live/chat_live/chat_components.ex
+++ b/lib/bright_web/live/chat_live/chat_components.ex
@@ -184,7 +184,7 @@ defmodule BrightWeb.ChatLive.ChatComponents do
 
   attr :path, :any
   attr :has_link, :boolean, default: false
-  attr :url, :string, required: true
+  attr :url, :string, default: nil
 
   def user_icon(%{has_link: true} = assigns) do
     ~H"""


### PR DESCRIPTION
タイトル通り
・匿名は 匿名として成長パネルに飛ぶ
・それ以外は通常の成長パネルに飛ぶ


https://github.com/bright-org/bright/assets/13599847/e91425aa-2609-4e39-b94e-d033c3a9ae20


