### PR TITLE
学習メモ HTMLエスケープが多重にかかって表示されていた現象対応

### DIFF
--- a/lib/bright/skill_evidences/markdown.ex
+++ b/lib/bright/skill_evidences/markdown.ex
@@ -30,7 +30,7 @@ defmodule Bright.SkillEvidences.Markdown do
     ast
     |> Earmark.Transform.map_ast(&post_processor/1)
     |> permit()
-    |> Earmark.Transform.transform(%Earmark.Options{compact_output: true})
+    |> Earmark.Transform.transform(%Earmark.Options{compact_output: true, escape: false})
   end
 
   defp permit(ast) do

--- a/lib/bright/skill_evidences/markdown.ex
+++ b/lib/bright/skill_evidences/markdown.ex
@@ -45,10 +45,6 @@ defmodule Bright.SkillEvidences.Markdown do
     make_safe_string(content)
   end
 
-  defp _permit({"code", attrs, [content], _meta}) when is_bitstring(content) do
-    {"code", make_safe_attrs("code", attrs), [content], %{}}
-  end
-
   defp _permit({"a", attrs, [content], _meta}) when is_bitstring(content) do
     {"a", make_safe_attrs("a", attrs ++ [{"target", "_blank"}]), [content], %{}}
   end

--- a/lib/bright/skill_evidences/markdown.ex
+++ b/lib/bright/skill_evidences/markdown.ex
@@ -46,7 +46,7 @@ defmodule Bright.SkillEvidences.Markdown do
   end
 
   defp _permit({"a", attrs, [content], _meta}) when is_bitstring(content) do
-    {"a", make_safe_attrs("a", attrs ++ [{"target", "_blank"}]), [content], %{}}
+    {"a", make_safe_attrs("a", attrs ++ [{"target", "_blank"}]), [make_safe_string(content)], %{}}
   end
 
   defp _permit({tag, attrs, [content], _meta}) when is_bitstring(content) do

--- a/test/bright/skill_evidences/markdown_test.exs
+++ b/test/bright/skill_evidences/markdown_test.exs
@@ -181,6 +181,17 @@ defmodule Bright.SkillEvidences.MarkdownTest do
 
       assert html == "<p>リストです</p><ul><li>リストアイテム1</li><li>リストアイテム2</li></ul>"
     end
+
+    test "html_escape cases" do
+      text =
+        String.trim("""
+        => こうなった
+        """)
+
+      html = SkillEvidences.make_content_as_html(text)
+
+      assert html == "<p>=&gt; こうなった</p>"
+    end
   end
 
   describe "Incomplete format" do
@@ -241,7 +252,7 @@ defmodule Bright.SkillEvidences.MarkdownTest do
 
       html = SkillEvidences.make_content_as_html(text)
 
-      assert html == "<p>&amp;lt;javascript&amp;gt;alert(1);&amp;lt;/javascript&amp;gt;</p>"
+      assert html == "<p>&lt;javascript&gt;alert(1);&lt;/javascript&gt;</p>"
 
       text =
         String.trim("""

--- a/test/bright/skill_evidences/markdown_test.exs
+++ b/test/bright/skill_evidences/markdown_test.exs
@@ -191,6 +191,18 @@ defmodule Bright.SkillEvidences.MarkdownTest do
       html = SkillEvidences.make_content_as_html(text)
 
       assert html == "<p>=&gt; こうなった</p>"
+
+      text =
+        String.trim("""
+        ```
+        <javascript>alert("test")</javascript>
+        ```
+        """)
+
+      html = SkillEvidences.make_content_as_html(text)
+
+      assert html ==
+               "<pre><code>&lt;javascript&gt;alert(&quot;test&quot;)&lt;/javascript&gt;</code></pre>"
     end
   end
 


### PR DESCRIPTION
## 対応内容

close #1640 

エスケープについて

- 構文木時点で考慮＋HTML変換時にライブラリ内部でエスケープ（デフォルト動作）

になってしまっていましたが、

- 構文木時点で考慮

のみにしました


## 参考画像

### 修正前

![image](https://github.com/user-attachments/assets/603f1378-b1f8-4ee5-88fe-66332e480e48)


### 修正後

![image](https://github.com/user-attachments/assets/c345540b-fc63-47c6-aeb6-c8dd8284e902)
