### PR TITLE
ドラフトツール 知識エリア（スキルユニット）移動操作を追加

### DIFF
--- a/lib/bright/draft_skill_units.ex
+++ b/lib/bright/draft_skill_units.ex
@@ -391,6 +391,16 @@ defmodule Bright.DraftSkillUnits do
     end
   end
 
+  def update_draft_skill_class_unit(%DraftSkillClassUnit{} = draft_skill_class_unit, attrs \\ %{}) do
+    draft_skill_class_unit
+    |> DraftSkillClassUnit.changeset(attrs)
+    |> Repo.update()
+  end
+
+  def change_draft_skill_class_unit(%DraftSkillClassUnit{} = draft_skill_class_unit, attrs \\ %{}) do
+    DraftSkillClassUnit.changeset(draft_skill_class_unit, attrs)
+  end
+
   def delete_draft_skill_class_unit(
         %DraftSkillPanels.DraftSkillClass{} = draft_skill_class,
         %DraftSkillUnit{} = draft_skill_unit

--- a/lib/bright_web/live/admin/draft_skill_class_live/show.ex
+++ b/lib/bright_web/live/admin/draft_skill_class_live/show.ex
@@ -9,6 +9,7 @@ defmodule BrightWeb.Admin.DraftSkillClassLive.Show do
     SkillClassFormComponent,
     SkillUnitFormComponent,
     SkillUnitAddFormComponent,
+    SkillUnitReplaceFormComponent,
     SkillCategoryFormComponent,
     SkillCategoryReplaceFormComponent,
     SkillFormComponent,
@@ -132,6 +133,19 @@ defmodule BrightWeb.Admin.DraftSkillClassLive.Show do
   end
 
   defp assign_on_action(:edit_skill_unit, %{"skill_unit_id" => unit_id} = params, socket) do
+    skill_unit = DraftSkillUnits.get_draft_skill_unit!(unit_id)
+
+    {:noreply,
+     socket
+     |> assign(:skill_unit, skill_unit)
+     |> assign_base_page_attrs(params)}
+  end
+
+  defp assign_on_action(
+         :replace_skill_unit,
+         %{"skill_unit_id" => unit_id} = params,
+         socket
+       ) do
     skill_unit = DraftSkillUnits.get_draft_skill_unit!(unit_id)
 
     {:noreply,

--- a/lib/bright_web/live/admin/draft_skill_class_live/show.html.heex
+++ b/lib/bright_web/live/admin/draft_skill_class_live/show.html.heex
@@ -65,6 +65,12 @@
                 <span class="cursor-pointer hero-arrow-down-circle" phx-click="position_down_skill_unit" phx-value-row={row}  />
               <% end %>
 
+              <%= if not single_row_data?(col1) do %>
+                <.link patch={"#{@page_path}/skill_units/#{col1.skill_unit.id}/replace"}>
+                  <span class="hero-arrow-top-right-on-square" />
+                </.link>
+              <% end %>
+
               <.link class="ml-1" patch={"#{@page_path}/skill_units/#{col1.skill_unit.id}/edit"}>
                 <span class="hero-pencil-square" />
               </.link>
@@ -211,6 +217,25 @@
     patch={@page_path}
   />
 </.modal>
+
+<.modal
+  :if={@live_action in [:replace_skill_unit]}
+  id="skill-unit-replace-modal"
+  show
+  on_cancel={JS.patch("#{@page_path}")}
+>
+  <.live_component
+    module={SkillUnitReplaceFormComponent}
+    id={@skill_unit.id}
+    title={@skill_unit.name}
+    action={@live_action}
+    skill_unit={@skill_unit}
+    skill_class={@skill_class}
+    this_skill_panel={@skill_panel}
+    patch={@page_path}
+  />
+</.modal>
+
 
 <%# スキルカテゴリ %>
 <.modal

--- a/lib/bright_web/live/admin/draft_skill_class_live/skill_selection_component.ex
+++ b/lib/bright_web/live/admin/draft_skill_class_live/skill_selection_component.ex
@@ -107,15 +107,25 @@ defmodule BrightWeb.Admin.DraftSkillClassLive.SkillSelectionComponent do
 
   def handle_event("select_skill_class", params, socket) do
     %{"skill_class_id" => skill_class_id} = params
+    %{target: target, on_select: on_select} = socket.assigns
+
     skill_class = DraftSkillPanels.get_draft_skill_class!(skill_class_id)
 
-    {:noreply,
-     socket
-     |> assign(:skill_class, skill_class)
-     |> assign(:skill_unit, nil)
-     |> assign(:skill_category, nil)
-     |> assign_skill_unit_options()
-     |> assign_skill_category_options()}
+    if is_struct(skill_class, target) do
+      on_select.(skill_class)
+
+      {:noreply,
+       socket
+       |> assign(:skill_class, skill_class)}
+    else
+      {:noreply,
+       socket
+       |> assign(:skill_class, skill_class)
+       |> assign(:skill_unit, nil)
+       |> assign(:skill_category, nil)
+       |> assign_skill_unit_options()
+       |> assign_skill_category_options()}
+    end
   end
 
   def handle_event("select_skill_unit", params, socket) do

--- a/lib/bright_web/live/admin/draft_skill_class_live/skill_unit_form_component.ex
+++ b/lib/bright_web/live/admin/draft_skill_class_live/skill_unit_form_component.ex
@@ -24,7 +24,7 @@ defmodule BrightWeb.Admin.DraftSkillClassLive.SkillUnitFormComponent do
 
           <div class="flex gap-x-2">
             <.button
-              :if={@action == :edit_skill_unit}
+              :if={@action == :edit_skill_unit && @removable?}
               class="!bg-orange-400 hover:!bg-orange-300"
               type="button"
               data-confirm="このスキルクラスとの紐づけを解除しますか？"
@@ -50,10 +50,12 @@ defmodule BrightWeb.Admin.DraftSkillClassLive.SkillUnitFormComponent do
   @impl true
   def update(%{skill_unit: skill_unit} = assigns, socket) do
     changeset = DraftSkillUnits.change_draft_skill_unit(skill_unit)
+    removable? = get_removable_skill_unit?(skill_unit)
 
     {:ok,
      socket
      |> assign(assigns)
+     |> assign(:removable?, removable?)
      |> assign_form(changeset)}
   end
 
@@ -127,5 +129,13 @@ defmodule BrightWeb.Admin.DraftSkillClassLive.SkillUnitFormComponent do
 
   defp assign_form(socket, %Ecto.Changeset{} = changeset) do
     assign(socket, :form, to_form(changeset))
+  end
+
+  defp get_removable_skill_unit?(skill_unit) do
+    # スキルクラスに１つしか紐づいていないなら紐づき解除不可とする
+    # UI上でデータが行方不明になるため
+    Ecto.assoc(skill_unit, :draft_skill_class_units)
+    |> Bright.Repo.aggregate(:count)
+    |> then(&(&1 > 1))
   end
 end

--- a/lib/bright_web/live/admin/draft_skill_class_live/skill_unit_replace_form_component.ex
+++ b/lib/bright_web/live/admin/draft_skill_class_live/skill_unit_replace_form_component.ex
@@ -1,0 +1,93 @@
+defmodule BrightWeb.Admin.DraftSkillClassLive.SkillUnitReplaceFormComponent do
+  use BrightWeb, :live_component
+
+  alias Bright.DraftSkillPanels
+  alias Bright.DraftSkillUnits
+  alias BrightWeb.Admin.DraftSkillClassLive.SkillSelectionComponent
+
+  def render(assigns) do
+    ~H"""
+    <div id={@id}>
+      <.header class="my-2">
+        <p><%= @skill_unit.name %></p>
+        <:subtitle>他のスキルクラスへの移動</:subtitle>
+      </.header>
+
+      <.simple_form
+        for={@form}
+        id="skill-unit-replace-form"
+        phx-target={@myself}
+        phx-submit="save"
+      >
+        <.input field={@form[:draft_skill_class_id]} value={@skill_class && @skill_class.id} type="hidden" />
+
+        <.live_component
+          id="skill-unit-selection"
+          module={SkillSelectionComponent}
+          skill_panel={@this_skill_panel}
+          target={Bright.DraftSkillPanels.DraftSkillClass}
+          on_select={on_select_skill_class(@id)}
+        />
+
+        <:actions>
+          <.button phx-disable-with="Saving...">保存</.button>
+        </:actions>
+      </.simple_form>
+    </div>
+    """
+  end
+
+  def update(%{form_skill_class: skill_class}, socket) do
+    # ParentSelectionComponentの選択結果受け取り
+    {:ok, assign(socket, :skill_class, skill_class)}
+  end
+
+  def update(%{skill_unit: skill_unit, skill_class: skill_class} = assigns, socket) do
+    skill_class_unit =
+      DraftSkillUnits.get_draft_skill_class_unit_by(
+        draft_skill_unit_id: skill_unit.id,
+        draft_skill_class_id: skill_class.id
+      )
+
+    changeset = DraftSkillUnits.change_draft_skill_class_unit(skill_class_unit)
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(:skill_class_unit, skill_class_unit)
+     |> assign_form(changeset)}
+  end
+
+  def handle_event("save", %{"draft_skill_class_unit" => params}, socket) do
+    skill_class_unit = socket.assigns.skill_class_unit
+    skill_class = DraftSkillPanels.get_draft_skill_class!(params["draft_skill_class_id"])
+
+    # 末尾追加とする
+    position =
+      DraftSkillUnits.get_max_position(skill_class, :draft_skill_class_units)
+      |> Kernel.+(1)
+
+    params = Map.put(params, "position", position)
+
+    case DraftSkillUnits.update_draft_skill_class_unit(skill_class_unit, params) do
+      {:ok, _skill_class_unit} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "クラスを移動しました")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign_form(socket, changeset)}
+    end
+  end
+
+  defp assign_form(socket, %Ecto.Changeset{} = changeset) do
+    assign(socket, :form, to_form(changeset))
+  end
+
+  defp on_select_skill_class(id) do
+    fn skill_class ->
+      send_update(__MODULE__, id: id, form_skill_class: skill_class)
+    end
+  end
+end

--- a/lib/bright_web/router.ex
+++ b/lib/bright_web/router.ex
@@ -142,6 +142,10 @@ defmodule BrightWeb.Router do
            DraftSkillClassLive.Show,
            :edit_skill_unit
 
+      live "/draft_skill_classes/:id/skill_units/:skill_unit_id/replace",
+           DraftSkillClassLive.Show,
+           :replace_skill_unit
+
       live "/draft_skill_classes/:id/skill_categories/new",
            DraftSkillClassLive.Show,
            :new_skill_category


### PR DESCRIPTION
## 対応内容

issue #1642 

> ③（余力あれば）ドラフト用 ＆ 本番用スキルパネル編集ツール
　→知識エリアの一発移動

の対応になります。

また１つのスキルクラスにしか紐づいていないスキルユニットを紐づけ解除すると、UI上で別のスキルクラスに紐づけできなくなる現象があったので予防しました。

## 参考画像

クラス１からクラス２に移動して、また戻しています。

![sample80](https://github.com/user-attachments/assets/c48a4531-e239-4fa0-8e8b-d21c5b156f94)
