### PR TITLE
TriangleGraphComponentの人数をコメントアウトする

### DIFF
--- a/assets/js/hooks/TriangleGraph.js
+++ b/assets/js/hooks/TriangleGraph.js
@@ -39,7 +39,10 @@ const getPercent = (number, total) => {
 const drawLevel = (ctx, levelText, number, percent, x, y) => {
   ctx.fillStyle = textColor;
   ctx.font = "14px 'Noto Sans JP'";
-  ctx.fillText(levelText + " " + number + "人 " + percent + "%", x, y);
+
+  // 人数は一定期間は封印の為コメントアウト
+  ctx.fillText(levelText + " " + percent + "%", x, y);
+  // ctx.fillText(levelText + " " + number + "人 " + percent + "%", x, y);
 }
 
 const drawTriangleGraph = (element) => {
@@ -58,7 +61,8 @@ const drawTriangleGraph = (element) => {
   drawLevel(ctx, "平均", data.normal, normalPercent, 210, 50);
   drawLevel(ctx, "見習い", + data.beginner, beginnerPercent, 210, 90);
 
-  ctx.fillText( "「 " + data.name + "」登録者 " + total + "人", 5, 120);
+  // 人数は一定期間は封印の為コメントアウト
+  // ctx.fillText( "「 " + data.name + "」登録者 " + total + "人", 5, 120);
 
   // 三角形を重ねて描画します
   // ・見習い


### PR DESCRIPTION
・各レベルの人数を非表示
・登録者人数を非表示
（いずれ復活を想定してコメントアウトで対応）

変更後

![Screenshot from 2024-08-22 14-29-10](https://github.com/user-attachments/assets/0de66814-4ab9-4b96-8a49-cb37ccae5b15)

![image](https://github.com/user-attachments/assets/f9207e25-9e31-4e12-97bc-526f67e841d8)


変更前

![image](https://github.com/user-attachments/assets/cce94474-bec5-43a6-ae80-3b13c61f777a)

![image](https://github.com/user-attachments/assets/0c75b658-54c8-4213-9d4a-29ffceb96951)
