### PR TITLE
ボタンホバー時に opacity ではなく filter にする

### DIFF
--- a/lib/bright_web/components/bright_button_components.ex
+++ b/lib/bright_web/components/bright_button_components.ex
@@ -24,7 +24,7 @@ defmodule BrightWeb.BrightButtonComponents do
     ~H"""
     <button
       type="button"
-      class="text-brightGreen-300 bg-white px-1 inline-flex rounded-md min-w-[60px] text-[10px] items-center border border-brightGreen-300 font-bold lg:px-2 lg:py-1 lg:text-sm hover:opacity-50"
+      class="text-brightGreen-300 bg-white px-1 inline-flex rounded-md min-w-[60px] text-[10px] items-center border border-brightGreen-300 font-bold lg:px-2 lg:py-1 lg:text-sm hover:filter hover:brightness-95"
       {@rest}
     >
       <%= render_slot(@inner_block) %>
@@ -128,7 +128,7 @@ defmodule BrightWeb.BrightButtonComponents do
     >
       <button
         type="button"
-        class="text-white bg-planUpgrade-600 px-1 inline-flex justify-center rounded-md text-xs items-center font-bold h-9 w-full hover:opacity-70 lg:px-2 lg:text-sm"
+        class="text-white bg-planUpgrade-600 px-1 inline-flex justify-center rounded-md text-xs items-center font-bold h-9 w-full hover:filter hover:brightness-95 lg:px-2 lg:text-sm"
       >
         <span class="material-icons mr-1 material-icons-outlined lg:mr-2">upgrade</span>
         アップグレード
@@ -153,7 +153,7 @@ defmodule BrightWeb.BrightButtonComponents do
       rel="noopener noreferrer"
     >
       <button type="button"
-        class="text-white bg-brightGreen-300 px-1 inline-flex rounded-md text-xs items-center justify-center font-bold h-9 w-full hover:opacity-70 lg:px-2 lg:text-sm">
+        class="text-white bg-brightGreen-300 px-1 inline-flex rounded-md text-xs items-center justify-center font-bold h-9 w-full hover:filter hover:brightness-95 lg:px-2 lg:text-sm">
         <span
             class="material-icons mr-1 material-icons-outlined lg:mr-2">sms</span>
         カスタマーサクセスに連絡

--- a/lib/bright_web/components/bright_core_components.ex
+++ b/lib/bright_web/components/bright_core_components.ex
@@ -96,7 +96,7 @@ defmodule BrightWeb.BrightCoreComponents do
     <button
       type={@type}
       class={[
-        "bg-brightGray-900 border border-solid border-brightGray-900 cursor-pointer font-bold px-4 py-2 rounded select-none text-center text-white w-80 hover:opacity-50",
+        "bg-brightGray-900 border border-solid border-brightGray-900 cursor-pointer font-bold px-4 py-2 rounded select-none text-center text-white w-80 hover:filter hover:brightness-95",
         "phx-submit-loading:opacity-75",
         @class
       ]}
@@ -119,7 +119,7 @@ defmodule BrightWeb.BrightCoreComponents do
 
   def action_button(%{icon: nil} = assigns) do
     ~H"""
-    <button type={@type} class={["bg-brightGray-10 text-xs lg:text-sm font-bold rounded border border-base hover:opacity-50", @class]} {@rest}>
+    <button type={@type} class={["bg-brightGray-10 text-xs lg:text-sm font-bold rounded border border-base hover:filter hover:brightness-95", @class]} {@rest}>
       <%= render_slot(@inner_block) %>
     </button>
     """
@@ -129,7 +129,7 @@ defmodule BrightWeb.BrightCoreComponents do
     ~H"""
     <button
       type={@type}
-      class={["bg-brightGray-10 text-xs lg:text-sm font-bold border border-base rounded flex items-center hover:opacity-50", @class]}
+      class={["bg-brightGray-10 text-xs lg:text-sm font-bold border border-base rounded flex items-center hover:filter hover:brightness-95", @class]}
       @rest
     >
       <%= render_slot(@inner_block) %>

--- a/lib/bright_web/components/mega_menu_components.ex
+++ b/lib/bright_web/components/mega_menu_components.ex
@@ -43,7 +43,7 @@ defmodule BrightWeb.MegaMenuComponents do
       data-dropdown-placement="bottom"
     >
       <button
-        class="dropdownTrigger text-white bg-brightGreen-300 rounded-md py-1.5 pl-3 flex items-center font-bold hover:opacity-50"
+        class="dropdownTrigger text-white bg-brightGreen-300 rounded-md py-1.5 pl-3 flex items-center font-bold hover:filter hover:brightness-95"
         type="button"
       >
         <span class="inline-flex gap-x-2 min-w-[4em] lg:min-w-[6em]">

--- a/lib/bright_web/components/team_components.ex
+++ b/lib/bright_web/components/team_components.ex
@@ -134,7 +134,7 @@ defmodule BrightWeb.TeamComponents do
       </h3>
       <button
         :if={show_star_button?(@current_users_team_member)}
-        class={"bg-white border border-#{get_star_style(@current_users_team_member)} rounded px-1 h-8 flex items-center mt-auto mb-1"}
+        class={"bg-white border border-#{get_star_style(@current_users_team_member)} rounded px-1 h-8 flex items-center mt-auto mb-1 hover:filter hover:brightness-95"}
         phx-click="click_star_button"
       >
         <span class={"material-icons text-#{get_star_style(@current_users_team_member)}"}>

--- a/lib/bright_web/components/timeline_bar_components.ex
+++ b/lib/bright_web/components/timeline_bar_components.ex
@@ -139,7 +139,7 @@ defmodule BrightWeb.TimelineBarComponents do
         phx-value-id={@id}
         phx-value-date={@date}
         phx-target={@target}
-        class={["rounded-full bg-white text-xs flex justify-center items-center h-12 w-12 lg:h-16 lg:w-16 hover:opacity-50", button_scale_class(@scale), button_style_class(@scale)]}
+        class={["rounded-full bg-white text-xs flex justify-center items-center h-12 w-12 lg:h-16 lg:w-16 hover:filter hover:brightness-95", button_scale_class(@scale), button_style_class(@scale)]}
       >
         <%= @date %>
       </button>
@@ -184,7 +184,7 @@ defmodule BrightWeb.TimelineBarComponents do
         phx-value-id={@id}
         phx-value-date="now"
         phx-target={@target}
-        class={["rounded-full bg-white text-xs text-attention-900 flex justify-center items-center h-[44px] w-[44px] hover:opacity-50", button_now_scale_class(@scale), button_style_class(@scale)]}
+        class={["rounded-full bg-white text-xs text-attention-900 flex justify-center items-center h-[44px] w-[44px] hover:filter hover:brightness-95", button_now_scale_class(@scale), button_style_class(@scale)]}
       >
         現在
       </button>
@@ -201,7 +201,7 @@ defmodule BrightWeb.TimelineBarComponents do
       phx-click="timeline_bar_close_button_click"
       phx-value-id={@id}
       phx-target={@target}
-      class="absolute right-0 -top-2 border rounded-full w-6 h-6 flex justify-center items-center bg-white border-brightPurple-300 hover:opacity-50"
+      class="absolute right-0 -top-2 border rounded-full w-6 h-6 flex justify-center items-center bg-white border-brightPurple-300 hover:filter hover:brightness-95"
     >
       <span class="material-icons text-brightPurple-300">close</span>
     </button>

--- a/lib/bright_web/live/card_live/related_team_card_component.ex
+++ b/lib/bright_web/live/card_live/related_team_card_component.ex
@@ -103,7 +103,7 @@ defmodule BrightWeb.CardLive.RelatedTeamCardComponent do
                 <div class="text-base">支援中の採用・育成先チームはありません</div>
                 <p class="my-4">
                   <a href="https://bright-fun.org/plan" class="w-[calc(45%-6px)] lg:w-56" rel="noopener noreferrer" target="_blank">
