### PR TITLE
マイページ スキルアップ 時刻表示をupdated_atから適当なカラム参照に変更、ほか

### DIFF
--- a/lib/bright/skill_scores.ex
+++ b/lib/bright/skill_scores.ex
@@ -820,7 +820,7 @@ defmodule Bright.SkillScores do
     |> Enum.slice(0, size)
   end
 
-  defp get_skill_class_score_action_timestamp(skill_class_score) do
+  def get_skill_class_score_action_timestamp(skill_class_score) do
     case {skill_class_score.became_skilled_at, skill_class_score.became_normal_at} do
       {nil, nil} ->
         # 平均, ベテランになければスキルパネル取得日時とする.

--- a/lib/bright_web/components/skill_evidence_components.ex
+++ b/lib/bright_web/components/skill_evidence_components.ex
@@ -40,33 +40,29 @@ defmodule BrightWeb.SkillEvidenceComponents do
     </div>
 
     <%# 投稿表示 %>
-    <div class="grow flex flex-col gap-y-2 mx-2">
+    <div
+      class="grow flex flex-col gap-y-2 mx-2 cursor-pointer link-evidence"
+      phx-click="edit_skill_evidence"
+      phx-target={@myself}
+      phx-value-id={@skill_evidence.id}
+    >
       <div class="text-xs flex justify-between">
         <p class="font-bold"><%= @skill_breadcrumb %></p>
-        <div
-          :if={@display_time}
-          id={"timestamp-#{@skill_evidence_post.id}"}
-          phx-hook="LocalTime"
-          phx-update="ignore"
-          data-iso={NaiveDateTime.to_iso8601(@skill_evidence_post.inserted_at)}
-          >
-          <p class="hidden lg:block" data-local-time="%x %H:%M"></p>
-        </div>
       </div>
       <div class="markdown-body break-all">
         <%= raw content_to_html_shortly(@skill_evidence_post, @content_length) %>
       </div>
-      <nav class="flex items-center gap-x-4">
-        <button
-          class="link-evidence"
-          phx-click="edit_skill_evidence"
-          phx-target={@myself}
-          phx-value-id={@skill_evidence.id}
+      <div class="flex flex-row-reverse justify-between">
+        <div
+          id={"timestamp-#{@skill_evidence_post.id}"}
+          phx-hook="LocalTime"
+          phx-update="ignore"
+          data-iso={NaiveDateTime.to_iso8601(@skill_evidence_post.inserted_at)}
         >
-          <img src="/images/common/icons/skillEvidenceActive.svg">
-        </button>
-        <p :if={@skill_evidence.progress == :help} class="border rounded-full p-1 text-xs text-gray-800 bg-gray-50">ヘルプ</p>
-      </nav>
+          <p data-local-time="%x %H:%M"></p>
+        </div>
+        <p :if={@skill_evidence.progress == :help} class="border rounded-full p-1 text-xs text-white bg-brightGreen-300">ヘルプ</p>
+      </div>
     </div>
     """
   end

--- a/lib/bright_web/live/mypage_live/index.ex
+++ b/lib/bright_web/live/mypage_live/index.ex
@@ -174,7 +174,7 @@ defmodule BrightWeb.MypageLive.Index do
                 <%= skill_up_message(skill_class_score) %>
               </span>
             </.link>
-            <%= format_datetime(skill_class_score.updated_at, "Asia/Tokyo") %>
+            <%= format_datetime(skill_up_datetime(skill_class_score), "Asia/Tokyo", "%Y-%m-%d") %>
           </li>
         </ul>
       </div>
@@ -242,6 +242,10 @@ defmodule BrightWeb.MypageLive.Index do
       _ ->
         "#{skill_panel_name}【クラス#{class}：#{skill_class_name}】が「#{level_name}」にレベルアップしました"
     end
+  end
+
+  defp skill_up_datetime(skill_class_score) do
+    SkillScores.get_skill_class_score_action_timestamp(skill_class_score)
   end
 
   defp get_latest_my_skill_evidence_post(skill_evidence) do

--- a/lib/bright_web/live/mypage_live/index.ex
+++ b/lib/bright_web/live/mypage_live/index.ex
@@ -185,7 +185,10 @@ defmodule BrightWeb.MypageLive.Index do
   defp others_skill_evidences(assigns) do
     ~H"""
     <section>
