### PR TITLE
PdMクラス1～3が最長っぽいので、折り返さない＋2文字位の余裕を入れて欲しい

### DIFF
--- a/lib/bright_web/components/profile_components.ex
+++ b/lib/bright_web/components/profile_components.ex
@@ -202,7 +202,7 @@ defmodule BrightWeb.ProfileComponents do
           />
         </div>
         <div class="flex mr-2 lg:mr-5">
-          <div class="text-md w-[110px] lg:w-[200px] truncate lg:text-xl font-bold lg:-mt-[4px]"><%= @user_name %></div>
+          <div class="text-md w-[110px] lg:w-[120px] break-all lg:text-xl font-bold lg:-mt-[4px]"><%= @user_name %></div>
         </div>
       </div>
     """
@@ -251,7 +251,7 @@ defmodule BrightWeb.ProfileComponents do
     ~H"""
       <div class="flex flex-col gap-y-2 w-full lg:max-w-[1110px]">
         <div class="p-4 bg-white rounded-lg">
-          <div class="flex flex-col 2xl:flex-row gap-x-4 gap-y-2 lg:gap-y-0">
+          <div class="flex flex-col 2xl:flex-row gap-x-7 gap-y-2 lg:gap-y-0">
             <div class="flex gap-x-4 lg:gap-x-0">
               <div class="flex flex-row lg:flex-col">
                 <.selected_user icon_file_path={@icon_file_path} user_name={@user_name} />


### PR DESCRIPTION
要望
![image](https://github.com/bright-org/bright/assets/13599847/440b0457-6056-4240-a9c3-35385d6fea82)

----

![image](https://github.com/bright-org/bright/assets/13599847/c9379568-cfdd-4531-a140-c8da8babca8d)

![image](https://github.com/bright-org/bright/assets/13599847/05e7dcc1-631d-41c9-a67d-8b613e18d470)

![image](https://github.com/bright-org/bright/assets/13599847/f72f0a77-bc02-427b-bf86-7c16642a5af9)

![image](https://github.com/bright-org/bright/assets/13599847/e69ce155-97b1-4291-8670-d41ef7358c9f)

関連項目
--------
シェア
![image](https://github.com/bright-org/bright/assets/13599847/9fc743ce-f1b7-4a99-96aa-e1bcd419ac5d)


![image](https://github.com/bright-org/bright/assets/13599847/3c3603d2-2935-448c-b03e-eeb5b2490721)
