### PR TITLE
採用確定したユーザーを採用担当者と参加者の採用結果に表示するように変更

### DIFF
--- a/lib/bright/recruits.ex
+++ b/lib/bright/recruits.ex
@@ -564,6 +564,17 @@ defmodule Bright.Recruits do
     |> Repo.all()
   end
 
+  def list_employment(user_id, status) do
+    Employment
+    |> where(
+      [i],
+      i.recruiter_user_id == ^user_id and i.status == ^status
+    )
+    |> preload(candidates_user: :user_profile)
+    |> order_by(desc: :updated_at)
+    |> Repo.all()
+  end
+
   def list_acceptance_employment(user_id) do
     Employment
     |> where(

--- a/lib/bright_web/live/recruit_coordination_live/index.ex
+++ b/lib/bright_web/live/recruit_coordination_live/index.ex
@@ -143,7 +143,7 @@ defmodule BrightWeb.RecruitCoordinationLive.Index do
             </.link>
           </li>
         <% end %>
-        <%= for coordination <- @waiting_acceptances do %>
+        <%= for coordination <- @waiting_decision do %>
           <% icon_path = coordination.candidates_user.user_profile.icon_file_path %>
           <li class="flex my-5">
             <.link
@@ -176,6 +176,38 @@ defmodule BrightWeb.RecruitCoordinationLive.Index do
             </.link>
           </li>
         <% end %>
+
+        <%= for employment <- @waiting_acceptances do %>
+        <% icon_path = employment.candidates_user.user_profile.icon_file_path %>
+          <li class="flex my-5">
+              <div class="flex flex-col">
+                <img
+                  src={UserProfiles.icon_url(icon_path)}
+                  class="object-cover h-12 w-12 rounded-full mr-2"
+                  alt=""
+                />
+                <span>
+                  <%= employment.candidates_user.name %>
+                </span>
+              </div>
+              <div class="flex-1">
+                <span><%= employment.candidates_user.name %></span>
+                <br />
+                <span class="text-brightGray-300">
+                <%= NaiveDateTime.to_date(employment.inserted_at) %>
+                提示年収:<%= employment.income %>
+                </span>
+              </div>
+
+              <span class="flex-1">
+                <%= Gettext.gettext(BrightWeb.Gettext, to_string(employment.status)) %>
+              </span>
+              <span class="w-24">
+                <.elapsed_time inserted_at={employment.updated_at} />
+              </span>
+          </li>
+        <% end %>
+
         <%= for member <- @acceptance_members do %>
         <% icon_path = member.coordination.candidates_user.user_profile.icon_file_path %>
         <% recruiter = member.coordination.recruiter_user %>
@@ -286,7 +318,8 @@ defmodule BrightWeb.RecruitCoordinationLive.Index do
     |> assign(:coordination, nil)
     |> assign(:coordination_member, nil)
     |> assign(:acceptances, Recruits.list_acceptance_employment(user_id))
-    |> assign(:waiting_acceptances, Recruits.list_coordination(user_id, :hiring_decision))
+    |> assign(:waiting_decision, Recruits.list_coordination(user_id, :hiring_decision))
+    |> assign(:waiting_acceptances, Recruits.list_employment(user_id, :waiting_response))
     |> assign(:acceptance_members, Recruits.list_coordination_members(user_id, :hiring_decision))
     |> assign(:acceptance, nil)
     |> then(&{:ok, &1})


### PR DESCRIPTION
## 採用担当者
### 検討中
![スクリーンショット 2024-07-05 14 54 20](https://github.com/bright-org/bright/assets/91950/8f4aa8e6-4aeb-414b-93c3-01c8f0da27f5)

### 採用決定後・採用連絡のフォームを閉じる
![スクリーンショット 2024-07-05 14 54 54](https://github.com/bright-org/bright/assets/91950/11f5b8e3-e942-485a-b047-2aff20ac417b)

### 採用連絡を行う
![スクリーンショット 2024-07-05 16 20 40](https://github.com/bright-org/bright/assets/91950/bb7172a4-8016-4c99-a430-bb8f85677650)

## 採用選考に参加した人
### 検討中

![スクリーンショット 2024-07-05 14 54 37](https://github.com/bright-org/bright/assets/91950/e610760b-8681-4deb-9bf0-72c08d89cddb)

### 採用決定後
![スクリーンショット 2024-07-05 14 55 07](https://github.com/bright-org/bright/assets/91950/381c6aed-f84c-4ad2-a733-1e4f714d1e39)

## 採用候補者
### 採用連絡を受け取る
![スクリーンショット 2024-07-05 14 56 20](https://github.com/bright-org/bright/assets/91950/81cb1d88-0b4e-4866-9477-e759431c1efb)
