### PR TITLE
保有スキル(/mypage) 「さらに表示」対応

### DIFF
--- a/lib/bright/skill_evidences.ex
+++ b/lib/bright/skill_evidences.ex
@@ -30,6 +30,16 @@ defmodule Bright.SkillEvidences do
   直近のコメント順に学習メモを返す
   """
   def list_recent_skill_evidences(user_ids, size \\ 10) do
+    from(q in query_recent_skill_evidences(user_ids), limit: ^size)
+    |> Repo.all()
+  end
+
+  def page_recent_skill_evidences(user_ids, page_params \\ [page: 1, page_size: 10]) do
+    query_recent_skill_evidences(user_ids)
+    |> Repo.paginate(page_params)
+  end
+
+  defp query_recent_skill_evidences(user_ids) do
     target_evidences = from(q in SkillEvidence, where: q.user_id in ^user_ids)
     target_evidence_ids = from(q in target_evidences, select: q.id)
 
@@ -48,10 +58,8 @@ defmodule Bright.SkillEvidences do
       se in subquery(target_evidences),
       join: latest_sep in subquery(latest_post),
       on: se.id == latest_sep.skill_evidence_id,
-      order_by: {:desc, latest_sep.latest_post_time},
-      limit: ^size
+      order_by: {:desc, latest_sep.latest_post_time}
     )
-    |> Repo.all()
   end
 
   @doc """

--- a/lib/bright_web/components/skill_evidence_components.ex
+++ b/lib/bright_web/components/skill_evidence_components.ex
@@ -1,0 +1,77 @@
+defmodule BrightWeb.SkillEvidenceComponents do
+  @moduledoc """
+  学習メモの表示に係るコンポーネント
+  """
+
+  use BrightWeb, :component
+
+  alias Bright.Accounts
+  alias Bright.UserProfiles
+  alias Bright.SkillEvidences
+  alias BrightWeb.PathHelper
+
+  @doc """
+  学習メモの簡易表示
+  """
+  attr :skill_evidence, SkillEvidences.SkillEvidence
+  attr :skill_evidence_post, SkillEvidences.SkillEvidencePost
+  attr :related_user_ids, :list
+  attr :skill_breadcrumb, :string
+  attr :current_user, Accounts.User
+  attr :display_time, :boolean, default: true
+  attr :anonymous, :boolean, default: true
+  attr :myself, :string, default: nil
+
+  def skill_evidence(assigns) do
+    ~H"""
+    <%# アイコン表示 %>
+    <div class="flex-none text-center pt-4 mx-2">
+      <% my_post? = @current_user.id == @skill_evidence_post.user_id %>
+      <% anonymous? = @anonymous || @skill_evidence_post.user_id not in @related_user_ids %>
+
+      <%= if my_post? do %>
+        <img class="h-10 w-10 rounded-full" src={icon_file_path(@current_user, false)} />
+      <% else %>
+        <.link navigate={PathHelper.mypage_path(@skill_evidence_post.user, anonymous?)}>
+          <img class="h-10 w-10 rounded-full" src={icon_file_path(@skill_evidence_post.user, anonymous?)} />
+        </.link>
+      <% end %>
+    </div>
+
+    <%# 投稿表示 %>
+    <div class="grow flex flex-col gap-y-2 mx-2">
+      <div class="text-xs flex justify-between">
+        <p class="font-bold"><%= @skill_breadcrumb %></p>
+        <div
+          :if={@display_time}
+          id={"timestamp-#{@skill_evidence_post.id}"}
+          phx-hook="LocalTime"
+          phx-update="ignore"
+          data-iso={NaiveDateTime.to_iso8601(@skill_evidence_post.inserted_at)}
+          >
+          <p class="hidden lg:block" data-local-time="%x %H:%M"></p>
+        </div>
+      </div>
+      <p class="break-all">
+        <%= SkillEvidences.truncate_post_content(@skill_evidence_post.content, 200) %>
+      </p>
+      <nav class="flex items-center gap-x-4">
+        <button
+          class="link-evidence"
+          phx-click="edit_skill_evidence"
+          phx-target={@myself}
+          phx-value-id={@skill_evidence.id}
+        >
+          <img src="/images/common/icons/skillEvidenceActive.svg">
+        </button>
+      </nav>
+    </div>
+    """
+  end
+
+  defp icon_file_path(_user, true), do: UserProfiles.icon_url(nil)
+
+  defp icon_file_path(user, _anonymous) do
+    UserProfiles.icon_url(user.user_profile.icon_file_path)
+  end
+end

