### PR TITLE
保有スキル(/mypage) スキルアップ状況を追加

### DIFF
--- a/lib/bright/skill_scores.ex
+++ b/lib/bright/skill_scores.ex
@@ -793,4 +793,47 @@ defmodule Bright.SkillScores do
 
     values_before_prev ++ values_after_prev
   end
+
+  @doc """
+  ユーザーが取得あるいはレベルアップした直近のスキルクラススコアを返す
+  """
+  def list_recent_level_up_skill_class_scores(user, size \\ 3) do
+    # 並び替えはレコード取得後に行っている。1ユーザーのスキルクラススコアは多くはないため
+    # 当該クラススコアの `became_normal_at` / `became_skilled_at` をみるが
+    # クラス1についてはスキルパネル取得（見習いスタート）を出すために `user_skill_panels.inserted_at` もみる
+    from(
+      scs in SkillClassScore,
+      where: scs.user_id == ^user.id,
+      join: sc in assoc(scs, :skill_class),
+      join: sp in assoc(sc, :skill_panel),
+      join: usp in assoc(sp, :user_skill_panels),
+      on: usp.user_id == ^user.id,
+      preload: [skill_class: {sc, skill_panel: {sp, user_skill_panels: usp}}]
+    )
+    |> Repo.all()
+    |> Enum.reject(fn skill_class_score ->
+      # クラス2,3 に対して作成されただけの状態は除外する
+      skill_class_score.level == :beginner &&
+        skill_class_score.skill_class.class in [2, 3]
+    end)
+    |> Enum.sort_by(&get_skill_class_score_action_timestamp/1, {:desc, NaiveDateTime})
+    |> Enum.slice(0, size)
+  end
+
+  defp get_skill_class_score_action_timestamp(skill_class_score) do
+    case {skill_class_score.became_skilled_at, skill_class_score.became_normal_at} do
+      {nil, nil} ->
+        # 平均, ベテランになければスキルパネル取得日時とする.
+        # skill_class_scores.inserted_atを使わないのは、
+        # スキルパネル更新処理時に再作成され適切な時間とならないため.
+        [user_skill_panel] = skill_class_score.skill_class.skill_panel.user_skill_panels
+        user_skill_panel.inserted_at
+
+      {nil, became_normal_at} ->
+        became_normal_at
+
+      {became_skilled_at, _became_normal_at} ->
+        became_skilled_at
+    end
+  end
 end

--- a/lib/bright_web/live/mypage_live/index.ex
+++ b/lib/bright_web/live/mypage_live/index.ex
@@ -6,6 +6,7 @@ defmodule BrightWeb.MypageLive.Index do
   import BrightWeb.BrightModalComponents, only: [bright_modal: 1]
 
   alias Bright.SkillScores
+  alias BrightWeb.PathHelper
   alias BrightWeb.DisplayUserHelper
 
   @impl true
@@ -25,6 +26,7 @@ defmodule BrightWeb.MypageLive.Index do
     socket
     |> assign(:page_title, "保有スキル")
     |> assign_skillset_gem()
+    |> assign_recent_level_up_skill_classes()
     |> assign(:search, false)
   end
 
@@ -32,6 +34,7 @@ defmodule BrightWeb.MypageLive.Index do
     socket
     |> assign(:page_title, "スキル検索／スカウト")
     |> assign_skillset_gem()
+    |> assign_recent_level_up_skill_classes()
     |> assign(:search, true)
   end
 
@@ -41,6 +44,7 @@ defmodule BrightWeb.MypageLive.Index do
     socket
     |> assign(:page_title, "無料トライアル")
     |> assign_skillset_gem()
+    |> assign_recent_level_up_skill_classes()
     |> assign(:plan, plan)
     |> assign(:search, false)
   end
@@ -57,5 +61,70 @@ defmodule BrightWeb.MypageLive.Index do
       end)
 
     assign(socket, :skillset_gem, skillset_gem)
