### PR TITLE
保有スキル(/mypage) プロフィール部に保有スキルを移動

### DIFF
--- a/lib/bright_web/live/card_live/managing_team_card_component.ex
+++ b/lib/bright_web/live/card_live/managing_team_card_component.ex
@@ -8,7 +8,7 @@ defmodule BrightWeb.CardLive.ManagingTeamCardComponent do
   ## Examples
     <.live_component
       id={@id}
-      module={BrightWeb.CardLive.RelatedTeamCardComponent}
+      module={BrightWeb.CardLive.ManagingTeamCardComponent}
       display_user={@display_user}
       over_ride_on_card_row_click_target={:true}
     />

--- a/lib/bright_web/live/card_live/related_team_card_component.ex
+++ b/lib/bright_web/live/card_live/related_team_card_component.ex
@@ -28,8 +28,6 @@ defmodule BrightWeb.CardLive.RelatedTeamCardComponent do
     {"supportee_teams", "採用・育成支援先"}
   ]
 
-  @menu_items []
-
   @impl true
   def render(assigns) do
     assigns =
@@ -49,7 +47,6 @@ defmodule BrightWeb.CardLive.RelatedTeamCardComponent do
         selected_tab={@card.selected_tab}
         page={@card.page_params.page}
         total_pages={@card.total_pages}
-        menu_items={show_menu(assigns)}
         target={@myself}
       >
         <div class="pt-3 pb-1 px-6 lg:h-[226px]">
@@ -284,17 +281,8 @@ defmodule BrightWeb.CardLive.RelatedTeamCardComponent do
       entries: [],
       page_params: %{page: page, page_size: 5},
       total_entries: 0,
-      total_pages: 0,
-      menu_items: @menu_items
+      total_pages: 0
     }
-  end
-
-  defp show_menu(assings) do
-    if Map.has_key?(assings, :show_menu) && assings.show_menu == true do
-      assings.card.menu_items
-    else
-      []
-    end
   end
 
   defp convert_team_params_from_custom_groups(custom_groups) do

--- a/lib/bright_web/live/card_live/related_user_card_component.ex
+++ b/lib/bright_web/live/card_live/related_user_card_component.ex
@@ -27,10 +27,6 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
     "candidate_for_employment" => "採用候補者はいません"
   }
 
-  @menu_items [
-    # αリリース対象外 %{text: "カスタムグループを作る", href: "/"}, %{text: "カスタムグループの編集", href: "/"}
-  ]
-
   @page_size 6
 
   @impl true
@@ -38,7 +34,6 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
     socket =
       socket
       |> assign(:current_user, nil)
-      |> assign(:menu_items, set_menu_items(socket.assigns[:display_menu]))
       |> assign(:tabs, @tabs)
       # TODO タブが増えたら初期選択タブの変更に対応する
       |> assign(:selected_tab, "team")
@@ -63,7 +58,6 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
         id={"related-user-card-#{@id}"}
         tabs={@tabs}
         selected_tab={@selected_tab}
-        menu_items={@menu_items}
         target={@myself}
         page={@page}
         total_pages={@total_pages}
@@ -216,9 +210,6 @@ defmodule BrightWeb.CardLive.RelatedUserCardComponent do
     |> assign_first_inner_tab()
     |> assign_selected_card(selected_tab)
   end