--- a/lib/bright_web/live/modal_component.ex
+++ b/lib/bright_web/live/modal_component.ex
@@ -54,8 +54,6 @@ defmodule BrightWeb.ModalComponent do
   defp call_on_open(_), do: nil
 
   defp call_on_close(%{on_close: func}) do
-    func.()
+    func && func.()
   end
-
-  defp call_on_close(_), do: nil
 end

--- a/lib/bright_web/live/mypage_live/index.ex
+++ b/lib/bright_web/live/mypage_live/index.ex
@@ -3,16 +3,17 @@ defmodule BrightWeb.MypageLive.Index do
 
   import BrightWeb.ProfileComponents
   import BrightWeb.ChartComponents
+  import BrightWeb.SkillEvidenceComponents
   import BrightWeb.BrightModalComponents, only: [bright_modal: 1]
 
   alias Phoenix.LiveView.JS
   alias Bright.SkillUnits
   alias Bright.SkillEvidences
-  alias Bright.UserProfiles
   alias Bright.SkillScores
   alias Bright.Teams
   alias BrightWeb.PathHelper
   alias BrightWeb.DisplayUserHelper
+  alias BrightWeb.MypageLive.MySkillEvidencesComponent
 
   def mount(params, _session, socket) do
     socket
@@ -26,18 +27,17 @@ defmodule BrightWeb.MypageLive.Index do
      socket
      |> assign_skillset_gem()
      |> assign_recent_level_up_skill_classes()
-     |> assign_recent_skill_evidences()
      |> assign_related_user_ids()
      |> assign_recent_others_skill_evidences()
      |> apply_action(socket.assigns.live_action, params)}
   end
 
   def handle_event("edit_skill_evidence", %{"id" => id}, socket) do
+    %{current_user: current_user} = socket.assigns
     skill_evidence = SkillEvidences.get_skill_evidence!(id)
     skill = SkillUnits.get_skill!(skill_evidence.skill_id)
 
     # モーダルを開き、表示内容を選択した学習メモで初期化する
-    # モーダルを閉じたときは、一覧を最新にしている
     send_update(BrightWeb.ModalComponent,
       id: "skill-evidence-modal",
       open: true,
@@ -47,19 +47,13 @@ defmodule BrightWeb.MypageLive.Index do
           reset: true,
           skill_evidence: skill_evidence,
           skill: skill,
-          user: socket.assigns.current_user
+          user: current_user,
+          me: current_user.id == skill_evidence.user_id
         )
-      end,
-      on_close: fn ->
-        send(self(), :reload_recent_skill_evidences)
       end
     )
 
     {:noreply, socket}
-  end
-
-  def handle_info(:reload_recent_skill_evidences, socket) do
-    {:noreply, assign_recent_skill_evidences(socket)}
   end
 
   defp apply_action(socket, :index, _params) do
@@ -104,17 +98,6 @@ defmodule BrightWeb.MypageLive.Index do
       SkillScores.list_recent_level_up_skill_class_scores(display_user)
 
     assign(socket, :recent_level_up_skill_class_scores, recent_level_up_skill_class_scores)
-  end
-
-  defp assign_recent_skill_evidences(socket) do
-    %{display_user: display_user} = socket.assigns
-
-    # 必要に応じてstream化のこと
-    recent_skill_evidences =
-      SkillEvidences.list_recent_skill_evidences([display_user.id])
-      |> Bright.Repo.preload(skill_evidence_posts: [user: [:user_profile]])
-
-    assign(socket, :recent_skill_evidences, recent_skill_evidences)
   end
 
   defp assign_related_user_ids(socket) do