+  end
+
+  defp assign_recent_level_up_skill_classes(socket) do
+    %{display_user: display_user} = socket.assigns
+
+    recent_level_up_skill_class_scores =
+      SkillScores.list_recent_level_up_skill_class_scores(display_user)
+
+    assign(socket, :recent_level_up_skill_class_scores, recent_level_up_skill_class_scores)
+  end
+
+  # local components
+  # ---
+
+  defp skill_ups(assigns) do
+    ~H"""
+    <section>
+      <h5>スキルアップ</h5>
+      <div class="bg-white rounded-md mt-1 px-2 py-0.5">
+        <ul class="text-sm font-medium text-center gap-y-2">
+          <li :for={skill_class_score <- @recent_level_up_skill_class_scores} class="flex flex-wrap my-2">
+            <.link
+              class="cursor-pointer hover:filter hover:brightness-[80%] text-left flex flex-wrap items-center text-base px-1 py-1 flex-1 mr-4 w-full lg:w-auto lg:flex-nowrap"
+              href={skill_panel_path(skill_class_score, @display_user, @me, @anonymous)}
+            >
+              <img src="/images/common/icons/skill.svg" class="w-6 h-6 mr-2.5">
+              <span class="order-3 lg:order-2 flex-1 mr-2">
+                <%= skill_up_message(skill_class_score) %>
+              </span>
+            </.link>
+          </li>
+        </ul>
+      </div>
+    </section>
+    """
+  end
+
+  defp skill_panel_path(skill_class_score, display_user, me, anonymous) do
+    %{skill_class: %{class: class, skill_panel: skill_panel}} = skill_class_score
+
+    PathHelper.skill_panel_path("graphs", skill_panel, display_user, me, anonymous) <>
+      "?class=#{class}"
+  end
+
+  defp skill_up_message(skill_class_score) do
+    %{
+      level: level,
+      skill_class: %{
+        name: skill_class_name,
+        class: class,
+        skill_panel: %{
+          name: skill_panel_name
+        }
+      }
+    } = skill_class_score
+
+    level_name = Gettext.gettext(BrightWeb.Gettext, "level_#{level}")
+
+    case {class, level} do
+      {1, :beginner} ->
+        "#{skill_panel_name}【#{skill_class_name}】を始めました"
+
+      _ ->
+        "#{skill_panel_name}【#{skill_class_name}】が「#{level_name}」にレベルアップしました"
+    end
   end
 end

--- a/lib/bright_web/live/mypage_live/index.html.heex
+++ b/lib/bright_web/live/mypage_live/index.html.heex
@@ -40,11 +40,19 @@
   </div>
 </div>
 
-<div class="px-4 py-3 flex flex-col items-center pb-20 lg:pb-4 lg:px-10">
-  <div class="flex flex-col mt-6 gap-y-6 w-full lt-0">
-    <%# TODO 未実装 %>
+<div class="flex justify-between">
+  <div class="px-4 py-3 grow flex flex-col items-center pb-20 lg:pb-4 lg:px-5">
+    <div class="flex flex-col gap-y-6 w-full">
+      <.skill_ups
+        recent_level_up_skill_class_scores={@recent_level_up_skill_class_scores}
+        display_user={@display_user}
+        me={@me}
+        anonymous={@anonymous}
+      />
+    </div>
   </div>
 </div>
+
 
 <.bright_modal
   :if={@live_action == :free_trial}


### PR DESCRIPTION
マージ先は #1544 用集約ブランチでmainではありません。
対応が多いのでPRを分割しています。

## 対応内容

保有スキル(/mypage) 画面にスキルアップを表示する対応の一部です。

https://github.com/bright-org/bright/issues/1544#issuecomment-2241953438

- メイン部に「スキルアップ」項目を追加しました。
- 下記の最新3件が表示されるようにしています。
  - レベルアップしたスキルクラス
  - 新規取得スキルパネルのスキルクラス(class: 1)
- クリックで成長パネル画面に遷移するようにしています（アイコンを置くかどうか未定）
- 細かい調整、動作確認は後にします。

## 参考画像

![スクリーンショット 2024-07-30 094230](https://github.com/user-attachments/assets/0d1f4b65-37b7-4a70-8139-85f00e6b3a67)

![スクリーンショット 2024-07-30 094244](https://github.com/user-attachments/assets/d6ffaf71-5d7c-4162-ba79-8cf1e98c1ed7)
