### PR TITLE
保有スキル(/mypage) 「自分に戻す」ボタン設置

### DIFF
--- a/lib/bright_web/live/mypage_live/index.ex
+++ b/lib/bright_web/live/mypage_live/index.ex
@@ -32,6 +32,10 @@ defmodule BrightWeb.MypageLive.Index do
      |> apply_action(socket.assigns.live_action, params)}
   end
 
+  def handle_event("clear_display_user", _params, socket) do
+    {:noreply, push_redirect(socket, to: ~p"/mypage")}
+  end
+
   def handle_event("edit_skill_evidence", %{"id" => id}, socket) do
     skill_evidence = SkillEvidences.get_skill_evidence!(id)
     skill = SkillUnits.get_skill!(skill_evidence.skill_id)

--- a/lib/bright_web/live/mypage_live/index.html.heex
+++ b/lib/bright_web/live/mypage_live/index.html.heex
@@ -11,6 +11,7 @@
       github_url={@display_user.user_profile.github_url}
       facebook_url={@display_user.user_profile.facebook_url}
       is_anonymous={@anonymous}
+      display_return_to_yourself={!@me}
     />
   </div>
 


### PR DESCRIPTION
マージ先は #1544 用集約ブランチでmainではありません。
対応が多いのでPRを分割しています。

## 対応内容

「自分に戻す」ボタンが抜けていたので対応しました。

## 参考画像

![image](https://github.com/user-attachments/assets/e8da7050-39db-48cc-8663-fd4965aed3e0)