@@ -194,35 +177,6 @@ defmodule BrightWeb.MypageLive.Index do
     """
   end
 
-  defp skill_evidences(assigns) do
-    ~H"""
-    <section>
-      <h5 class="text-base lg:text-lg">学習メモ</h5>
-      <div
-        :if={@recent_skill_evidences == []}
-        class="bg-white rounded-md mt-1 px-2 py-0.5 text-sm font-medium gap-y-2 flex py-2 my-2"
-      >
-        まだ学習メモがありません
-      </div>
-
-      <div
-        :for={skill_evidence <- @recent_skill_evidences}
-        class="bg-white rounded-md mt-1 px-2 py-0.5 text-sm font-medium gap-y-2 flex py-2 my-2"
-      >
-        <.skill_evidence
-          skill_evidence={skill_evidence}
-          skill_evidence_post={get_latest_skill_evidence_post(skill_evidence)}
-          skill_breadcrumb={SkillEvidences.get_skill_breadcrumb(%{id: skill_evidence.skill_id})}
-          current_user={@current_user}
-          anonymous={@anonymous}
-          related_user_ids={@related_user_ids}
-          display_time={true}
-        />
-      </div>
-    </section>
-    """
-  end
-
   defp others_skill_evidences(assigns) do
     ~H"""
     <section>
@@ -241,58 +195,12 @@ defmodule BrightWeb.MypageLive.Index do
           display_time={false}
         />
       </div>
-      <div class="bg-white rounded-md mt-1 px-2 py-0.5 text-sm font-medium gap-y-2 flex py-2 my-2">
+      <div class="bg-white rounded-md px-2 py-2 my-2 text-sm font-medium">
         <.link navigate={~p"/notifications/evidences"}>
           「学習メモのヘルプ」をみる
         </.link>
       </div>
     </section>