-
-  defp set_menu_items(false), do: []
-  defp set_menu_items(_), do: @menu_items
 
   defp inner_tab(assigns) do
     ~H"""

--- a/lib/bright_web/live/chart_live/growth_graph_component.ex
+++ b/lib/bright_web/live/chart_live/growth_graph_component.ex
@@ -135,7 +135,6 @@ defmodule BrightWeb.ChartLive.GrowthGraphComponent do
                 id="related-user-card-compare"
                 module={BrightWeb.CardLive.RelatedUserCardComponent}
                 current_user={@current_user}
-                display_menu={false}
                 purpose="compare"
                 card_row_click_target={@myself}
               />

--- a/lib/bright_web/live/mypage_live/index.html.heex
+++ b/lib/bright_web/live/mypage_live/index.html.heex
@@ -1,5 +1,5 @@
 <!-- プロフィール -->
-<div class="flex flex-col lg:flex-row justify-between px-4 py-2 bg-white lg:px-10 lg:py-6">
+<div class="flex flex-col lg:flex-row gap-x-4 gap-y-2 px-4 py-2 bg-white lg:px-10 lg:py-6 ">
   <div class="pt-4 lg:w-full lg:max-w-[850px]">
     <.profile
       user_name={@display_user.name}
@@ -27,44 +27,22 @@
       display_link="false"
     />
   </div>
-</div>
-<!-- コンテンツ -->
-<div class="px-4 py-3 flex flex-col items-center pb-20 lg:pb-4 lg:px-10">
-  <div class="flex flex-col gap-y-6 w-full">
-    <!-- 保有スキル（ジェムをクリックすると成長パネルが見れます） -->
-    <div>
-      <h5>保有スキル（ジェムをクリック）</h5>
-      <.live_component
-        id="skill_card"
-        module={BrightWeb.CardLive.SkillCardComponent}
-        display_user={@display_user}
-        me={@me}
-        anonymous={@anonymous}
-        root="graphs"
-      />
-    </div>
-  </div>
-  <div class="flex flex-col mt-6 gap-y-6 w-full lt-0">
-    <!-- 関わっているチーム -->
-    <div :if={@me}>
-      <h5>関わっているチーム</h5>
-      <.live_component
-        id="related_team_card"
-        module={BrightWeb.CardLive.RelatedTeamCardComponent}
-        display_user={@current_user}
-        show_menu={true}
-      />
 
-    </div>
-    <!-- 関わっているユーザー -->
-    <div :if={@me}>
-      <h5>関わっているユーザー</h5>
-      <.live_component
-        id="intriguing_card"
-        module={BrightWeb.CardLive.RelatedUserCardComponent}
-        current_user={@current_user}
-      />
-    </div>
+  <div>
+    <.live_component
+      id="skill_list"
+      module={BrightWeb.SkillListComponent}
+      display_user={@display_user}
+      me={@me}
+      root="panels"
+      anonymous={@anonymous}
+    />
+  </div>
+</div>
+
+<div class="px-4 py-3 flex flex-col items-center pb-20 lg:pb-4 lg:px-10">
+  <div class="flex flex-col mt-6 gap-y-6 w-full lt-0">
+    <%# TODO 未実装 %>
   </div>
 </div>
 

--- a/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_panel_components.ex
@@ -99,7 +99,6 @@ defmodule BrightWeb.SkillPanelLive.SkillPanelComponents do
         id="related_user"
         module={BrightWeb.CardLive.RelatedUserCardComponent}
         current_user={@current_user}
-        display_menu={false}
         purpose="menu"
       />
     </.mega_menu_button>

--- a/lib/bright_web/live/skill_panel_live/skills_components.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_components.ex
@@ -100,7 +100,6 @@ defmodule BrightWeb.SkillPanelLive.SkillsComponents do
           id="related-user-card-compare"
           module={BrightWeb.CardLive.RelatedUserCardComponent}
           current_user={@current_user}
-          display_menu={false}
           purpose="compare"
           card_row_click_target={@myself}
         />

--- a/test/bright_web/live/mypage_live_test.exs
+++ b/test/bright_web/live/mypage_live_test.exs
@@ -24,15 +24,6 @@ defmodule BrightWeb.MypageLiveTest do
 
       assert index_live
              |> has_element?("button:nth-child(3) img[src='/images/common/facebook.svg']")
-
-      assert index_live |> has_element?("h5", "保有スキル（ジェムをクリック）")
-      assert index_live |> has_element?("li a", "エンジニア")
-
-      assert index_live |> has_element?("h5", "関わっているチーム")
-      assert index_live |> has_element?("li a", "所属チーム")
-
-      assert index_live |> has_element?("h5", "関わっているユーザー")
-      assert index_live |> has_element?("li a", "チーム")
     end
   end
 


### PR DESCRIPTION
マージ先は #1544 用集約ブランチでmainではありません。
対応が多いのでPRを分割しています。

## 対応内容

保有スキル(/mypage) 画面に学習メモを表示する対応の一部です。

https://github.com/bright-org/bright/issues/1544#issuecomment-2241953438

- 保有スキルをページプロフィール部に移しました。
- bodyをいったん白紙にしています。
- 細かい動作確認は後にします。

## 参考画像

![スクリーンショット 2024-07-29 104224](https://github.com/user-attachments/assets/d43ca72d-0248-4e84-9849-ce6402fed0f2)

![スクリーンショット 2024-07-29 104207](https://github.com/user-attachments/assets/f7519a9c-fe38-4be4-b9ba-ff738d3fdf02)