-                    <button type="button" class="text-white bg-planUpgrade-600 px-1 inline-flex justify-center rounded-md text-xs items-center font-bold h-9 w-full hover:opacity-70 lg:px-2 lg:text-sm">
+                    <button type="button" class="text-white bg-planUpgrade-600 px-1 inline-flex justify-center rounded-md text-xs items-center font-bold h-9 w-full hover:filter hover:brightness-95 lg:px-2 lg:text-sm">
                       <span class="bg-white material-icons mr-1 !text-sm !text-planUpgrade-600 rounded-full h-5 w-5 !font-bold material-icons-outlined lg:mr-2 lg:h-6 lg:w-6">upgrade</span>
                       アップグレード
                     </button>

--- a/lib/bright_web/live/chat_live/chat_components.ex
+++ b/lib/bright_web/live/chat_live/chat_components.ex
@@ -88,7 +88,7 @@ defmodule BrightWeb.ChatLive.ChatComponents do
           <div class="flex justify-end gap-x-4">
             <%= for file <- Enum.filter(@message.files, & &1.file_type == :images) do %>
               <div
-                class="cursor-pointer hover:opacity-50"
+                class="cursor-pointer hover:opacity-70"
                 phx-click="preview"
                 phx-value-preview={file.file_path}
               >
@@ -100,7 +100,7 @@ defmodule BrightWeb.ChatLive.ChatComponents do
           <div class="flex justify-end mt-4 gap-x-4">
             <%= for file <- Enum.filter(@message.files, & &1.file_type == :files) do %>
               <a
-                class="cursor-pointer hover:opacity-50 underline"
+                class="cursor-pointer hover:opacity-70 underline"
                 href={Storage.public_url(file.file_path)}
                 target="_blank"
                 rel="noopener"
@@ -131,7 +131,7 @@ defmodule BrightWeb.ChatLive.ChatComponents do
       <div class="flex justify-start">
         <%= for file <- Enum.filter(@message.files, & &1.file_type == :images) do %>
           <div
-            class="cursor-pointer hover:opacity-50"
+            class="cursor-pointer hover:opacity-70"
             phx-click="preview"
             phx-value-preview={file.file_path}
           >
@@ -143,7 +143,7 @@ defmodule BrightWeb.ChatLive.ChatComponents do
       <div class="w-full flex flex-col justify-end mt-4">
         <%= for file <- Enum.filter(@message.files, & &1.file_type == :files) do %>
           <a
-            class="cursor-pointer hover:opacity-50 underline text-xl"
+            class="cursor-pointer hover:opacity-70 underline text-xl"
             href={Storage.public_url(file.file_path)}
             target="_blank"
             rel="noopener"

--- a/lib/bright_web/live/graph_live/graphs.html.heex
+++ b/lib/bright_web/live/graph_live/graphs.html.heex
@@ -21,7 +21,7 @@
           patch={~p"/panels/#{@skill_panel}/edit?#{@query}"}
           id="link-skills-form"
           class={[
-            "w-56 flex-1 flex items-center text-sm font-bold justify-center px-4 py-1.5 relative rounded-md !text-white bg-brightGray-900 hover:opacity-50"
+            "w-56 flex-1 flex items-center text-sm font-bold justify-center px-4 py-1.5 relative rounded-md !text-white bg-brightGray-900 hover:filter hover:brightness-90"
           ]}
         >
           <span class="material-icons-outlined text-white text-md">edit</span> スキルを入力する
@@ -30,7 +30,7 @@
         <div
           :if={@me}
           id="btn-help-enter-skills-button"
