### PR TITLE
マイページ 学習メモ マークダウン記法が完璧でないときにエラーになる現象の対応、他

### DIFF
--- a/lib/bright/skill_evidences/markdown.ex
+++ b/lib/bright/skill_evidences/markdown.ex
@@ -15,7 +15,17 @@ defmodule Bright.SkillEvidences.Markdown do
   }
 
   def as_html(content) do
-    {:ok, ast, _} = Earmark.Parser.as_ast(content)
+    ast =
+      case Earmark.Parser.as_ast(content) do
+        {:ok, ast, _} ->
+          ast
+
+        {:error, ast, _message} ->
+          # コードブロック閉じがない等でエラーになるが無視してastのみ返す
+          # error時の例
+          # {:error, <ast:略>, [{:error, 1, "Fenced Code Block opened with ``` not closed at end of input"}]
+          ast
+      end
 
     ast
     |> Earmark.Transform.map_ast(&post_processor/1)

--- a/lib/bright_web/components/sns_components.ex
+++ b/lib/bright_web/components/sns_components.ex
@@ -20,7 +20,7 @@ defmodule BrightWeb.SnsComponents do
 
   def sns(assigns) do
     ~H"""
-    <div class="flex gap-x-4 lg:gap-x-6 mr-2 mt-1">
+    <div class="flex-none flex gap-x-3 lg:gap-x-4 mt-1">
       <.icon_button sns_type="x" url={@twitter_url} />
       <.icon_button sns_type="github" url={@github_url} />
       <.icon_button sns_type="facebook" url={@facebook_url} />

--- a/lib/bright_web/live/mypage_live/my_skill_evidences_component.ex
+++ b/lib/bright_web/live/mypage_live/my_skill_evidences_component.ex
@@ -19,7 +19,7 @@ defmodule BrightWeb.MypageLive.MySkillEvidencesComponent do
     <section id={@id}>
       <h5 class="text-base lg:text-lg">学習メモ</h5>
       <div
-        :if={@page_number ==  0}
+        :if={@page_number == 0}
         class="bg-white rounded-md mt-1 px-2 py-0.5 text-sm font-medium gap-y-2 flex py-2 my-2"
       >
         まだ学習メモがありません

--- a/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skill_evidence_component.ex
@@ -76,6 +76,7 @@ defmodule BrightWeb.SkillPanelLive.SkillEvidenceComponent do
                   phx-click="delete"
                   phx-target={@myself}
                   phx-value-id={post.id}
+                  data-confirm="投稿を削除しますか？"
                 >
                   <span class="material-symbols-outlined text-brightGray-500 font-xs hover:filter hover:brightness-[80%]">delete</span>
                 </div>

--- a/test/bright/skill_evidences/markdown_test.exs
+++ b/test/bright/skill_evidences/markdown_test.exs
@@ -183,6 +183,45 @@ defmodule Bright.SkillEvidences.MarkdownTest do
     end
   end
 
+  describe "Incomplete format" do
+    test "code block" do
+      text =
+        String.trim("""
+        ```
+        あああ
+        """)
+
+      html = SkillEvidences.make_content_as_html(text)
+
+      # 中途半端でもエラー無視して解析結果に任せて出力されること
+      assert html == "<pre><code>あああ</code></pre>"
+    end
+
+    test "link" do
+      text =
+        String.trim("""
+        [link](https://
+        """)
+
+      html = SkillEvidences.make_content_as_html(text)
+
+      # 中途半端でもエラー無視して解析結果に任せて出力されること
+      assert html == "<p>[link](https://</p>"
+    end
+
+    test "tag" do
+      text =
+        String.trim("""
+        <a href="https://example.com">test
+        """)
+
+      html = SkillEvidences.make_content_as_html(text)
+
+      # 中途半端でもエラー無視して解析結果に任せて出力されること
+      assert html == "<a href=\"https://example.com\" target=\"_blank\">test</a>"
+    end
+  end
+
   describe "Forbidden format" do
     test "javascript" do
       # tags


### PR DESCRIPTION
## 対応内容

#1544 

マークダウンのパース時に、コードブロックが完結していないなどでエラーになる現象に対応しました。
例えば、投稿文字数を表示都合で省略したり、ユーザー自身が間違えたりしたときに発生します。

また、学習メモ削除押下時に確認ダイアログがなかったので付けました。

微調整として、中途半端な表示サイズのときにSNSアイコンがつぶれる現象に対応しました。
