### PR TITLE
保有スキル(/mypage) SPで画面切り替えによる表示対応等

### DIFF
--- a/lib/bright_web/live/mypage_live/index.html.heex
+++ b/lib/bright_web/live/mypage_live/index.html.heex
@@ -1,6 +1,6 @@
 <!-- プロフィール -->
 <div class="flex flex-col lg:flex-row gap-x-4 gap-y-2 px-4 py-2 bg-white lg:px-10 lg:py-6 ">
-  <div class="pt-4 lg:w-full lg:max-w-[850px]">
+  <div id="profile-field" class="pt-4 lg:w-full lg:max-w-[850px]">
     <.profile
       user_name={@display_user.name}
       title={@display_user.user_profile.title}
@@ -43,7 +43,7 @@
 <%# 2つの領域からなる。SPではJSでの切り替え表示、PCではflexでのメイン/サイド分割表示 %>
 <div class="lg:flex lg:flex-row lg:justify-between pb-16">
   <%# SP用切り替え部 %>
-  <div class="lg:hidden text-md text-center px-2 mt-8 mb-2">
+  <div :if={@me} class="lg:hidden text-md text-center px-2 mt-8 mb-2">
     <button id="btn-my-field" class="inline-flex items-center font-bold rounded-l-full gap-x-2 px-6 py-2 button-toggle-active" phx-click={js_show_my_field()}>
       マイページ
     </button>
@@ -66,8 +66,9 @@
       <%# 学習メモ %>
       <.skill_evidences
         recent_skill_evidences={@recent_skill_evidences}
-        me={@me}
+        current_user={@current_user}
         anonymous={@anonymous}
+        related_user_ids={@related_user_ids}
       />
     </div>
   </div>
@@ -76,7 +77,12 @@
   <div id="others-field" :if={@me} class="hidden lg:block px-4 pt-3 flex flex-col items-center lg:max-w-md">
     <div class="flex flex-col gap-y-6 w-full">
       <%# いま学んでいます %>
-      <.others_skill_evidences recent_others_skill_evidences={@recent_others_skill_evidences} />
+      <.others_skill_evidences
+        recent_others_skill_evidences={@recent_others_skill_evidences}
+        current_user={@current_user}
+        anonymous={@anonymous}
+        related_user_ids={@related_user_ids}
+      />
     </div>
   </div>
 </div>

