### PR TITLE
レベルアップ時文言にクラス番号を追加

### DIFF
--- a/lib/bright/skill_scores.ex
+++ b/lib/bright/skill_scores.ex
@@ -229,7 +229,7 @@ defmodule Bright.SkillScores do
     base_attrs = %{
       from_user_id: user.id,
       message:
-        "#{user.name}さんが#{skill_panel.name}【#{skill_class.name}】で「#{Gettext.gettext(BrightWeb.Gettext, "level_#{level}")}」レベルになりました",
+        "#{user.name}さんが#{skill_panel.name}【クラス#{skill_class.class}：#{skill_class.name}】で「#{Gettext.gettext(BrightWeb.Gettext, "level_#{level}")}」レベルになりました",
       url: "/panels/#{skill_panel.id}/#{user.name}?class=#{skill_class.class}",
       inserted_at: timestamp,
       updated_at: timestamp

--- a/lib/bright_web/live/mypage_live/index.ex
+++ b/lib/bright_web/live/mypage_live/index.ex
@@ -230,7 +230,7 @@ defmodule BrightWeb.MypageLive.Index do
         "#{skill_panel_name}【#{skill_class_name}】を始めました"
 
       _ ->
-        "#{skill_panel_name}【#{skill_class_name}】が「#{level_name}」にレベルアップしました"
+        "#{skill_panel_name}【クラス#{class}：#{skill_class_name}】が「#{level_name}」にレベルアップしました"
     end
   end
 

--- a/test/bright/skill_scores_test.exs
+++ b/test/bright/skill_scores_test.exs
@@ -157,7 +157,7 @@ defmodule Bright.SkillScoresTest do
           page_size: 1
         })
 
-      assert notification.message == "HogeさんがElixir基本【零細Web開発】で「平均」レベルになりました"
+      assert notification.message == "HogeさんがElixir基本【クラス1：零細Web開発】で「平均」レベルになりました"
       assert notification.url == "/panels/#{skill_panel.id}/#{user.name}?class=1"
     end
 


### PR DESCRIPTION
マージ先は #1544 用集約ブランチでmainではありません。
対応が多いのでPRを分割しています。

## 対応内容

Slackでnakoさんより、レベルアップの通知にクラス番号がないとわかりにくいとの意見をいただいたので追加しました。
（意見は通知のところですが、マイページでも同じようなものを表示するので、一緒に対応しました）

![image](https://github.com/user-attachments/assets/4c58a835-680a-4a4b-b72a-5c2df314d357)
