### PR TITLE
保有スキル(/mypage) 「いま学んでいます」を追加

### DIFF
--- a/lib/bright/skill_evidences.ex
+++ b/lib/bright/skill_evidences.ex
@@ -29,14 +29,14 @@ defmodule Bright.SkillEvidences do
   @doc """
   直近のコメント順に学習メモを返す
   """
-  def list_recent_skill_evidences(user, size \\ 10) do
-    my_evidences = Ecto.assoc(user, :skill_evidences)
-    my_evidence_ids = from(q in my_evidences, select: q.id)
+  def list_recent_skill_evidences(user_ids, size \\ 10) do
+    target_evidences = from(q in SkillEvidence, where: q.user_id in ^user_ids)
+    target_evidence_ids = from(q in target_evidences, select: q.id)
 
     latest_post =
       from(
         sep in SkillEvidencePost,
-        where: sep.skill_evidence_id in subquery(my_evidence_ids),
+        where: sep.skill_evidence_id in subquery(target_evidence_ids),
         group_by: sep.skill_evidence_id,
         select: %{
           skill_evidence_id: sep.skill_evidence_id,
@@ -45,7 +45,7 @@ defmodule Bright.SkillEvidences do
       )
 
     from(
-      se in subquery(my_evidences),
+      se in subquery(target_evidences),
       join: latest_sep in subquery(latest_post),
       on: se.id == latest_sep.skill_evidence_id,
       order_by: {:desc, latest_sep.latest_post_time},

--- a/lib/bright_web/live/mypage_live/index.html.heex
+++ b/lib/bright_web/live/mypage_live/index.html.heex
@@ -40,8 +40,8 @@
   </div>
 </div>
 
-<div class="flex justify-between">
-  <div class="px-4 py-3 grow flex flex-col items-center pb-20 lg:pb-4 lg:px-5">
+<div class="flex flex-col md:flex-row justify-between">
+  <div class="px-4 py-3 grow flex flex-col items-center lg:pb-8 lg:px-5">
     <div class="flex flex-col gap-y-6 w-full">
       <%# スキルアップ %>
       <.skill_ups
@@ -54,12 +54,20 @@
       <%# 学習メモ %>
       <.skill_evidences
         recent_skill_evidences={@recent_skill_evidences}
+        me={@me}
         anonymous={@anonymous}
       />
     </div>
   </div>
-</div>
 
+  <%# サイド部 %>
+  <div :if={@me} class="px-4 py-3 flex flex-col items-center pb-20 lg:pb-4 lg:px-5 max-w-md">
+    <div class="flex flex-col gap-y-6 w-full">
+      <%# いま学んでいます %>
+      <.others_skill_evidences recent_others_skill_evidences={@recent_others_skill_evidences} />
+    </div>
+  </div>
+</div>
 
 <% # 無料体験申し込み用モーダル %>
 <.bright_modal

--- a/test/bright/skill_evidences_test.exs
+++ b/test/bright/skill_evidences_test.exs
@@ -504,7 +504,7 @@ defmodule Bright.SkillEvidencesTest do
         inserted_at: ~N[2024-08-01 09:38:01]
       )
 
-      [latest, second] = SkillEvidences.list_recent_skill_evidences(user)
+      [latest, second] = SkillEvidences.list_recent_skill_evidences([user.id])
       assert latest.id == skill_evidence_2.id
       assert second.id == skill_evidence_1.id
 
@@ -516,7 +516,7 @@ defmodule Bright.SkillEvidencesTest do
         inserted_at: ~N[2024-08-01 09:38:02]
       )
 
-      [latest, second] = SkillEvidences.list_recent_skill_evidences(user)
+      [latest, second] = SkillEvidences.list_recent_skill_evidences([user.id])
       assert latest.id == skill_evidence_1.id
       assert second.id == skill_evidence_2.id
     end
@@ -529,14 +529,14 @@ defmodule Bright.SkillEvidencesTest do
       insert(:skill_evidence_post, skill_evidence: skill_evidence, user: user, content: "post")
 
       # 指定したuser分が返ること
-      [latest] = SkillEvidences.list_recent_skill_evidences(user)
+      [latest] = SkillEvidences.list_recent_skill_evidences([user.id])
       assert latest.id == skill_evidence.id
 
       user_2 = insert(:user)
-      assert [] = SkillEvidences.list_recent_skill_evidences(user_2)
+      assert [] = SkillEvidences.list_recent_skill_evidences([user_2.id])
 
       # 指定したsize分が返ること
-      assert [] = SkillEvidences.list_recent_skill_evidences(user, 0)
+      assert [] = SkillEvidences.list_recent_skill_evidences([user.id], 0)
     end
   end
 

--- a/test/bright_web/live/notification_live/notification_header_component_test.exs
+++ b/test/bright_web/live/notification_live/notification_header_component_test.exs
@@ -10,7 +10,7 @@ defmodule BrightWeb.NotificationLive.NotificationHeaderComponentTest do
     setup [:register_and_log_in_user]
 
     test "opens header", %{conn: conn} do
-      {:ok, lv, _html} = live(conn, ~p"/mypage")
+      {:ok, lv, _html} = live(conn, ~p"/more_skills")
 
       refute lv |> has_element?(~s{a[href="/notifications/operations"]})
       refute lv |> has_element?(~s{a[href="/notifications/communities"]})


### PR DESCRIPTION
マージ先は #1544 用集約ブランチでmainではありません。
対応が多いのでPRを分割しています。

## 対応内容

保有スキル(/mypage) 画面の対応の一部です。

https://github.com/bright-org/bright/issues/1544#issuecomment-2241953438

- サイド部に「いま学んでいます」項目を追加しました。
  - チームメンバーの学習メモで直近投稿があった順に表示
  - ただし、表示されるのは所有者自身の直近投稿にしています。所有者以外の投稿がでると、誰が学んでいるか見てもわからなくなるため
  - 現状はスマホはコンテンツを縦に並べる形にしていますが、後続PRで変更予定です。
- 細かい調整、動作確認は後にします。

## 参考画像

![image](https://github.com/user-attachments/assets/7752c4bc-5516-4965-b627-a48b6090cba6)