--- a/lib/bright_web/live/path_helper.ex
+++ b/lib/bright_web/live/path_helper.ex
@@ -3,6 +3,21 @@ defmodule BrightWeb.PathHelper do
   URL構築用の補助モジュール
   """
 
+  import BrightWeb.DisplayUserHelper, only: [encrypt_user_name: 1]
+
+  @doc """
+  指定条件で /mypage へ遷移するURLを返す
+  """
+  def mypage_path(user, anonymous)
+
+  def mypage_path(user, true) do
+    "/mypage/anon/#{encrypt_user_name(user)}"
+  end
+
+  def mypage_path(user, false) do
+    "/mypage/#{user.name}"
+  end
+
   @doc """
   指定条件で /graphs, /panels へ遷移するURLを返す
   """

--- a/test/bright_web/live/mypage_live_test.exs
+++ b/test/bright_web/live/mypage_live_test.exs
@@ -6,27 +6,37 @@ defmodule BrightWeb.MypageLiveTest do
 
   setup :set_swoosh_global
 
+  defp create_first_skill_evidence(user) do
+    skill_unit = insert(:skill_unit)
+    skill_category = insert(:skill_category, skill_unit: skill_unit)
+    skill = insert(:skill, skill_category: skill_category)
+    skill_evidence = insert(:skill_evidence, user: user, skill: skill)
+    skill_evidence
+  end
+
+  defp open_skill_evidence_modal(lv, skill_evidence) do
+    lv
+    |> element("button[class='link-evidence'][phx-value-id='#{skill_evidence.id}']")
+    |> render_click()
+  end
+
   describe "Index" do
     setup [:register_and_log_in_user, :setup_career_fields]
 
     test "view mypages", %{conn: conn, user: user} do
-      {:ok, index_live, html} = live(conn, ~p"/mypage")
+      {:ok, lv, html} = live(conn, ~p"/mypage")
 
       assert html =~ "マイページ"
 
       # プロフィールの検証
-      assert index_live |> has_element?("div .font-bold", user.name)
-      assert index_live |> has_element?("div .break-all", user.user_profile.title)
-      assert index_live |> has_element?("div .pt-5", user.user_profile.detail)
+      assert has_element?(lv, "#profile-field", user.name)
+      assert has_element?(lv, "#profile-field", user.user_profile.title)
+      assert has_element?(lv, "#profile-field", user.user_profile.detail)
+
       # SNSアイコン表示
-      assert index_live
-             |> has_element?("button:nth-child(1) img[src='/images/common/x.svg']")
-
-      assert index_live
-             |> has_element?("button:nth-child(2) img[src='/images/common/github.svg']")
-
-      assert index_live
-             |> has_element?("button:nth-child(3) img[src='/images/common/facebook.svg']")
+      assert has_element?(lv, "button:nth-child(1) img[src='/images/common/x.svg']")
+      assert has_element?(lv, "button:nth-child(2) img[src='/images/common/github.svg']")
+      assert has_element?(lv, "button:nth-child(3) img[src='/images/common/facebook.svg']")
     end
   end
 
@@ -77,6 +87,238 @@ defmodule BrightWeb.MypageLiveTest do
       # dataが切り替えている対象者のものであること
       data = [[50, 0, 0, 0]] |> Jason.encode!()
       assert has_element?(index_live, ~s(#skillset-gem[data-data='#{data}']))
+    end
+  end
+
+  # スキルアップ確認
+  describe "skill_ups" do
+    setup [:register_and_log_in_user, :setup_career_fields]
+
+    test "shows empty message", %{conn: conn} do
+      {:ok, _index_live, html} = live(conn, ~p"/mypage")
+      assert html =~ "まだスキルを選択していません"
+    end
+  end
+
+  # 学習メモ確認
+  describe "recent_skill_evidences" do
+    setup [:register_and_log_in_user, :setup_career_fields]
+
+    test "shows empty message", %{conn: conn} do
+      {:ok, _index_live, html} = live(conn, ~p"/mypage")
+      assert html =~ "まだ学習メモがありません"
+    end
+
+    test "adds new post", %{conn: conn, user: user} do
+      skill_evidence = create_first_skill_evidence(user)
+
+      insert(:skill_evidence_post,
+        user: user,
+        skill_evidence: skill_evidence,
+        content: "最初の投稿",
+        inserted_at: ~N[2024-08-01 00:00:00]
+      )
+
+      {:ok, lv, _html} = live(conn, ~p"/mypage")
+      assert has_element?(lv, "#my-field", "最初の投稿")
+
+      # 投稿
+      open_skill_evidence_modal(lv, skill_evidence)
+
+      lv
+      |> form("#skill_evidence_post-form", skill_evidence_post: %{content: "新メモ"})
+      |> render_submit()
+
+      assert has_element?(lv, "#skill_evidence_posts", "新メモ")
+
+      {:ok, lv, _html} = live(conn, ~p"/mypage")
+      refute has_element?(lv, "#my-field", "最初の投稿")
+      assert has_element?(lv, "#my-field", "新メモ")
+    end
+
+    test "deletes post", %{conn: conn, user: user} do
+      skill_evidence = create_first_skill_evidence(user)
+
+      post =
+        insert(:skill_evidence_post, user: user, skill_evidence: skill_evidence, content: "最初の投稿")
+
+      {:ok, lv, _html} = live(conn, ~p"/mypage")
+      assert has_element?(lv, "#my-field", "最初の投稿")
+
+      # 投稿削除
+      open_skill_evidence_modal(lv, skill_evidence)
+
+      lv
+      |> element(~s([phx-click="delete"][phx-value-id="#{post.id}"]))
+      |> render_click()
+
+      refute has_element?(lv, "#skill_evidence_posts", "最初の投稿")
+
+      {:ok, lv, _html} = live(conn, ~p"/mypage")
+      refute has_element?(lv, "#my-field", "最初の投稿")
+    end
+  end
+
+  # いま学んでいます確認
+  describe "recent_others_skill_evidences" do
+    setup [:register_and_log_in_user, :setup_career_fields]
+
+    test "adds new post", %{conn: conn, user: user} do
+      user_2 = insert(:user) |> with_user_profile()
+      create_team_with_team_member_users([user, user_2])
+
+      skill_evidence = create_first_skill_evidence(user_2)
+
+      insert(:skill_evidence_post,
+        user: user_2,
+        skill_evidence: skill_evidence,
+        content: "チームメンバーの投稿",
+        inserted_at: ~N[2024-08-01 00:00:00]
+      )
+
+      {:ok, lv, _html} = live(conn, ~p"/mypage")
+      assert has_element?(lv, "#others-field", "チームメンバーの投稿")
+
+      # 投稿
+      open_skill_evidence_modal(lv, skill_evidence)
+
+      lv
+      |> form("#skill_evidence_post-form", skill_evidence_post: %{content: "メモ投稿"})
+      |> render_submit()
+
+      assert has_element?(lv, "#skill_evidence_posts", "メモ投稿")
+
+      {:ok, lv, _html} = live(conn, ~p"/mypage")
+
+      # 持ち主の最新が表示されるので「チームメンバーの投稿」で正しい
+      assert has_element?(lv, "#others-field", "チームメンバーの投稿")
+      refute has_element?(lv, "#others-field", "メモ投稿")
+    end
+
+    test "deletes post", %{conn: conn, user: user} do
+      user_2 = insert(:user) |> with_user_profile()
+      create_team_with_team_member_users([user, user_2])
+
+      skill_evidence = create_first_skill_evidence(user_2)
+
+      insert(:skill_evidence_post,
+        user: user_2,
+        skill_evidence: skill_evidence,
+        content: "チームメンバーの投稿"
+      )
+
+      post =
+        insert(:skill_evidence_post, user: user, skill_evidence: skill_evidence, content: "メモ投稿")
+
+      {:ok, lv, _html} = live(conn, ~p"/mypage")
+      assert has_element?(lv, "#others-field", "チームメンバーの投稿")
+
+      # 投稿削除
+      open_skill_evidence_modal(lv, skill_evidence)
+
+      lv
+      |> element(~s([phx-click="delete"][phx-value-id="#{post.id}"]))
+      |> render_click()
+    end
+
+    test "does not show non-relation user's skill_evidence", %{conn: conn} do
+      user_2 = insert(:user) |> with_user_profile()
+
+      # 無関係なuser_2の投稿作成
+      skill_evidence = create_first_skill_evidence(user_2)
+      insert(:skill_evidence_post, user: user_2, skill_evidence: skill_evidence, content: "誰かの投稿")
+
+      {:ok, lv, _html} = live(conn, ~p"/mypage")
+      refute has_element?(lv, "#others-field", "誰かの投稿")
+    end
+  end
+
+  # 他者閲覧時の確認
+  describe "Team member page" do
+    setup [:register_and_log_in_user, :setup_career_fields]
+
+    test "does not show others evidence_posts fields", %{
+      user: user,
+      conn: conn
+    } do
+      user_2 = insert(:user) |> with_user_profile()
+      create_team_with_team_member_users([user, user_2])
+
+      {:ok, lv, _html} = live(conn, ~p"/mypage/#{user_2.name}")
+
+      assert has_element?(lv, "#my-field")
+      refute has_element?(lv, "#others-field")
+    end
+
+    test "shows link with skill_evidence_post", %{user: user, conn: conn} do
+      user_2 = insert(:user) |> with_user_profile()
+      create_team_with_team_member_users([user, user_2])
+
+      user_3 = insert(:user) |> with_user_profile()
+      create_team_with_team_member_users([user_2, user_3])
+
+      skill_evidence = create_first_skill_evidence(user_2)
+
+      insert(:skill_evidence_post,
+        user: user_3,
+        skill_evidence: skill_evidence,
+        content: "チームメンバーの投稿",
+        inserted_at: ~N[2024-08-01 00:00:00]
+      )
+
+      # 他者マイページに出てくる無関係のチームメンバーの投稿が匿名であること
+      {:ok, lv, _html} = live(conn, ~p"/mypage/#{user_2.name}")
+
+      refute has_element?(lv, "#my-field a[href='/mypage/#{user_3.name}']")
+
+      # 知っているメンバーならば匿名表示にならないこと
+      create_team_with_team_member_users([user, user_3])
+
+      {:ok, lv, _html} = live(conn, ~p"/mypage/#{user_2.name}")
+
+      assert has_element?(lv, "#my-field a[href='/mypage/#{user_3.name}']")
+    end
+  end
+
+  # 他者閲覧（匿名）時の確認
+  describe "Anonymous user page" do
+    alias BrightWeb.PathHelper
+
+    setup [:register_and_log_in_user, :setup_career_fields]
+
+    test "does not show others evidence_posts fields", %{
+      conn: conn
+    } do
+      user_2 = insert(:user) |> with_user_profile()
+
+      {:ok, lv, _html} = live(conn, PathHelper.mypage_path(user_2, true))
+
+      assert has_element?(lv, "#my-field")
+      refute has_element?(lv, "#others-field")
+    end
+
+    test "shows link with skill_evidence_post", %{user: user, conn: conn} do
+      user_2 = insert(:user) |> with_user_profile()
+      user_3 = insert(:user) |> with_user_profile()
+
+      skill_evidence = create_first_skill_evidence(user_2)
+
+      insert(:skill_evidence_post,
+        user: user_3,
+        skill_evidence: skill_evidence,
+        content: "チームメンバーの投稿",
+        inserted_at: ~N[2024-08-01 00:00:00]
+      )
+
+      # 匿名アクセス時は仮に知っているメンバーでも匿名表示になること
+      # (現状の学習メモ仕様を踏襲)
+      create_team_with_team_member_users([user_2, user_3])
+      create_team_with_team_member_users([user, user_3])
+
+      {:ok, lv, html} = live(conn, PathHelper.mypage_path(user_2, true))
+
+      assert html =~ "チームメンバーの投稿"
+      refute has_element?(lv, "#my-field a[href='/mypage/#{user_3.name}']")
     end
   end
 end


### PR DESCRIPTION
マージ先は #1544 用集約ブランチでmainではありません。
対応が多いのでPRを分割しています。

## 対応内容

保有スキル(/mypage) 画面の対応の一部です。

https://github.com/bright-org/bright/issues/1544#issuecomment-2241953438

- SPでボタンによって、マイページ／チームメンバーを切り替えられるようにしました
- その他、文字サイズなどの表示調整や自動テストを追加しました

## 参考画像

(gif)

![sample78](https://github.com/user-attachments/assets/fc794937-16c1-403d-a35e-7c2686e660fa)