-          class="flex-none cursor-pointer w-8 h-8 hover:opacity-50 bg-[url('/images/icon_help.svg')]"
+          class="flex-none cursor-pointer w-8 h-8 hover:filter hover:brightness-90 bg-[url('/images/icon_help.svg')]"
           phx-click={
             JS.push("open", target: "#help-enter-skills-button")
             |> show("#help-enter-skills-button")
@@ -163,7 +163,7 @@
                 <button
                   phx-click="open_income_consultation"
                   type="button"
-                  class="text-white bg-brightGreen-300 px-1 inline-flex rounded-md text-xs items-center justify-center font-bold h-9 w-full hover:opacity-70 lg:px-2 lg:text-sm"
+                  class="text-white bg-brightGreen-300 px-1 inline-flex rounded-md text-xs items-center justify-center font-bold h-9 w-full hover:filter hover:brightness-95 lg:px-2 lg:text-sm"
                 >
                   報酬アップを相談する
                 </button>

--- a/lib/bright_web/live/notification_live/community.ex
+++ b/lib/bright_web/live/notification_live/community.ex
@@ -20,13 +20,13 @@ defmodule BrightWeb.NotificationLive.Community do
         </li>
         <%= for notification <- @notifications do %>
           <li class="flex flex-wrap my-5">
-            <div phx-click="confirm_notification" phx-value-notification_community_id={notification.id} class="cursor-pointer hover:opacity-70 text-left flex flex-wrap items-center text-base px-1 py-1 flex-1 mr-4 w-full lg:w-auto lg:flex-nowrap truncate">
+            <div phx-click="confirm_notification" phx-value-notification_community_id={notification.id} class="cursor-pointer hover:filter hover:brightness-90 text-left flex flex-wrap items-center text-base px-1 py-1 flex-1 mr-4 w-full lg:w-auto lg:flex-nowrap truncate">
               <img src="/images/common/icons/community.svg" class="w-6 h-6 mr-2.5" />
               <span class={"order-3 lg:order-2 flex-1 mr-2 truncate"}><%= notification.message %></span>
               <.elapsed_time inserted_at={notification.inserted_at} />
             </div>
             <div class="flex gap-x-2 w-full justify-end lg:justify-start lg:w-auto">
-              <button phx-click="confirm_notification" phx-value-notification_community_id={notification.id} class="hidden hover:opacity-70 font-bold lg:inline-block bg-brightGray-900 text-white min-w-[76px] rounded p-2 text-sm">
+              <button phx-click="confirm_notification" phx-value-notification_community_id={notification.id} class="hidden hover:filter hover:brightness-90 font-bold lg:inline-block bg-brightGray-900 text-white min-w-[76px] rounded p-2 text-sm">
                 内容を見る
               </button>
             </div>

--- a/lib/bright_web/live/notification_live/evidence.ex
+++ b/lib/bright_web/live/notification_live/evidence.ex
@@ -24,7 +24,7 @@ defmodule BrightWeb.NotificationLive.Evidence do
         </li>
         <%= for notification <- @notifications do %>
           <li class="flex flex-wrap my-5">
-            <div phx-click="click" phx-value-notification_evidence_id={notification.id} class="cursor-pointer hover:opacity-70 text-left flex flex-wrap items-center text-base px-1 py-1 flex-1 mr-4 w-full lg:w-auto lg:flex-nowrap">
+            <div phx-click="click" phx-value-notification_evidence_id={notification.id} class="cursor-pointer hover:filter hover:brightness-90 text-left flex flex-wrap items-center text-base px-1 py-1 flex-1 mr-4 w-full lg:w-auto lg:flex-nowrap">
               <span class="material-icons text-lg text-white bg-brightGreen-300 rounded-full flex w-6 h-6 mr-2.5 items-center justify-center">
                 person
               </span>
@@ -32,7 +32,7 @@ defmodule BrightWeb.NotificationLive.Evidence do
               <.elapsed_time inserted_at={notification.inserted_at} />
             </div>
             <div class="flex gap-x-2 w-full justify-end lg:justify-start lg:w-auto">
-              <button phx-click="click" phx-value-notification_evidence_id={notification.id} class="hidden hover:opacity-70 font-bold lg:inline-block bg-brightGray-900 text-white min-w-[76px] rounded p-2 text-sm">
+              <button phx-click="click" phx-value-notification_evidence_id={notification.id} class="hidden hover:filter hover:brightness-90 font-bold lg:inline-block bg-brightGray-900 text-white min-w-[76px] rounded p-2 text-sm">
                 内容を見る
               </button>
             </div>

--- a/lib/bright_web/live/notification_live/operation.ex
+++ b/lib/bright_web/live/notification_live/operation.ex
@@ -20,13 +20,13 @@ defmodule BrightWeb.NotificationLive.Operation do
         </li>
         <%= for notification <- @notifications do %>
           <li class="flex flex-wrap my-5">
-            <div phx-click="confirm_notification" phx-value-notification_operation_id={notification.id} class="cursor-pointer hover:opacity-70 text-left flex flex-wrap items-center text-base px-1 py-1 flex-1 mr-4 w-full lg:w-auto lg:flex-nowrap truncate">
+            <div phx-click="confirm_notification" phx-value-notification_operation_id={notification.id} class="cursor-pointer hover:filter hover:brightness-90 text-left flex flex-wrap items-center text-base px-1 py-1 flex-1 mr-4 w-full lg:w-auto lg:flex-nowrap truncate">
               <img src="/images/common/icons/management.svg" class="w-6 h-6 mr-2.5" />
               <span class={["order-3 lg:order-2 flex-1 mr-2 truncate"]}><%= notification.message %></span>
               <.elapsed_time inserted_at={notification.inserted_at} />
             </div>
             <div class="flex gap-x-2 w-full justify-end lg:justify-start lg:w-auto">
-              <button phx-click="confirm_notification" phx-value-notification_operation_id={notification.id} class="hidden hover:opacity-70 font-bold lg:inline-block bg-brightGray-900 text-white min-w-[76px] rounded p-2 text-sm">
+              <button phx-click="confirm_notification" phx-value-notification_operation_id={notification.id} class="hidden hover:filter hover:brightness-90 font-bold lg:inline-block bg-brightGray-900 text-white min-w-[76px] rounded p-2 text-sm">
                 内容を見る
               </button>
             </div>

--- a/lib/bright_web/live/notification_live/skill_update.ex
+++ b/lib/bright_web/live/notification_live/skill_update.ex
@@ -20,13 +20,13 @@ defmodule BrightWeb.NotificationLive.SkillUpdate do
         </li>
         <%= for notification <- @notifications do %>
           <li class="flex flex-wrap my-5">
-            <div phx-click="click" phx-value-notification_skill_update_id={notification.id} class="cursor-pointer hover:opacity-70 text-left flex flex-wrap items-center text-base px-1 py-1 flex-1 mr-4 w-full lg:w-auto lg:flex-nowrap">
+            <div phx-click="click" phx-value-notification_skill_update_id={notification.id} class="cursor-pointer hover:filter hover:brightness-90 text-left flex flex-wrap items-center text-base px-1 py-1 flex-1 mr-4 w-full lg:w-auto lg:flex-nowrap">
               <img src="/images/common/icons/skill.svg" class="w-6 h-6 mr-2.5" />
               <span class={["order-3 lg:order-2 flex-1 mr-2"]}><%= notification.message %></span>
               <.elapsed_time inserted_at={notification.inserted_at} />
             </div>
             <div class="flex gap-x-2 w-full justify-end lg:justify-start lg:w-auto">
-              <button phx-click="click" phx-value-notification_skill_update_id={notification.id} class="hidden hover:opacity-70 font-bold lg:inline-block bg-brightGray-900 text-white min-w-[76px] rounded p-2 text-sm">
+              <button phx-click="click" phx-value-notification_skill_update_id={notification.id} class="hidden hover:filter hover:brightness-90 font-bold lg:inline-block bg-brightGray-900 text-white min-w-[76px] rounded p-2 text-sm">
                 詳細を見る
               </button>
             </div>

--- a/lib/bright_web/live/onboarding_live/index.html.heex
+++ b/lib/bright_web/live/onboarding_live/index.html.heex
@@ -23,7 +23,7 @@
     <p>スキル評価やチーム育成、スカウトを行う方は、まずチームを作成してください</p>
     <a
       id="skip_onboarding"
-      class="w-full white cursor-pointer font-bold py-2 relative select-none hover:opacity-50 underline text-blue-600"
+      class="w-full white cursor-pointer font-bold py-2 relative select-none underline text-blue-600"
       phx-click="skip_onboarding">
       チームを作る
     </a>

--- a/lib/bright_web/live/onboarding_live/skill_panel.ex
+++ b/lib/bright_web/live/onboarding_live/skill_panel.ex
@@ -40,23 +40,14 @@ defmodule BrightWeb.OnboardingLive.SkillPanel do
       <p class="flex flex-col lg:flex-row gap-y-4 lg:gap-y-0 justify-center mt-8 lg:px-4 w-full lg:w-[1040px]">
         <button
           phx-click={JS.push("select_skill_panel", value: %{id: @skill_panel.id, name: @skill_panel.name, type: "input"})}
-          class="bg-brightGray-900 border border-solid border-brightGray-900 font-bold px-4 py-2 rounded select-none text-white w-full lg:w-64 hover:opacity-50"
+          class="bg-brightGray-900 border border-solid border-brightGray-900 font-bold px-4 py-2 rounded select-none text-white w-full lg:w-64 hover:filter hover:brightness-90"
         >
           このスキルでスキル入力に進む
         </button>
 
-        <!-- αは落とす
-        <button
-          phx-click={JS.push("select_skill_panel", value: %{id: @skill_panel.id, name: @skill_panel.name, type: "skillup"})}
-          class="bg-brightGray-900 border border-solid border-brightGray-900 font-bold ml-4  px-4 py-2 rounded select-none text-white w-full lg:w-64 hover:opacity-50"
-        >
-          このスキルでスキルアップに進む
-        </button>
-        -->
-
         <.link
           navigate={@return_to}
-          class="bg-white block border border-solid border-black font-bold lg:ml-16 px-4 py-2 rounded select-none text-black text-center w-full lg:w-40 hover:opacity-50"
+          class="bg-white block border border-solid border-black font-bold lg:ml-16 px-4 py-2 rounded select-none text-black text-center w-full lg:w-40 hover:filter hover:brightness-90"
         >
           戻る
         </.link>

--- a/lib/bright_web/live/onboarding_live/skill_panels.ex
+++ b/lib/bright_web/live/onboarding_live/skill_panels.ex
@@ -32,7 +32,7 @@ defmodule BrightWeb.OnboardingLive.SkillPanels do
                       navigate={"/#{@current_path}/#{@route}/#{@id}/skill_panels/#{skill_panel.id}"}
                       class={[
                         "bg-#{career_field.name_en}-dark border-#{career_field.name_en}-dark",
-                        "block border border-solid cursor-pointer font-bold px-4 py-2 rounded select-none text-white text-center w-full lg:w-60 hover:opacity-50"
+                        "block border border-solid cursor-pointer font-bold px-4 py-2 rounded select-none text-white text-center w-full lg:w-60 hover:filter hover:brightness-95"
                         ]}
                       >
                       <%= skill_panel.name %>
@@ -49,7 +49,7 @@ defmodule BrightWeb.OnboardingLive.SkillPanels do
       <p class="mt-8 w-full lg:w-[1040px]">
         <.link
           navigate={@return_to}
-          class="self-start lg:self-center bg-white block border border-solid border-black font-bold mt-4 mx-auto px-4 py-2 rounded select-none text-black text-center w-full lg:w-40 hover:opacity-50"
+          class="self-start lg:self-center bg-white block border border-solid border-black font-bold mt-4 mx-auto px-4 py-2 rounded select-none text-black text-center w-full lg:w-40 hover:filter hover:brightness-95"
         >
           戻る
         </.link>

--- a/lib/bright_web/live/onboarding_live/want_todo_components.ex
+++ b/lib/bright_web/live/onboarding_live/want_todo_components.ex
@@ -10,7 +10,7 @@ defmodule BrightWeb.OnboardingLive.WantToDoComponents do
       <ul class="flex flex-wrap gap-4 justify-center p-4 lg:justify-start">
         <!-- やりたいこと ここから -->
         <%= for wants <- @career_wants do %>
-        <li class="bg-white px-4 py-4 rounded select-none w-72 hover:opacity-50">
+        <li class="bg-white px-4 py-4 rounded select-none w-72 hover:filter hover:brightness-90">
           <.link navigate={"#{@current_path}/wants/#{wants.id}"} class="block">
             <b class="block text-center"><%= wants.name %></b>
             <div class="flex flex-wrap gap-2 justify-center mt-2 py-2">
@@ -36,7 +36,7 @@ defmodule BrightWeb.OnboardingLive.WantToDoComponents do
           placeholder="やりたいことに関連するキーワードを入れてください"
           class="border border-solid border-black placeholder-brightGray-200 px-4 py-2 rounded-l w-[512px]"
         />
-        <button class="bg-white border border-l-0 border-solid border-black font-bold -ml-4 px-4 py-2 rounded-r w-20 hover:opacity-50">
+        <button class="bg-white border border-l-0 border-solid border-black font-bold -ml-4 px-4 py-2 rounded-r w-20 hover:filter hover:brightness-90">
           検索
         </button>
         <div class="w-full"><span class="px-4 text-brightGray-300">検索結果が表示されます。</span></div>

--- a/lib/bright_web/live/onboarding_live/wants_job_components.ex
+++ b/lib/bright_web/live/onboarding_live/wants_job_components.ex
@@ -31,7 +31,7 @@ defmodule BrightWeb.OnboardingLive.WantsJobComponents do
           <li :if={false}>
             <a
               href="#"
-              class="absolute bg-brightGray-900 block cursor-pointer font-bold select-none py-2 right-0 rounded text-center text-white -top-1.5 w-48 hover:opacity-50"
+              class="absolute bg-brightGray-900 block cursor-pointer font-bold select-none py-2 right-0 rounded text-center text-white -top-1.5 w-48 hover:filter hover:brightness-90"
             >
               キャリアパスを見直す
             </a>
@@ -56,7 +56,7 @@ defmodule BrightWeb.OnboardingLive.WantsJobComponents do
               <li>
                 <.link navigate={"#{@current_path}/jobs/#{job.id}"} class="block">
                   <label
-                    class={"bg-#{@selected_career.name_en}-dark block border border-solid border-#{@selected_career.name_en}-dark cursor-pointer font-bold px-2 rounded select-none text-white text-center hover:opacity-50 min-w-[220px] h-10 leading-10"}
+                    class={"bg-#{@selected_career.name_en}-dark block border border-solid border-#{@selected_career.name_en}-dark cursor-pointer font-bold px-2 rounded select-none text-white text-center hover:filter hover:brightness-90 min-w-[220px] h-10 leading-10"}
                   >
                     <%= job.name %>
                   </label>

--- a/lib/bright_web/live/onboarding_live/welcome.ex
+++ b/lib/bright_web/live/onboarding_live/welcome.ex
@@ -23,7 +23,7 @@ defmodule BrightWeb.OnboardingLive.Welcome do
 
       <div class="flex justify-center lg:justify-start w-full">
         <.link
-          class="text-white bg-brightGreen-300 p-3 rounded-md text-base lg:text-xl font-bold hover:opacity-70"
+          class="text-white bg-brightGreen-300 p-3 rounded-md text-base lg:text-xl font-bold hover:filter hover:brightness-95"
           navigate={~p"/onboardings?open=want_todo_panel"}
         >
           自分に合ったスキルパネルを見つける

--- a/lib/bright_web/live/recruit_coordination_live/create_component.ex
+++ b/lib/bright_web/live/recruit_coordination_live/create_component.ex
@@ -94,14 +94,14 @@ defmodule BrightWeb.RecruitCoordinationLive.CreateComponent do
                   </dl>
                 </div>
                 <div class="flex justify-start gap-x-4 mt-4">
-                  <button class="text-sm font-bold py-3 rounded border border-base w-44 h-12">
+                  <button class="text-sm font-bold py-3 rounded border border-base w-44 h-12 bg-white hover:filter hover:brightness-90">
                     <.link navigate={@patch}>閉じる</.link>
                   </button>
                   <div>
                     <button
                       phx-click={JS.show(to: "#menu01")}
                       type="button"
-                      class="text-sm font-bold py-3 pl-3 rounded text-white bg-base w-40 flex items-center"
+                      class="text-sm font-bold py-3 pl-3 rounded text-white bg-base w-40 flex items-center hover:filter hover:brightness-90"
                     >
                       <span class="min-w-[6em]">選考キャンセル</span>
                       <span class="material-icons relative ml-2 px-1 before:content[''] before:absolute before:left-0 before:top-[-9px] before:bg-brightGray-200 before:w-[1px] before:h-[42px]">add</span>
@@ -141,7 +141,7 @@ defmodule BrightWeb.RecruitCoordinationLive.CreateComponent do
                     </div>
                   </div>
                   <button
-                    class="text-sm font-bold py-3 rounded text-white bg-base w-44 h-12"
+                    class="text-sm font-bold py-3 rounded text-white bg-base w-44 h-12 hover:filter hover:brightness-90"
                     type="submit"
                   >
                     採用選考する

--- a/lib/bright_web/live/recruit_interview_live/conrifm_component.ex
+++ b/lib/bright_web/live/recruit_interview_live/conrifm_component.ex
@@ -85,20 +85,20 @@ defmodule BrightWeb.RecruitInterviewLive.ConfirmComponent do
                 </div>
                 <div class="flex justify-end gap-x-4 mt-16">
                   <.link navigate={@patch}>
-                  <button class="text-sm font-bold py-3 rounded border border-base w-44">
+                  <button class="text-sm font-bold py-3 rounded border border-base w-44 hover:filter hover:brightness-90">
                   閉じる
                   </button>
                   </.link>
                   <button
                     phx-click={JS.push("decision", target: @myself, value: %{decision: :cancel_interview})}
-                    class="text-sm font-bold py-3 rounded text-white bg-base w-44"
+                    class="text-sm font-bold py-3 rounded text-white bg-base w-44 hover:filter hover:brightness-90"
                   >
                     面談をキャンセル
                   </button>
 
                   <button
                     phx-click={JS.push("decision", target: @myself, value: %{decision: :ongoing_interview})}
-                    class="text-sm font-bold py-3 rounded text-white bg-base w-44"
+                    class="text-sm font-bold py-3 rounded text-white bg-base w-44 hover:filter hover:brightness-90"
                   >
                     面談確定
                   </button>

--- a/lib/bright_web/live/recruit_interview_live/edit_component.ex
+++ b/lib/bright_web/live/recruit_interview_live/edit_component.ex
@@ -89,20 +89,20 @@ defmodule BrightWeb.RecruitInterviewLive.EditComponent do
                 </div>
                 <div class="flex justify-end gap-x-4 mt-16">
                   <.link navigate={~p"/recruits/interviews"}>
-                  <button class="text-sm font-bold py-3 rounded border border-base w-44">
+                  <button class="text-sm font-bold py-3 rounded border border-base w-44 bg-white hover:filter hover:brightness-90">
                   閉じる
                   </button>
                   </.link>
                   <button
                     phx-click={JS.push("decision", target: @myself, value: %{decision: :dismiss_interview})}
-                    class="text-sm font-bold py-3 rounded text-white bg-base w-44"
+                    class="text-sm font-bold py-3 rounded text-white bg-base w-44 hover:filter hover:brightness-90"
                   >
                     面談をキャンセル
                   </button>
 
                   <button
                     phx-click={JS.push("decision", target: @myself, value: %{decision: :consume_interview})}
-                    class="text-sm font-bold py-3 rounded text-white bg-base w-44"
+                    class="text-sm font-bold py-3 rounded text-white bg-base w-44 hover:filter hover:brightness-90"
                   >
                     面談対象者に連絡
                   </button>

--- a/lib/bright_web/live/recruit_interview_live/index.ex
+++ b/lib/bright_web/live/recruit_interview_live/index.ex
@@ -27,7 +27,7 @@ defmodule BrightWeb.RecruitInterviewLive.Index do
           <li class="flex my-5">
             <.link
               patch={~p"/recruits/interviews/#{interview.id}"}
-              class="cursor-pointer hover:opacity-70 text-left flex items-center text-base px-1 py-1 flex-1 mr-4 w-full lg:w-auto lg:flex-nowrap truncate"
+              class="cursor-pointer hover:filter hover:brightness-90 text-left flex items-center text-base px-1 py-1 flex-1 mr-4 w-full lg:w-auto lg:flex-nowrap truncate"
             >
               <div class="flex flex-col">
                 <img

--- a/lib/bright_web/live/search_live/result_components.ex
+++ b/lib/bright_web/live/search_live/result_components.ex
@@ -138,7 +138,7 @@ defmodule BrightWeb.SearchLive.ResultComponents do
       </button>
       <% end %>
       <.link
-        class="bg-white block border border-solid border-brightGreen-300 cursor-pointer mb-2 px-4 py-1 rounded select-none text-center text-brightGreen-300 font-bold w-28 hover:opacity-50"
+        class="bg-white block border border-solid border-brightGreen-300 cursor-pointer mb-2 px-4 py-1 rounded select-none text-center text-brightGreen-300 font-bold w-28 hover:filter hover:brightness-90"
         target="_blank"
         rel="noopener noreferrer"
         href={if (@anon), do: skill_panel_path("graphs",%{id: @skill_panel.skill_panel}, %{name_encrypted: encrypt_user_name(@user)},false,true)
@@ -150,7 +150,7 @@ defmodule BrightWeb.SearchLive.ResultComponents do
         成長パネル
       </.link>
       <.link
-        class="bg-white block border border-solid border-brightGreen-300 cursor-pointer px-4 py-1 rounded select-none text-center text-brightGreen-300 font-bold w-28 hover:opacity-50"
+        class="bg-white block border border-solid border-brightGreen-300 cursor-pointer px-4 py-1 rounded select-none text-center text-brightGreen-300 font-bold w-28 hover:filter hover:brightness-90"
         target="_blank"
         rel="noopener noreferrer"
         href={if (@anon), do: "/mypage/anon/#{encrypt_user_name(@user)}", else: "/mypage/#{@user.name}"

--- a/lib/bright_web/live/search_live/search_result_component.ex
+++ b/lib/bright_web/live/search_live/search_result_component.ex
@@ -85,7 +85,6 @@ defmodule BrightWeb.SearchLive.SearchResultComponent do
             </div>
           </div>
           <div :if={@search} class="flex justify-end mt-8">
-            <!--- β opacity-50 -> hover:opacity-50 に戻すこと --->
             <a
               phx-click={
                 if @hr_enabled,
@@ -97,7 +96,7 @@ defmodule BrightWeb.SearchLive.SearchResultComponent do
                     ),
                   else: JS.push("open_free_trial", target: @myself)
               }
-              class="self-center bg-base border border-solid border-brightGray-300 cursor-pointer font-bold px-4 py-2 rounded select-none text-center text-white w-56 hover:opacity-50"
+              class="self-center bg-base border border-solid border-brightGray-300 cursor-pointer font-bold px-4 py-2 rounded select-none text-center text-white w-56 hover:filter hover:brightness-90"
             >
               面談の打診
             </a>
@@ -110,7 +109,7 @@ defmodule BrightWeb.SearchLive.SearchResultComponent do
           </div>
           <div :if={!@search} class="flex justify-start mt-8">
             <.link
-              class="bg-white text-sm block border border-solid border-brightGreen-300 cursor-pointer font-bold lg:mx-2 my-1 py-1 rounded text-center select-none text-brightGreen-300 w-28 hover:opacity-50"
+              class="bg-white text-sm block border border-solid border-brightGreen-300 cursor-pointer font-bold lg:mx-2 my-1 py-1 rounded text-center select-none text-brightGreen-300 w-28 hover:filter hover:brightness-90"
               target="_blank"
               rel="noopener noreferrer"
               href={
@@ -121,7 +120,7 @@ defmodule BrightWeb.SearchLive.SearchResultComponent do
               成長パネル
             </.link>
             <.link
-              class="bg-white text-sm block border border-solid border-brightGreen-300 cursor-pointer font-bold lg:mx-2 my-1 py-1 rounded text-center select-none text-brightGreen-300 w-28 hover:opacity-50"
+              class="bg-white text-sm block border border-solid border-brightGreen-300 cursor-pointer font-bold lg:mx-2 my-1 py-1 rounded text-center select-none text-brightGreen-300 w-28 hover:filter hover:brightness-90"
               target="_blank"
               rel="noopener noreferrer"
               href={

--- a/lib/bright_web/live/search_live/user_search_component.html.heex
+++ b/lib/bright_web/live/search_live/user_search_component.html.heex
@@ -128,7 +128,7 @@
                 value={sk.index}
                 class="hidden"
               />
-              <i class="delete_skill_conditions bg-base block border border-base cursor-pointer h-4 indent-40 -ml-5 mr-1 overflow-hidden relative rounded-full w-4 before:top-1/2 before:left-1/2 before:-ml-1 before:-mt-px before:content-[''] before:block before:absolute before:w-2 before:h-0.5 before:bg-white hover:opacity-50">
+              <i class="delete_skill_conditions bg-base block border border-base cursor-pointer h-4 indent-40 -ml-5 mr-1 overflow-hidden relative rounded-full w-4 before:top-1/2 before:left-1/2 before:-ml-1 before:-mt-px before:content-[''] before:block before:absolute before:w-2 before:h-0.5 before:bg-white hover:filter hover:brightness-90">
                 スキル削除
               </i>
             </label>
@@ -166,13 +166,6 @@
               disabled={sk[:class].value in ["", nil]}
               prompt="レベル"
             />
-            <!--- αでは落とす
-        <a
-          class="bg-white border border-solid border-brightGray-900 cursor-pointer font-bold ml-6 px-2 py-1 rounded select-none text-center text-brightGray-900 w-44 hover:opacity-50"
-        >
-          スキル詳細も設定
-        </a>
-        --->
           </div>
         </.inputs_for>
       </div>
@@ -181,7 +174,7 @@
       <input type="checkbox" name="user_search[skills_sort][]" class="hidden" />
       <i
         id="set_skill_conditions"
-        class="bg-base block border border-base cursor-pointer h-4 indent-40 mx-auto overflow-hidden relative rounded-full w-4 before:top-1/2 before:left-1/2 before:-ml-1 before:-mt-px before:content-[''] before:block before:absolute before:w-2 before:h-0.5 before:bg-white after:top-1/2 after:left-1/2 after:-ml-1 after:-mt-px after:content-[''] after:block after:absolute after:w-2 after:h-0.5 after:bg-white after:rotate-90 hover:opacity-50"
+        class="bg-base block border border-base cursor-pointer h-4 indent-40 mx-auto overflow-hidden relative rounded-full w-4 before:top-1/2 before:left-1/2 before:-ml-1 before:-mt-px before:content-[''] before:block before:absolute before:w-2 before:h-0.5 before:bg-white after:top-1/2 after:left-1/2 after:-ml-1 after:-mt-px after:content-[''] after:block after:absolute after:w-2 after:h-0.5 after:bg-white after:rotate-90 hover:filter hover:brightness-90"
       >
         追加
       </i>

--- a/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
@@ -75,7 +75,7 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
                   phx-target={@myself}
                   phx-value-id={post.id}
                 >
-                  <span class="material-symbols-outlined text-brightGray-500 font-xs hover:opacity-50">delete</span>
+                  <span class="material-symbols-outlined text-brightGray-500 font-xs hover:filter hover:brightness-90">delete</span>
                 </div>
               </div>
             </div>

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -120,7 +120,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
         <button
           class={
             "inline-flex items-center font-bold rounded-l-full gap-x-2 px-6 py-2 " <>
-            if @active == "graph", do: "button-toggle-active", else: "hover:opacity-50"
+            if @active == "graph", do: "button-toggle-active", else: "hover:filter hover:brightness-90"
           }
         >
           <div
@@ -136,7 +136,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
         <button
           class={
             "inline-flex items-center font-bold rounded-r-full gap-x-2 px-4 py-2 " <>
-            if @active == "panel", do: "button-toggle-active", else: "hover:opacity-50"
+            if @active == "panel", do: "button-toggle-active", else: "hover:filter hover:brightness-90"
           }
         >
           <div
@@ -189,7 +189,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
             [
               "flex grow cursor-pointer justify-center items-center rounded-t px-1 lg:px-4 py-1 lg:py-3",
               selected_skill?(@select_skill_class, skill_class) && "text-brightGreen-300 border-x-2 border-x-brightGreen-300 border-t-2 border-t-brightGreen-300",
-              !selected_skill?(@select_skill_class, skill_class) && "hover:opacity-50 hover:text-brightGreen-300 border-x-2 border-x-brightGray-100 border-t-2 border-t-brightGray-100 border-b-2 border-b-brightGreen-300"
+              !selected_skill?(@select_skill_class, skill_class) && "hover:filter hover:brightness-90 hover:text-brightGreen-300 border-x-2 border-x-brightGray-100 border-t-2 border-t-brightGray-100 border-b-2 border-b-brightGreen-300"
             ]
           }
           phx-click="skill_class_tab_click"
@@ -227,7 +227,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
       <ul class="flex relative z-1 text-normal font-bold text-brightGray-300 text-center lg:text-md w-full">
         <%= for {skill_class, skill_class_score} <- pair_skill_class_score(@skill_classes) do %>
           <li class="w-1 lg:w-2 border-b-2 border-b-brightGreen-300"></li>
-          <li id={"class_tab_#{skill_class.class}"} class={["grow lg:grow-0 rounded-t", selected_skill?(@skill_class, skill_class) && "text-brightGreen-300 border-x-2 border-x-brightGreen-300 border-t-2 border-t-brightGreen-300", !selected_skill?(@skill_class, skill_class) && "hover:opacity-50 hover:text-brightGreen-300 border-x-2 border-x-brightGray-100 border-t-2 border-t-brightGray-100 border-b-2 border-b-brightGreen-300"]}>
+          <li id={"class_tab_#{skill_class.class}"} class={["grow lg:grow-0 rounded-t", selected_skill?(@skill_class, skill_class) && "text-brightGreen-300 border-x-2 border-x-brightGreen-300 border-t-2 border-t-brightGreen-300", !selected_skill?(@skill_class, skill_class) && "hover:filter hover:brightness-90 hover:text-brightGreen-300 border-x-2 border-x-brightGray-100 border-t-2 border-t-brightGray-100 border-b-2 border-b-brightGreen-300"]}>
             <.link
               patch={"#{@path}?#{build_query(@query, %{"class" => skill_class.class})}"}
               class="flex justify-center items-center px-1 lg:px-10 py-2"
@@ -260,7 +260,7 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
     <div class="h-screen w-full flex flex-col justify-center items-center gap-y-2">
       <p class="text-2xl lg:text-4xl">スキルパネルがありません</p>
       <p class="text-md lg:text-xl">スキルを選ぶからスキルパネルを取得しましょう</p>
-      <a href={~p"/onboardings"} class="text-xl cursor-pointer bg-brightGray-900 !text-white font-bold px-6 py-4 rounded mt-10 hover:opacity-50">
+      <a href={~p"/onboardings"} class="text-xl cursor-pointer bg-brightGray-900 !text-white font-bold px-6 py-4 rounded mt-10 hover:filter hover:brightness-90">
       スキルを選ぶ
       </a>
     </div>

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -20,7 +20,7 @@
       <.link
         patch={~p"/panels/#{@skill_panel}/edit?#{@query}"}
         id="link-skills-form"
-        class={[Map.get(@flash, "first_skills_edit") && "z-20", "w-56 flex-1 flex items-center text-sm font-bold justify-center px-4 py-1.5 relative rounded-md !text-white bg-brightGray-900 hover:opacity-50"]}>
+        class={[Map.get(@flash, "first_skills_edit") && "z-20", "w-56 flex-1 flex items-center text-sm font-bold justify-center px-4 py-1.5 relative rounded-md !text-white bg-brightGray-900 hover:filter hover:brightness-90"]}>
         <span class="material-icons-outlined text-white text-md">edit</span>
         スキルを入力する
       </.link>
@@ -28,7 +28,7 @@
       <div
         :if={@me}
         id="btn-help-enter-skills-button"
-        class="flex-none cursor-pointer w-8 h-8 hover:opacity-50 bg-[url('/images/icon_help.svg')]"
+        class="flex-none cursor-pointer w-8 h-8 hover:filter hover:brightness-90 bg-[url('/images/icon_help.svg')]"
         phx-click={JS.push("open", target: "#help-enter-skills-button") |> show("#help-enter-skills-button")}>
       </div>
     </div>

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -34,7 +34,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
         <div class="flex justify-center items-center ml-1 mr-2">
           <%= if @timeline.past_enabled do %>
             <button
-              class="w-6 h-10 bg-brightGreen-300 flex justify-center items-center rounded absolute left-4 lg:left-0 lg:relative hover:opacity-50"
+              class="w-6 h-10 bg-brightGreen-300 flex justify-center items-center rounded absolute left-4 lg:left-0 lg:relative hover:filter hover:brightness-90"
               phx-click="shift_timeline_past"
               phx-target={@myself}
             >
@@ -62,7 +62,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
         <div class="flex justify-center items-center ml-2">
           <%= if @timeline.future_enabled do %>
             <button
-              class="w-6 h-10 bg-brightGreen-300 flex justify-center items-center rounded absolute right-4 lg:right-0 lg:relative hover:opacity-50"
+              class="w-6 h-10 bg-brightGreen-300 flex justify-center items-center rounded absolute right-4 lg:right-0 lg:relative hover:filter hover:brightness-90"
               phx-click="shift_timeline_future"
               phx-target={@myself}
               disabled={!@timeline.future_enabled}

--- a/lib/bright_web/live/skill_panel_live/skills_form_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_form_component.ex
@@ -27,11 +27,11 @@ defmodule BrightWeb.SkillPanelLive.SkillsFormComponent do
   # スコアと対応するHTML class属性
   @score_mark_class %{
     "high" =>
-      "bg-white border border-brightGray-300 flex cursor-pointer h-6 items-center justify-center rounded w-6 before:content-[''] before:h-4 before:w-4 before:rounded-full before:bg-brightGray-300 before:block peer-checked:bg-brightGreen-300 peer-checked:border-brightGreen-300 peer-checked:before:bg-white hover:opacity-50",
+      "bg-white border border-brightGray-300 flex cursor-pointer h-6 items-center justify-center rounded w-6 before:content-[''] before:h-4 before:w-4 before:rounded-full before:bg-brightGray-300 before:block peer-checked:bg-brightGreen-300 peer-checked:border-brightGreen-300 peer-checked:before:bg-white hover:filter hover:brightness-95",
     "middle" =>
-      "bg-white border border-brightGray-300 flex cursor-pointer h-6 items-center justify-center rounded w-6 before:content-[''] before:h-0 before:w-0 before:border-solid before:border-t-0 before:border-r-8 before:border-l-8 before:border-transparent before:border-b-[14px] before:border-b-brightGray-300 peer-checked:bg-brightGreen-300 peer-checked:border-brightGreen-300 peer-checked:before:border-b-white hover:opacity-50",
+      "bg-white border border-brightGray-300 flex cursor-pointer h-6 items-center justify-center rounded w-6 before:content-[''] before:h-0 before:w-0 before:border-solid before:border-t-0 before:border-r-8 before:border-l-8 before:border-transparent before:border-b-[14px] before:border-b-brightGray-300 peer-checked:bg-brightGreen-300 peer-checked:border-brightGreen-300 peer-checked:before:border-b-white hover:filter hover:brightness-95",
     "low" =>
-      "bg-white border border-brightGray-300 flex cursor-pointer h-6 items-center justify-center rounded w-6 before:content-[''] before:block before:w-4 before:h-1 before:bg-brightGray-300 peer-checked:bg-brightGreen-300 peer-checked:border-brightGreen-300 peer-checked:before:bg-white hover:opacity-50"
+      "bg-white border border-brightGray-300 flex cursor-pointer h-6 items-center justify-center rounded w-6 before:content-[''] before:block before:w-4 before:h-1 before:bg-brightGray-300 peer-checked:bg-brightGreen-300 peer-checked:border-brightGreen-300 peer-checked:before:bg-white hover:filter hover:brightness-95"
   }
 
   @local_storage_backup_key "skills"

--- a/lib/bright_web/live/team_live/my_team_live.html.heex
+++ b/lib/bright_web/live/team_live/my_team_live.html.heex
@@ -4,7 +4,7 @@
     <div class="flex flex-col gap-y-4 lg:gap-x-4">
       <div class="flex flex-col lg:flex-row gap-4">
         <.link navigate={~p"/teams/new"}>
-          <button class="inline-flex gap-x-2 justify-center text-sm text-center font-bold px-4 py-1.5 rounded-md text-white bg-base w-full lg:w-52 hover:opacity-50">
+          <button class="inline-flex gap-x-2 justify-center text-sm text-center font-bold px-4 py-1.5 rounded-md text-white bg-base w-full lg:w-52 hover:filter hover:brightness-90">
             <div
               class={[
                 "inline-block h-6 w-6 [mask-image:url('/images/common/icons/teamAdd.svg')] [mask-position:center_center] [mask-size:100%] [mask-repeat:no-repeat] bg-white"]
@@ -18,14 +18,14 @@
           :if={Teams.is_admin?(@display_team, @current_user)}
           navigate={~p"/teams/#{@display_team.id}/edit"}
           >
-          <button class="inline-flex gap-x-2 justify-center text-sm text-center font-bold px-4 py-1.5 rounded-md text-white bg-base w-full lg:w-52 hover:opacity-50">
+          <button class="inline-flex gap-x-2 justify-center text-sm text-center font-bold px-4 py-1.5 rounded-md text-white bg-base w-full lg:w-52 hover:filter hover:brightness-90">
             <span class="material-icons-outlined text-white text-md">edit</span>
             チームを編集（β）
           </button>
         </.link>
         <button
           :if={!is_nil(@display_team) && Teams.is_admin?(@display_team, @current_user)}
-          class="inline-flex gap-x-2 justify-center text-sm text-center font-bold px-4 py-1.5 rounded-md text-white bg-base w-full lg:w-64 hover:opacity-50"
+          class="inline-flex gap-x-2 justify-center text-sm text-center font-bold px-4 py-1.5 rounded-md text-white bg-base w-full lg:w-64 hover:filter hover:brightness-90"
           phx-click="toggle_show_hr_support_modal"
           phx-value-team_id={@display_team.id}
         >
@@ -145,7 +145,7 @@
     <.team_skill_summary_table level_count={@level_count} />
     <form id="filter-form" phx-submit="filter">
       <input type="text" name="filter_name" value={@filter_name} placeholder="ハンドル名で絞り込みできます" class="input w-64">
-      <button class="text-sm font-bold p-2 rounded border bg-base text-white hover:opacity-50">
+      <button class="text-sm font-bold p-2 rounded border bg-base text-white hover:filter hover:brightness-90">
         絞り込み
       </button>
     </form>

--- a/lib/bright_web/live/team_live/team_create_live_component.html.heex
+++ b/lib/bright_web/live/team_live/team_create_live_component.html.heex
@@ -75,7 +75,7 @@
                 チームを削除する
               </button>
             </.link>
-            <button type="submit" class="text-sm font-bold px-5 py-3 rounded text-white bg-base">
+            <button type="submit" class="text-sm font-bold px-5 py-3 rounded text-white bg-base hover:filter hover:brightness-90">
               <%= @submit %>
             </button>
           </div>

--- a/lib/bright_web/live/team_live/team_member_skill_card_component.ex
+++ b/lib/bright_web/live/team_live/team_member_skill_card_component.ex
@@ -40,7 +40,7 @@ defmodule BrightWeb.TeamMemberSkillCardComponent do
               />
             </div>
             <.link
-              class="text-xl w-40 lg:w-56 truncate lg:text-2xl font-bold hover:opacity-50"
+              class="text-xl w-40 lg:w-56 truncate lg:text-2xl font-bold hover:opacity-70"
               navigate={~p"/mypage/#{if me, do: "", else: @display_skill_card.user.name}"}
             >
               <%= @display_skill_card.user.name %>
@@ -49,7 +49,7 @@ defmodule BrightWeb.TeamMemberSkillCardComponent do
           <div class="flex gap-x-1 lg:gap-x-2">
             <.link
               :if={!is_nil(@display_skill_card.user_skill_class_score)}
-              class="h-8 bg-white flex items-center justify-center border border-solid border-brightGreen-300 px-1 rounded text-center hover:opacity-50"
+              class="h-8 bg-white flex items-center justify-center border border-solid border-brightGreen-300 px-1 rounded text-center hover:filter hover:brightness-95"
               href={
                     skill_panel_path("graphs",@display_skill_panel, @display_skill_card.user, me, false)
                     <> "?class=#{@display_skill_card.select_skill_class.class}"
@@ -60,7 +60,7 @@ defmodule BrightWeb.TeamMemberSkillCardComponent do
 
             <.link
               :if={!is_nil(@display_skill_card.user_skill_class_score)}
-              class="h-8 bg-white flex items-center justify-center border border-solid border-brightGreen-300 px-1 rounded text-center hover:opacity-50"
+              class="h-8 bg-white flex items-center justify-center border border-solid border-brightGreen-300 px-1 rounded text-center hover:filter hover:brightness-95"
               href={
                     skill_panel_path("panels",@display_skill_panel, @display_skill_card.user, me, false)
                     <> "?class=#{@display_skill_card.select_skill_class.class}"
@@ -126,7 +126,7 @@ defmodule BrightWeb.TeamMemberSkillCardComponent do
       <div class="pb-2 flex w-full gap-x-1 lg:gap-x-2 justify-around">
         <button
           :if={@display_skill_card.user.id != @current_user.id}
-          class="flex gap-x-1 lg:gap-x-2 items-center text-xs lg:text-sm font-bold px-1 lg:px-3 py-2 rounded text-white bg-base hover:opacity-50"
+          class="flex gap-x-1 lg:gap-x-2 items-center text-xs lg:text-sm font-bold px-1 lg:px-3 py-2 rounded text-white bg-base hover:filter hover:brightness-90"
           phx-click={
             if @hr_enabled,
               do:
@@ -145,7 +145,7 @@ defmodule BrightWeb.TeamMemberSkillCardComponent do
         <%= if @display_skill_card.user.id == @current_user.id do %>
           <%= if !is_nil(@display_skill_panel) && is_nil(@display_skill_card.user_skill_class_score) do %>
             <.link navigate={~p"/more_skills/teams/#{@team_id}/skill_panels/#{@display_skill_panel}"}>
-              <button class="flex gap-x-1 lg:gap-x-2 items-center text-xs lg:text-sm font-bold px-1 lg:px-3 py-2 rounded text-white bg-base hover:opacity-50">
+              <button class="flex gap-x-1 lg:gap-x-2 items-center text-xs lg:text-sm font-bold px-1 lg:px-3 py-2 rounded text-white bg-base hover:filter hover:brightness-90">
                 <div class={[
                   "inline-block h-4 w-4 lg:h-6 lg:w-6 [mask-image:url('/images/common/icons/skillSelect.svg')] [mask-position:center_center] [mask-size:100%] [mask-repeat:no-repeat] bg-white"
                 ]} /> スキルを取得

--- a/lib/bright_web/live/user_auth_components.ex
+++ b/lib/bright_web/live/user_auth_components.ex
@@ -208,7 +208,7 @@ defmodule BrightWeb.UserAuthComponents do
 
   def link_button(assigns) do
     ~H"""
-    <.link href={@href} class="text-center bg-white border border-solid border-black font-bold mt-16 mx-auto px-4 py-2 rounded select-none text-black w-40 hover:opacity-50">
+    <.link href={@href} class="text-center bg-white border border-solid border-black font-bold mt-16 mx-auto px-4 py-2 rounded select-none text-black w-40">
       <%= render_slot(@inner_block) %>
     </.link>
     """
@@ -226,7 +226,7 @@ defmodule BrightWeb.UserAuthComponents do
     ~H"""
     <button
       class={[
-        "bg-brightGray-900 border border-solid border-brightGray-900 font-bold max-w-xs px-4 py-2 rounded select-none text-white w-full hover:opacity-50 disabled:bg-gray-400 disabled:border-gray-400",
+        "bg-brightGray-900 border border-solid border-brightGray-900 font-bold max-w-xs px-4 py-2 rounded select-none text-white w-full hover:filter hover:brightness-90 disabled:bg-gray-400 disabled:border-gray-400",
         @variant == "normal" && "mt-12",
         @variant == "mx-auto" && "mt-12 mx-auto",
         @variant == "mt-sm" && "mt-8",
@@ -257,7 +257,7 @@ defmodule BrightWeb.UserAuthComponents do
       <button
         type="button"
         class={[
-          "bg-no-repeat border-solid bg-5 bg-left-2.5 border font-bold max-w-xs px-4 py-2 rounded select-none w-full hover:opacity-50",
+          "bg-no-repeat border-solid bg-5 bg-left-2.5 border font-bold max-w-xs px-4 py-2 rounded select-none w-full hover:filter hover:brightness-90",
           @variant == "google" && "bg-bgGoogle border-black mt-4 text-black",
           @variant == "github" && "bg-bgGithub bg-sns-github border-github mt-6 text-white",
           @variant == "facebook" && "bg-bgFacebook bg-gray-400 border-facebook mt-6 text-white",

--- a/lib/bright_web/live/user_settings_live/auth_setting_component.ex
+++ b/lib/bright_web/live/user_settings_live/auth_setting_component.ex
@@ -36,7 +36,7 @@ defmodule BrightWeb.UserSettingsLive.AuthSettingComponent do
             </label>
 
             <div class="lg:ml-4 mt-1 py-4 w-full lg:w-fit">
-              <button type="submit" class="bg-brightGray-900 block border border-solid border-brightGray-900 cursor-pointer font-bold px-2 py-1 rounded select-none text-center text-white w-full lg:w-28 hover:opacity-50">保存する</button>
+              <button type="submit" class="bg-brightGray-900 block border border-solid border-brightGray-900 cursor-pointer font-bold px-2 py-1 rounded select-none text-center text-white w-full lg:w-28 hover:filter hover:brightness-90">保存する</button>
             </div>
           </div>
         </.form>
@@ -57,7 +57,7 @@ defmodule BrightWeb.UserSettingsLive.AuthSettingComponent do
                 <input type="text" size="20" name={"sub_mail_#{index}"} value={user_sub_email.email} class="bg-brightGray-50 border border-brightGray-200 px-2 py-1 rounded w-60" disabled>
               </label>
               <div class="mt-1 ml-auto w-fit">
-                <button id={"delete_sub_email_button_#{index}"} phx-click="delete_sub_email" phx-value-sub_email={user_sub_email.email} phx-target={@myself} type="button" class="mail_delete bg-white block border border-solid border-brightGray-900 cursor-pointer font-bold my-0.5 px-2 py-1 rounded select-none text-center text-brightGray-900 w-28 hover:opacity-50">削除する</button>
+                <button id={"delete_sub_email_button_#{index}"} phx-click="delete_sub_email" phx-value-sub_email={user_sub_email.email} phx-target={@myself} type="button" class="mail_delete bg-white block border border-solid border-brightGray-900 cursor-pointer font-bold my-0.5 px-2 py-1 rounded select-none text-center text-brightGray-900 w-28 hover:filter hover:brightness-90">削除する</button>
               </div>
             </div>
 
@@ -80,7 +80,7 @@ defmodule BrightWeb.UserSettingsLive.AuthSettingComponent do
                 />
               </label>
               <div class="mt-1 ml-auto w-fit">
-                <button type="submit" class="bg-brightGray-900 block border border-solid border-brightGray-900 cursor-pointer font-bold px-2 py-1 rounded select-none text-center text-white w-28 hover:opacity-50">追加する</button>
+                <button type="submit" class="bg-brightGray-900 block border border-solid border-brightGray-900 cursor-pointer font-bold px-2 py-1 rounded select-none text-center text-white w-28 hover:filter hover:brightness-90">追加する</button>
               </div>
             </.form>
           </div>
@@ -143,7 +143,7 @@ defmodule BrightWeb.UserSettingsLive.AuthSettingComponent do
             </label>
           </div>
           <div class="w-full mt-4 lg:mt-0 lg:absolute lg:right-0 lg:bottom-0 lg:w-fit">
-            <button type="submit" class="bg-brightGray-900 block border border-solid border-brightGray-900 cursor-pointer font-bold px-2 py-1 rounded select-none text-center text-white w-full lg:w-28 hover:opacity-50">保存する</button>
+            <button type="submit" class="bg-brightGray-900 block border border-solid border-brightGray-900 cursor-pointer font-bold px-2 py-1 rounded select-none text-center text-white w-full lg:w-28 hover:filter hover:brightness-90">保存する</button>
           </div>
         </div>
       </.form>

--- a/lib/bright_web/live/user_settings_live/general_setting_component.ex
+++ b/lib/bright_web/live/user_settings_live/general_setting_component.ex
@@ -81,7 +81,7 @@ defmodule BrightWeb.UserSettingsLive.GeneralSettingComponent do
         </div>
 
         <div class="flex mt-8 relative">
-          <button type="submit" class="bg-brightGray-900 border block border-solid border-brightGray-900 cursor-pointer font-bold mx-auto px-4 py-2 rounded select-none text-center text-white w-80 hover:opacity-50">保存する</button>
+          <button type="submit" class="bg-brightGray-900 border block border-solid border-brightGray-900 cursor-pointer font-bold mx-auto px-4 py-2 rounded select-none text-center text-white w-80 hover:filter hover:brightness-90">保存する</button>
         </div>
       </.form>
     </li>

--- a/lib/bright_web/live/user_settings_live/notification_setting_component.ex
+++ b/lib/bright_web/live/user_settings_live/notification_setting_component.ex
@@ -90,7 +90,7 @@ defmodule BrightWeb.UserSettingsLive.NotificationSettingComponent do
       </div><!-- End スキルパネル更新通知 -->
 
       <div class="flex mt-8 mx-auto w-fit">
-        <a class="bg-brightGray-900 border border-solid border-brightGray-900 cursor-pointer font-bold px-4 py-2 rounded select-none text-center text-white w-80 hover:opacity-50">保存する</a>
+        <a class="bg-brightGray-900 border border-solid border-brightGray-900 cursor-pointer font-bold px-4 py-2 rounded select-none text-center text-white w-80 hover:filter hover:brightness-90">保存する</a>
       </div>
     </li>
     """


### PR DESCRIPTION
- close: https://github.com/bright-org/bright/issues/1482

表題の通り

https://github.com/bright-org/bright/assets/18478417/0c1080dc-3f5b-4122-8759-d08e813594b0

いくつかボタンアイコンやら画像アイコンの場合は opacity にしないと見づらかったりしたので残した。
一旦ざっと適応してみて反応次第で調整する。
のでレビュワーはざっと見てもらうで大丈夫です。