-    """
-  end
-
-  defp skill_evidence(assigns) do
-    ~H"""
-    <%# アイコン表示 %>
-    <div class="flex-none text-center pt-4 mx-2">
-      <% my_post? = @current_user.id == @skill_evidence_post.user_id %>
-      <% anonymous? = @anonymous || @skill_evidence_post.user_id not in @related_user_ids %>
-
-      <%= if my_post? do %>
-        <img class="h-10 w-10 rounded-full" src={icon_file_path(@current_user, false)} />
-      <% else %>
-        <.link navigate={PathHelper.mypage_path(@skill_evidence_post.user, anonymous?)}>
-          <img class="h-10 w-10 rounded-full" src={icon_file_path(@skill_evidence_post.user, anonymous?)} />
-        </.link>
-      <% end %>
-    </div>
-
-    <%# 投稿表示 %>
-    <div class="grow flex flex-col gap-y-2 mx-2">
-      <div class="text-xs flex justify-between">
-        <p class="font-bold"><%= @skill_breadcrumb %></p>
-        <div
-          :if={@display_time}
-          id={"timestamp-#{@skill_evidence_post.id}"}
-          phx-hook="LocalTime"
-          phx-update="ignore"
-          data-iso={NaiveDateTime.to_iso8601(@skill_evidence_post.inserted_at)}
-          >
-          <p class="hidden lg:block" data-local-time="%x %H:%M"></p>
-        </div>
-      </div>
-      <p class="break-all">
-        <%= SkillEvidences.truncate_post_content(@skill_evidence_post.content, 200) %>
-      </p>
-      <nav class="flex items-center gap-x-4">
-        <button
-          class="link-evidence"
-          phx-click="edit_skill_evidence"
-          phx-value-id={@skill_evidence.id}
-        >
-          <img src="/images/common/icons/skillEvidenceActive.svg">
-        </button>
-      </nav>
-    </div>
     """
   end
 
@@ -326,22 +234,10 @@ defmodule BrightWeb.MypageLive.Index do
     end
   end
 
-  defp get_latest_skill_evidence_post(skill_evidence) do
-    skill_evidence.skill_evidence_posts
-    |> Enum.sort_by(& &1.inserted_at, {:desc, NaiveDateTime})
-    |> List.first()
-  end
-
   defp get_latest_my_skill_evidence_post(skill_evidence) do
     # 「いま学んでいます」では自分自身の最新投稿を参照する
     skill_evidence.skill_evidence_posts
     |> Enum.sort_by(& &1.inserted_at, {:desc, NaiveDateTime})
     |> Enum.find(&(&1.user_id == skill_evidence.user_id))
-  end
-
-  defp icon_file_path(_user, true), do: UserProfiles.icon_url(nil)
-
-  defp icon_file_path(user, _anonymous) do
-    UserProfiles.icon_url(user.user_profile.icon_file_path)
   end
 end

--- a/lib/bright_web/live/mypage_live/index.html.heex
+++ b/lib/bright_web/live/mypage_live/index.html.heex
@@ -64,8 +64,10 @@
       />
 
       <%# 学習メモ %>
-      <.skill_evidences
-        recent_skill_evidences={@recent_skill_evidences}
+      <.live_component
+        module={MySkillEvidencesComponent}
+        id="my-skill-evidences"
+        display_user={@display_user}
         current_user={@current_user}
         anonymous={@anonymous}
         related_user_ids={@related_user_ids}
@@ -121,7 +123,7 @@
     skill={nil}
     user={@current_user}
     anonymous={@anonymous}
-    me={@me}
+    me={nil}
   />
 </.live_component>
 

--- a/lib/bright_web/live/mypage_live/my_skill_evidences_component.ex
+++ b/lib/bright_web/live/mypage_live/my_skill_evidences_component.ex
@@ -1,0 +1,144 @@
+defmodule BrightWeb.MypageLive.MySkillEvidencesComponent do
+  @moduledoc """
+  画面表示対象者の学習メモの表示用
+
+  「さらに表示」をpageで管理している
+  """
+
+  @page_size 10
+
+  use BrightWeb, :live_component
+
+  import BrightWeb.SkillEvidenceComponents
+
+  alias Bright.SkillUnits
+  alias Bright.SkillEvidences
+
+  def render(assigns) do
+    ~H"""
+    <section id={@id}>
+      <h5 class="text-base lg:text-lg">学習メモ</h5>
+      <div
+        :if={@page_number ==  0}
+        class="bg-white rounded-md mt-1 px-2 py-0.5 text-sm font-medium gap-y-2 flex py-2 my-2"
+      >
+        まだ学習メモがありません
+      </div>
+
+      <div id="skill-evidences" phx-update="stream">
+        <div
+          :for={{id, skill_evidence} <- @streams.skill_evidences}
+          id={id}
+          class="bg-white rounded-md mt-1 px-2 py-0.5 text-sm font-medium gap-y-2 flex py-2 my-2"
+        >
+          <.skill_evidence
+            myself={@myself}
+            skill_evidence={skill_evidence}
+            skill_evidence_post={get_latest_skill_evidence_post(skill_evidence)}
+            skill_breadcrumb={SkillEvidences.get_skill_breadcrumb(%{id: skill_evidence.skill_id})}
+            current_user={@current_user}
+            anonymous={@anonymous}
+            related_user_ids={@related_user_ids}
+            display_time={true}
+          />
+        </div>
+      </div>
+
+      <div :if={@read_more} class="bg-white rounded-md px-2 py-2 my-2 text-sm font-medium">
+        <button id="btn-#{@id}-read-more" class="w-full" phx-click="read_more" phx-target={@myself}>
+          さらに表示
+        </button>
+      </div>
+    </section>
+    """
+  end
+
+  def mount(socket) do
+    {:ok,
+     socket
+     |> assign(:page_number, 0)
+     |> assign(:read_more, false)
+     |> stream(:skill_evidences, [])}
+  end
+
+  def update(%{reload_skill_evidence: true} = assigns, socket) do
+    # 更新時再取得
+    # 画面初期表示は最新を上に表示するが、本処理後に位置を動かすと混乱するため同じ位置のままにしている
+    %{skill_evidence_id: skill_evidence_id} = assigns
+
+    skill_evidence =
+      SkillEvidences.get_skill_evidence!(skill_evidence_id)
+      |> Bright.Repo.preload(skill_evidence_posts: [user: [:user_profile]])
+
+    {:ok, stream_insert(socket, :skill_evidences, skill_evidence)}
+  end
+
+  def update(assigns, socket) do
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> load_recent_skill_evidences()}
+  end
+
+  def handle_event("read_more", _params, socket) do
+    {:noreply, load_recent_skill_evidences(socket)}
+  end
+
+  def handle_event("edit_skill_evidence", %{"id" => id}, socket) do
+    %{current_user: current_user} = socket.assigns
+    skill_evidence = SkillEvidences.get_skill_evidence!(id)
+    skill = SkillUnits.get_skill!(skill_evidence.skill_id)
+
+    # モーダルを開き、表示内容を選択した学習メモで初期化する
+    # モーダルを閉じたときは、最新にするupdateを実行する
+    send_update(BrightWeb.ModalComponent,
+      id: "skill-evidence-modal",
+      open: true,
+      on_open: fn ->
+        send_update(BrightWeb.SkillPanelLive.SkillEvidenceComponent,
+          id: "skill-evidence",
+          reset: true,
+          skill_evidence: skill_evidence,
+          skill: skill,
+          user: current_user,
+          me: current_user.id == skill_evidence.user_id
+        )
+      end,
+      on_close: fn ->
+        send_update(__MODULE__,
+          id: socket.assigns.id,
+          reload_skill_evidence: true,
+          skill_evidence_id: skill_evidence.id
+        )
+      end
+    )
+
+    {:noreply, socket}
+  end
+
+  defp load_recent_skill_evidences(socket) do
+    %{display_user: display_user, page_number: page_number} = socket.assigns
+
+    page =
+      SkillEvidences.page_recent_skill_evidences([display_user.id],
+        page: page_number + 1,
+        page_size: @page_size
+      )
+
+    entries = Bright.Repo.preload(page.entries, skill_evidence_posts: [user: [:user_profile]])
+
+    page_number = if(page.entries != [], do: page_number + 1, else: page_number)
+
+    Enum.reduce(entries, socket, fn skill_evidence, acc ->
+      stream_insert(acc, :skill_evidences, skill_evidence)
+    end)
+    |> assign(:page_number, page_number)
+    |> assign(:read_more, page.total_pages > page_number)
+  end
+
+  defp get_latest_skill_evidence_post(skill_evidence) do
+    skill_evidence.skill_evidence_posts
+    |> Enum.sort_by(& &1.inserted_at, {:desc, NaiveDateTime})
+    |> List.first()
+  end
+end

--- a/test/bright_web/live/mypage_live_test.exs
+++ b/test/bright_web/live/mypage_live_test.exs
@@ -157,6 +157,35 @@ defmodule BrightWeb.MypageLiveTest do
       {:ok, lv, _html} = live(conn, ~p"/mypage")
       refute has_element?(lv, "#my-field", "最初の投稿")
     end
+
+    test "paginations", %{conn: conn, user: user} do
+      # 1~11 の投稿作成
+      gen_timestamps(11)
+      |> Enum.with_index(1)
+      |> Enum.map(fn {timestamp, i} ->
+        skill_evidence = create_first_skill_evidence(user)
+
+        insert(:skill_evidence_post,
+          user: user,
+          skill_evidence: skill_evidence,
+          content: "投稿#{i}です",
+          inserted_at: timestamp
+        )
+      end)
+
+      {:ok, lv, html} = live(conn, ~p"/mypage")
+
+      assert html =~ "投稿11です"
+      assert html =~ "投稿2です"
+      refute html =~ "投稿1です"
+
+      # さらに表示
+      lv
+      |> element("button", "さらに表示")
+      |> render_click()
+
+      assert render(lv) =~ "投稿1です"
+    end
   end
 
   # いま学んでいます確認

--- a/test/support/test_helper.ex
+++ b/test/support/test_helper.ex
@@ -19,6 +19,25 @@ defmodule Bright.TestHelper do
   @test_support_dir __DIR__
 
   @doc """
+  時間差を付けたulidを降順で返す
+  """
+  def gen_ulids(num) do
+    gen_timestamps(num)
+    |> Enum.map(&Ecto.ULID.generate(DateTime.to_unix(&1, :millisecond)))
+  end
+
+  @doc """
+  時間差を付けたDateTimeを昇順（先頭が最も過去）で返す
+  """
+  def gen_timestamps(num) do
+    num..1//-1
+    |> Enum.map(fn n ->
+      DateTime.utc_now()
+      |> DateTime.add(-1 * n, :second)
+    end)
+  end
+
+  @doc """
   Setup helper that registers and logs in users.
 
       setup :register_and_log_in_user


### PR DESCRIPTION
マージ先は #1544 用集約ブランチでmainではありません。
対応が多いのでPRを分割しています。

## 対応内容

保有スキル(/mypage) 画面の対応の一部です。

https://github.com/bright-org/bright/issues/1544#issuecomment-2241953438

- 学習メモの「さらに表示」に対応しました
  - そんなに頻度の高い操作とも思わないので無限スクロールではなく、簡易なボタンを押してもらう方向で対応しています

## 参考画像

![sample79](https://github.com/user-attachments/assets/35056c0d-31bc-44e7-9d59-c09c1cfd5f1e)
