### PR TITLE
Bright保有スキルのSNSアイコンをTwitterからXに変更

### DIFF
--- a/lib/bright_web/components/sns_components.ex
+++ b/lib/bright_web/components/sns_components.ex
@@ -86,7 +86,7 @@ defmodule BrightWeb.SnsComponents do
   end
 
   attr :url, :string
-  attr :sns_type, :string, values: ~w(twitter github facebook)
+  attr :sns_type, :string, values: ~w(x github facebook)
 
   defp icon_button(%{url: url} = assigns) when url in ["", nil] do
     ~H"""

--- a/test/bright_web/live/mypage_live_test.exs
+++ b/test/bright_web/live/mypage_live_test.exs
@@ -17,7 +17,7 @@ defmodule BrightWeb.MypageLiveTest do
       assert index_live |> has_element?("div .pt-5", user.user_profile.detail)
       # SNSアイコン表示
       assert index_live
-             |> has_element?("button:nth-child(1) img[src='/images/common/twitter.svg']")
+             |> has_element?("button:nth-child(1) img[src='/images/common/x.svg']")
 
       assert index_live
              |> has_element?("button:nth-child(2) img[src='/images/common/github.svg']")


### PR DESCRIPTION
Bright保有スキルのSNSアイコンをTwitterからXに変更しました。
![image](https://github.com/user-attachments/assets/7e784e6e-ccc5-4878-a85c-c0e931aca251)
