### PR TITLE
マイページ、ジョブパネル、サイドメニューデザイン修正

### DIFF
--- a/lib/bright_web.ex
+++ b/lib/bright_web.ex
@@ -94,7 +94,7 @@ defmodule BrightWeb do
       # Core UI components and translation
       import BrightWeb.CoreComponents
       import BrightWeb.Gettext
-
+      import BrightWeb.ViewHelper
       # Shortcut for generating JS commands
       alias Phoenix.LiveView.JS
 

--- a/lib/bright_web/components/layout_components.ex
+++ b/lib/bright_web/components/layout_components.ex
@@ -206,9 +206,8 @@ defmodule BrightWeb.LayoutComponents do
     [
       {"マイページ", "/mypage", nil, "/images/common/icons/mypage.svg"},
       {"スキルを選ぶ", "/more_skills", nil, "/images/common/icons/skillSelect.svg"},
-      {"保有スキル", "/graphs", nil, "/images/common/icons/mySkill.svg"},
+      {"成長パネル", "/graphs", nil, "/images/common/icons/mySkill.svg"},
       {"チームスキル分析", "/teams", ~r/\/teams(?!\/new)/, "/images/common/icons/skillAnalyze.svg"},
-      {"チームを作る", "/teams/new", nil, "/images/common/icons/teamAdd.svg"},
       {"面談チャット", "/recruits/chats", nil, "/images/common/icons/oneOnOneChat.svg"}
       # TODO α版はskill_upを表示しない
       # {"スキルアップする", "/skill_up"},

--- a/lib/bright_web/live/chat_live/chat_components.ex
+++ b/lib/bright_web/live/chat_live/chat_components.ex
@@ -89,7 +89,7 @@ defmodule BrightWeb.ChatLive.ChatComponents do
             <p class="mt-1 flex justify-end">
               <.elapsed_time extend_style="w-auto" inserted_at={@message.inserted_at} />
             </p>
-            <p class="flex justify-end">(<%= datetime(@message.inserted_at, "Asia/Tokyo") %>)</p>
+            <p class="flex justify-end">(<%= format_datetime(@message.inserted_at, "Asia/Tokyo") %>)</p>
             <div class="flex justify-end cursor-pointer" phx-click="delete_message" phx-value-message_id={@message.id} data-confirm="メッセージを削除しますか？">
               <span class="text-brightGray-500 hover:filter hover:brightness-[80%] hover:underline">削除&nbsp;</span><.icon name="hero-archive-box-x-mark-solid" class="w-6 h-6" />
             </div>
@@ -136,7 +136,7 @@ defmodule BrightWeb.ChatLive.ChatComponents do
           </div>
         </div>
         <p class="-ml-4"><.elapsed_time inserted_at={@message.inserted_at} /></p>
-        <p class="">(<%= datetime(@message.inserted_at, "Asia/Tokyo") %>)</p>
+        <p class="">(<%= format_datetime(@message.inserted_at, "Asia/Tokyo") %>)</p>
         <div class="flex justify-start">
           <%= for file <- Enum.filter(@message.files, & &1.file_type == :images) do %>
             <div
@@ -249,13 +249,6 @@ defmodule BrightWeb.ChatLive.ChatComponents do
   end
 
   defp nl_to_br(str), do: str |> String.replace(~r/\n/, "<br />") |> Phoenix.HTML.raw()
-
-  defp datetime(naive_datetime, "Asia/Tokyo") do
-    naive_datetime
-    |> NaiveDateTime.add(9, :hour)
-    |> NaiveDateTime.to_string()
-    |> String.slice(0, 16)
-  end
 
   defp anon?(anon, chat, user), do: anon and Interview.anon?(chat.interview) and !user.is_member
 end

--- a/lib/bright_web/live/graph_live/graphs.ex
+++ b/lib/bright_web/live/graph_live/graphs.ex
@@ -26,7 +26,7 @@ defmodule BrightWeb.GraphLive.Graphs do
     |> assign(:select_label, "now")
     |> assign(:compared_user, nil)
     |> assign(:select_label_compared_user, nil)
-    |> assign(:page_title, "保有スキル")
+    |> assign(:page_title, "成長パネル")
     |> assign(:open_income_consultation, false)
     |> then(&{:ok, &1})
   end

--- a/lib/bright_web/live/graph_live/graphs.html.heex
+++ b/lib/bright_web/live/graph_live/graphs.html.heex
@@ -98,25 +98,14 @@
         <div class="relative flex flex-col">
           <div class="flex justify-between items-center w-full lg:w-72 gap-x-2">
             <.link
-              patch={~p"/panels/#{@skill_panel}/edit?#{@query}"}
-              id="link-skills-form"
+              navigate={~p"/panels/#{@skill_panel}?#{@query}"}
+              id="link-skills"
               class={[
                 "w-56 flex-1 flex items-center text-sm font-bold justify-center px-4 py-1.5 relative rounded-md !text-white bg-brightGray-900 hover:filter hover:brightness-[80%]"
               ]}
             >
               <span class="material-icons-outlined text-white text-md">edit</span> スキルを入力する
             </.link>
-
-            <div
-              :if={@me}
-              id="btn-help-enter-skills-button"
-              class="flex-none cursor-pointer w-8 h-8 hover:filter hover:brightness-[80%] bg-[url('/images/icon_help.svg')]"
-              phx-click={
-                JS.push("open", target: "#help-enter-skills-button")
-                |> show("#help-enter-skills-button")
-              }
-            >
-            </div>
           </div>
 
           <div class="lg:absolute lg:left-0 lg:top-16 z-10 flex items-center lg:items-end flex-col lg:min-w-[600px]">

--- a/lib/bright_web/live/mypage_live/index.ex
+++ b/lib/bright_web/live/mypage_live/index.ex
@@ -174,6 +174,7 @@ defmodule BrightWeb.MypageLive.Index do
                 <%= skill_up_message(skill_class_score) %>
               </span>
             </.link>
+            <%= format_datetime(skill_class_score.updated_at, "Asia/Tokyo") %>
           </li>
         </ul>
       </div>
@@ -187,17 +188,22 @@ defmodule BrightWeb.MypageLive.Index do
       <h5 class="text-base lg:text-lg">いま学んでいます</h5>
       <div
         :for={skill_evidence <- @recent_others_skill_evidences}
-        class="bg-white rounded-md mt-1 px-2 py-0.5 text-sm font-medium gap-y-2 flex py-2 my-2"
+        class="bg-white rounded-md mt-1 px-2 py-0.5 text-sm font-medium gap-y-2 flex py-2 my-2 flex flex-col"
       >
-        <.skill_evidence
-          skill_evidence={skill_evidence}
-          skill_evidence_post={get_latest_my_skill_evidence_post(skill_evidence)}
-          skill_breadcrumb={SkillEvidences.get_skill_breadcrumb(%{id: skill_evidence.skill_id})}
-          current_user={@current_user}
-          anonymous={@anonymous}
-          related_user_ids={@related_user_ids}
-          display_time={false}
-        />
+        <div class="flex">
+          <.skill_evidence
+            skill_evidence={skill_evidence}
+            skill_evidence_post={get_latest_my_skill_evidence_post(skill_evidence)}
+            skill_breadcrumb={SkillEvidences.get_skill_breadcrumb(%{id: skill_evidence.skill_id})}
+            current_user={@current_user}
+            anonymous={@anonymous}
+            related_user_ids={@related_user_ids}
+            display_time={false}
+          />
+        </div>
+        <span class="text-end">
+          <%= format_datetime(skill_evidence.updated_at, "Asia/Tokyo") %>
+        </span>
       </div>
       <div class="bg-white rounded-md px-2 py-2 my-2 text-sm font-medium">
         <.link navigate={~p"/notifications/evidences"}>

--- a/lib/bright_web/live/onboarding_live/wants_job_components.ex
+++ b/lib/bright_web/live/onboarding_live/wants_job_components.ex
@@ -81,7 +81,7 @@ defmodule BrightWeb.OnboardingLive.WantsJobComponents do
 
   def unlocked_job(assigns) do
     ~H"""
-    <.link navigate={"/#{@current_path}/jobs/#{@job.id}?career_field=#{@career_field.name_en}"}>
+    <div phx-click={JS.navigate("/#{@current_path}/jobs/#{@job.id}?career_field=#{@career_field.name_en}")} class="cursor-pointer">
       <div
         id={"#{@career_field.name_en}-#{@job.id}"}
         class={"px-2 lg:px-4 m-2 rounded w-[150px] lg:w-[340px] h-[100px] lg:h-[74px] flex flex-col hover:bg-[#F5FBFB] #{if is_nil(@score), do: "border-[2px]", else: "border border-brightGreen-300"}"}
@@ -118,7 +118,7 @@ defmodule BrightWeb.OnboardingLive.WantsJobComponents do
           <% end %>
         </div>
       </div>
-    </.link>
+    </div>
     """
   end
 

--- a/lib/bright_web/live/view_helper.ex
+++ b/lib/bright_web/live/view_helper.ex
@@ -1,4 +1,8 @@
 defmodule BrightWeb.ViewHelper do
+  @moduledoc """
+  汎用的な表示用のヘルパー
+  """
+
   def format_datetime(naive_datetime, "Asia/Tokyo") do
     naive_datetime
     |> NaiveDateTime.add(9, :hour)

--- a/lib/bright_web/view_helper.ex
+++ b/lib/bright_web/view_helper.ex
@@ -1,0 +1,8 @@
+defmodule BrightWeb.ViewHelper do
+  def format_datetime(naive_datetime, "Asia/Tokyo") do
+    naive_datetime
+    |> NaiveDateTime.add(9, :hour)
+    |> NaiveDateTime.to_string()
+    |> String.slice(0, 16)
+  end
+end


### PR DESCRIPTION
サイドメニュー、保有スキル -> 成長パネル, チームを作るを削除
ジョブカードのクリッカブル領域修正
マイページの学習メモに日付を追加
成長グラフのスキル入力ボタンをカードレイアウトへのリンクに変更