-      <h5 class="text-base lg:text-lg">いま学んでいます</h5>
+      <h5 class="text-base lg:text-lg flex gap-x-2">
+        いま学んでいます
+        <img src="/images/common/icons/skillEvidenceActive.svg" />
+      </h5>
       <div
         :for={skill_evidence <- @recent_others_skill_evidences}
         class="bg-white rounded-md mt-1 px-2 py-0.5 text-sm font-medium gap-y-2 flex py-2 my-2 flex flex-col"
@@ -201,9 +204,6 @@ defmodule BrightWeb.MypageLive.Index do
             display_time={false}
           />
         </div>
-        <span class="text-end">
-          <%= format_datetime(skill_evidence.updated_at, "Asia/Tokyo") %>
-        </span>
       </div>
       <div class="bg-white rounded-md px-2 py-2 my-2 text-sm font-medium">
         <.link navigate={~p"/notifications/evidences"}>

--- a/lib/bright_web/live/mypage_live/my_skill_evidences_component.ex
+++ b/lib/bright_web/live/mypage_live/my_skill_evidences_component.ex
@@ -17,7 +17,10 @@ defmodule BrightWeb.MypageLive.MySkillEvidencesComponent do
   def render(assigns) do
     ~H"""
     <section id={@id}>
-      <h5 class="text-base lg:text-lg">学習メモ</h5>
+      <h5 class="text-base lg:text-lg flex gap-x-2">
+        学習メモ
+        <img src="/images/common/icons/skillEvidenceActive.svg" />
+      </h5>
       <div
         :if={@page_number ==  0}
         class="bg-white rounded-md mt-1 px-2 py-0.5 text-sm font-medium gap-y-2 flex py-2 my-2"

--- a/lib/bright_web/live/view_helper.ex
+++ b/lib/bright_web/live/view_helper.ex
@@ -3,10 +3,9 @@ defmodule BrightWeb.ViewHelper do
   汎用的な表示用のヘルパー
   """
 
-  def format_datetime(naive_datetime, "Asia/Tokyo") do
+  def format_datetime(naive_datetime, "Asia/Tokyo", string_format \\ "%Y-%m-%d %H:%M") do
     naive_datetime
     |> NaiveDateTime.add(9, :hour)
-    |> NaiveDateTime.to_string()
-    |> String.slice(0, 16)
+    |> Calendar.strftime(string_format)
   end
 end

--- a/test/bright_web/live/mypage_live_test.exs
+++ b/test/bright_web/live/mypage_live_test.exs
@@ -16,7 +16,7 @@ defmodule BrightWeb.MypageLiveTest do
 
   defp open_skill_evidence_modal(lv, skill_evidence) do
     lv
-    |> element("button[class='link-evidence'][phx-value-id='#{skill_evidence.id}']")
+    |> element("div[phx-click='edit_skill_evidence'][phx-value-id='#{skill_evidence.id}']")
     |> render_click()
   end
 


### PR DESCRIPTION
## 対応内容

#1544

本番機投入後のフィードバック対応です。

[マイページ スキルアップ 時刻表示をupdated_atから適当なカラム参照に変更](https://github.com/bright-org/bright/commit/467fc5ebbb1cf4886b0d40a5ee8b1d2fafe21aa6)

[マイページ 学習メモ リンク仕組みの変更、ほか表示調整](https://github.com/bright-org/bright/commit/a9296ac5bb3c1411a276932e7401e0d916915092)

- スキルアップ時刻は適当なカラム参照にしましたが、表示は日付までにしています。時分まで見るケースがいまいちなく細かく出ると情報過多になると考えたため。
- 学習メモのアイコンを削って、全体クリックとのことだったのでそのようにしました。ただアイコンは他の画面でも「学習メモ」を表すわかりやすいものなので、見出し横につけました。
- アイコンがなくなると「ヘルプ」が見つけにくくなったので「ヘルプ」に色を付けました。また学習メモの日時を下の段にしました。

## 参考画像

![スクリーンショット 2024-08-09 135654](https://github.com/user-attachments/assets/b874b384-362a-4a90-865f-f3dd70768f83)
