### PR TITLE
保有スキル(/mypage) ヘルプを出した学習メモを認識できるようにラベル追加

### DIFF
--- a/lib/bright_web/components/skill_evidence_components.ex
+++ b/lib/bright_web/components/skill_evidence_components.ex
@@ -64,6 +64,7 @@ defmodule BrightWeb.SkillEvidenceComponents do
         >
           <img src="/images/common/icons/skillEvidenceActive.svg">
         </button>
+        <p :if={@skill_evidence.progress == :help} class="border rounded-full p-1 text-xs text-gray-800 bg-gray-50">ヘルプ</p>
       </nav>
     </div>
     """

--- a/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
@@ -150,6 +150,7 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
                   :if={@me}
                   class="text-sm font-bold px-5 py-2 rounded border bg-base text-white"
                   type="submit"
+                  data-confirm="ヘルプを出しますか？"
                   phx-disable-with="送信中..."
                   phx-click={JS.set_attribute({"value", "on"}, to: "#checkbox-help")}
                 >
@@ -259,6 +260,7 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
         maybe_make_filled(user, skill, me)
         maybe_make_notification_evidence_by_help(user, skill_evidence, help?)
         maybe_make_notification_evidence_by_other_post(user, skill_evidence, me)
+        maybe_make_skill_evidence_help(skill_evidence, help?)
 
         {:noreply,
          socket
@@ -365,6 +367,12 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
 
   defp maybe_make_notification_evidence_by_other_post(user, skill_evidence, false) do
     SkillEvidences.receive_post(skill_evidence, user)
+  end
+
+  defp maybe_make_skill_evidence_help(_skill_evidence, false), do: nil
+
+  defp maybe_make_skill_evidence_help(skill_evidence, true) do
+    SkillEvidences.update_skill_evidence(skill_evidence, %{progress: :help})
   end
 
   defp icon_file_path(_user, true), do: UserProfiles.icon_url(nil)


### PR DESCRIPTION
マージ先は #1544 用集約ブランチでmainではありません。
対応が多いのでPRを分割しています。

## 対応内容

保有スキル(/mypage) 画面の対応の一部です。

https://github.com/bright-org/bright/issues/1544#issuecomment-2241953438

- 学習メモでヘルプを出している際に、識別できるようにラベルを追加しました
- またヘルプを出す際に `data-confirm`で確認ダイアログを出しています
  - 通知がわりとチームメンバー全体にいくので前から[課題](https://github.com/orgs/bright-org/projects/3/views/2?filterQuery=%E3%83%98%E3%83%AB%E3%83%97&pane=issue&itemId=60180788)に挙げていた点です
- ヘルプを出したかどうかは既存に用意していた `skill_evidences.progress` を使っています
  - なお、`progress`は完了(done)も当初構想のままありますがその辺りは未実装ままです

## 参考画像

![スクリーンショット 2024-08-06 094936](https://github.com/user-attachments/assets/72c8900b-a6c6-4eba-8ee1-2c505bae72ad)
