### PR TITLE
「ナイスブライト」に山も表示する

### DIFF
--- a/assets/js/hooks/TriangleGraph.js
+++ b/assets/js/hooks/TriangleGraph.js
@@ -55,6 +55,7 @@ const drawTriangleGraph = (element) => {
   const data = JSON.parse(dataset.data);
   const canvas = document.querySelector("#" + element.id + " canvas");
   const ctx = canvas.getContext('2d');
+  const level = data.level;
 
   const total = data.beginner + data.normal + data.skilled;
 
@@ -62,9 +63,9 @@ const drawTriangleGraph = (element) => {
   const normalPercent = getPercent(data.normal, total);
   const beginnerPercent = total == 0 ? 0 : maxPercent - skilledPercent - normalPercent;
 
-  drawLevel(ctx, "ベテラン", data.skilled, skilledPercent, 210, 15, false);
-  drawLevel(ctx, "平均", data.normal, normalPercent, 210, 50, true);
-  drawLevel(ctx, "見習い", + data.beginner, beginnerPercent, 210, 90, false);
+  drawLevel(ctx, "ベテラン", data.skilled, skilledPercent, 210, 15, level === "skilled");
+  drawLevel(ctx, "平均", data.normal, normalPercent, 210, 50, level === "normal");
+  drawLevel(ctx, "見習い", + data.beginner, beginnerPercent, 210, 90, level === "beginner");
 
   // 人数は一定期間は封印の為コメントアウト
   // ctx.fillText( "「 " + data.name + "」登録者 " + total + "人", 5, 120);

--- a/assets/js/hooks/TriangleGraph.js
+++ b/assets/js/hooks/TriangleGraph.js
@@ -36,12 +36,17 @@ const getPercent = (number, total) => {
 }
 
 // 各レベルのテキストを描画する関数
-const drawLevel = (ctx, levelText, number, percent, x, y) => {
+const drawLevel = (ctx, levelText, number, percent, x, y, isDisplay) => {
   ctx.fillStyle = textColor;
   ctx.font = "14px 'Noto Sans JP'";
 
   // 人数は一定期間は封印の為コメントアウト
   ctx.fillText(levelText + " " + percent + "%", x, y);
+
+  // アイコン取得
+  image = document.querySelector("#user_menu_dropmenu img")
+  if (isDisplay) ctx.drawImage(image, x + 100, y - 15, 20, 20);
+
   // ctx.fillText(levelText + " " + number + "人 " + percent + "%", x, y);
 }
 
@@ -57,9 +62,9 @@ const drawTriangleGraph = (element) => {
   const normalPercent = getPercent(data.normal, total);
   const beginnerPercent = total == 0 ? 0 : maxPercent - skilledPercent - normalPercent;
 
-  drawLevel(ctx, "ベテラン", data.skilled, skilledPercent, 210, 15);
-  drawLevel(ctx, "平均", data.normal, normalPercent, 210, 50);
-  drawLevel(ctx, "見習い", + data.beginner, beginnerPercent, 210, 90);
+  drawLevel(ctx, "ベテラン", data.skilled, skilledPercent, 210, 15, false);
+  drawLevel(ctx, "平均", data.normal, normalPercent, 210, 50, true);
+  drawLevel(ctx, "見習い", + data.beginner, beginnerPercent, 210, 90, false);
 
   // 人数は一定期間は封印の為コメントアウト
   // ctx.fillText( "「 " + data.name + "」登録者 " + total + "人", 5, 120);

--- a/assets/js/hooks/TriangleGraph.js
+++ b/assets/js/hooks/TriangleGraph.js
@@ -10,6 +10,9 @@ const textColor = "#688888";
 
 const maxPercent = 100;
 
+// アイコン取得のセレクタ
+const iconQuery = "#user_menu_dropmenu img";
+
 // 三角形の描画関数
 // 三角形を一つだけ描きます
 const drawTriangle = (ctx, percent, color) => {
@@ -44,7 +47,7 @@ const drawLevel = (ctx, levelText, number, percent, x, y, isDisplay) => {
   ctx.fillText(levelText + " " + percent + "%", x, y);
 
   // アイコン取得
-  image = document.querySelector("#user_menu_dropmenu img")
+  image = document.querySelector(iconQuery)
   if (isDisplay) ctx.drawImage(image, x + 100, y - 15, 20, 20);
 
   // ctx.fillText(levelText + " " + number + "人 " + percent + "%", x, y);

--- a/assets/js/hooks/TriangleGraph.js
+++ b/assets/js/hooks/TriangleGraph.js
@@ -47,7 +47,7 @@ const drawLevel = (ctx, levelText, number, percent, x, y, isDisplay) => {
   ctx.fillText(levelText + " " + percent + "%", x, y);
 
   // アイコン取得
-  image = document.querySelector(iconQuery)
+  const image = document.querySelector(iconQuery)
   if (isDisplay) ctx.drawImage(image, x + 100, y - 15, 20, 20);
 
   // ctx.fillText(levelText + " " + number + "人 " + percent + "%", x, y);

--- a/assets/js/hooks/TriangleGraph.js
+++ b/assets/js/hooks/TriangleGraph.js
@@ -47,7 +47,7 @@ const drawLevel = (ctx, levelText, number, percent, x, y, isDisplay) => {
   ctx.fillText(levelText + " " + percent + "%", x, y);
 
   // アイコン取得
-  const image = document.querySelector(iconQuery)
+  const image = document.querySelector(iconQuery);
   if (isDisplay) ctx.drawImage(image, x + 100, y - 15, 20, 20);
 
   // ctx.fillText(levelText + " " + number + "人 " + percent + "%", x, y);

--- a/assets/js/hooks/TriangleGraph.js
+++ b/assets/js/hooks/TriangleGraph.js
@@ -10,8 +10,8 @@ const textColor = "#688888";
 
 const maxPercent = 100;
 
-// アイコン取得のセレクタ
-const iconQuery = "#user_menu_dropmenu img";
+// アイコン取得のセレクタ BrightWeb.BrightButtonComponentsのuser_buttonのimgを指定してます
+const iconQuery = "#user_icon";
 
 // 三角形の描画関数
 // 三角形を一つだけ描きます
@@ -39,7 +39,7 @@ const getPercent = (number, total) => {
 }
 
 // 各レベルのテキストを描画する関数
-const drawLevel = (ctx, levelText, number, percent, x, y, isDisplay) => {
+const drawLevel = (ctx, levelText, number, percent, x, y, withAvator) => {
   ctx.fillStyle = textColor;
   ctx.font = "14px 'Noto Sans JP'";
 
@@ -48,7 +48,7 @@ const drawLevel = (ctx, levelText, number, percent, x, y, isDisplay) => {
 
   // アイコン取得
   const image = document.querySelector(iconQuery);
-  if (isDisplay) ctx.drawImage(image, x + 100, y - 15, 20, 20);
+  if (withAvator) ctx.drawImage(image, x + 100, y - 15, 20, 20);
 
   // ctx.fillText(levelText + " " + number + "人 " + percent + "%", x, y);
 }

--- a/lib/bright/skill_scores.ex
+++ b/lib/bright/skill_scores.ex
@@ -847,11 +847,11 @@ defmodule Bright.SkillScores do
   スキルパネルIDを指定して、指定したスキルパネルの「見習い」「平均」「ベテラン」
   の人数をカウントする
   """
-  def get_level_count_from_skill_panel_id(skill_panel_id) do
+  def get_level_count_from_skill_panel_id(skill_panel_id, class \\ 1) do
     datas =
       from(scs in SkillClassScore,
         join: sc in assoc(scs, :skill_class),
-        where: sc.class == 1 and sc.skill_panel_id == ^skill_panel_id,
+        where: sc.class == ^class and sc.skill_panel_id == ^skill_panel_id,
         group_by: [scs.level],
         select: %{
           level: scs.level,

--- a/lib/bright_web/components/bright_button_components.ex
+++ b/lib/bright_web/components/bright_button_components.ex
@@ -197,7 +197,9 @@ defmodule BrightWeb.BrightButtonComponents do
       class="fixed top-2 right-0 mr-4 hover:opacity-70 lg:top-0 lg:ml-4 lg:mr-0 lg:relative"
       phx-click={JS.toggle(to: "#personal_setting_modal")}
     >
+     <% # TriangleGraph.jsでもuser_iconを使用しています %>
       <img
+        id="user_icon"
         class="object-cover inline-block h-10 w-10 rounded-full"
         src={@icon_file_path}
       />

--- a/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
+++ b/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
@@ -40,7 +40,7 @@ defmodule BrightWeb.SkillPanelLive.GrowthShareModalComponent do
                 historical_skill_unit_scores={@historical_skill_unit_scores}
                 date_from={@date_from} />
             </div>
-            <div class="flex flex-row">
+            <div class="lg:flex lg:flex-row">
               <.triangle_graph data={@skill_share_data_past} id="triangle_graph_past"/>
               <div>
                 <p class="text-lg">Level Up!</p>

--- a/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
+++ b/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
@@ -67,7 +67,7 @@ defmodule BrightWeb.SkillPanelLive.GrowthShareModalComponent do
       |> Map.merge(%{name: skill_panel.name, level: assigns.new_level})
 
     prev_skill_share_data =
-      Map.get(assigns, :prev_skill_share_data, socket.assigns.prev_skill_share_data)
+      assigns.prev_skill_share_data
       |> Map.merge(%{level: assigns.prev_level})
 
     # スキルクラスも取る

--- a/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
+++ b/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
@@ -64,7 +64,11 @@ defmodule BrightWeb.SkillPanelLive.GrowthShareModalComponent do
 
     skill_share_data =
       SkillScores.get_level_count_from_skill_panel_id(skill_panel.id)
-      |> Map.merge(%{name: skill_panel.name})
+      |> Map.merge(%{name: skill_panel.name, level: assigns.new_level})
+
+    skill_share_data_past =
+      socket.assigns.skill_share_data_past
+      |> Map.merge(%{level: assigns.prev_level})
 
     # スキルクラスも取る
     # 現状と3か月前を比べての成果も出す
@@ -75,6 +79,7 @@ defmodule BrightWeb.SkillPanelLive.GrowthShareModalComponent do
      |> assign(:skill_class, skill_class)
      |> assign(:skill_panel, skill_panel)
      |> assign(:skill_share_data, skill_share_data)
+     |> assign(:skill_share_data_past, skill_share_data_past)
      |> assign_presents()
      |> assign_historicals()}
   end

--- a/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
+++ b/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
@@ -6,6 +6,7 @@ defmodule BrightWeb.SkillPanelLive.GrowthShareModalComponent do
   use BrightWeb, :live_component
 
   import BrightWeb.BrightModalComponents
+  import BrightWeb.BrightGraphComponents
 
   alias BrightWeb.SnsComponents
   alias BrightWeb.TimelineHelper
@@ -39,6 +40,7 @@ defmodule BrightWeb.SkillPanelLive.GrowthShareModalComponent do
                 historical_skill_unit_scores={@historical_skill_unit_scores}
                 date_from={@date_from} />
             </div>
+            <.triangle_graph data={@skill_share_data} id="triangle_graph"/>
           </div>
         </div>
 
@@ -53,6 +55,10 @@ defmodule BrightWeb.SkillPanelLive.GrowthShareModalComponent do
     skill_class = SkillPanels.get_skill_class!(assigns.skill_class_id)
     skill_panel = SkillPanels.get_skill_panel!(skill_class.skill_panel_id)
 
+    skill_share_data =
+      SkillScores.get_level_count_from_skill_panel_id(skill_panel.id)
+      |> Map.merge(%{name: skill_panel.name})
+
     # スキルクラスも取る
     # 現状と3か月前を比べての成果も出す
     {:ok,
@@ -61,6 +67,7 @@ defmodule BrightWeb.SkillPanelLive.GrowthShareModalComponent do
      |> assign(:user, user)
      |> assign(:skill_class, skill_class)
      |> assign(:skill_panel, skill_panel)
+     |> assign(:skill_share_data, skill_share_data)
      |> assign_presents()
      |> assign_historicals()}
   end

--- a/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
+++ b/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
@@ -42,9 +42,10 @@ defmodule BrightWeb.SkillPanelLive.GrowthShareModalComponent do
             </div>
             <div class="lg:flex lg:flex-row">
               <.triangle_graph data={@prev_skill_share_data} id="triangle_graph_past"/>
-              <div>
-                <p class="text-lg">Level Up!</p>
-                <p class="material-icons text-7xl">arrow_right_alt</p>
+              <div class="w-[75px] ml-[65px] mb-[5px] flex flex-col justify-center lg:ml-0 lg:block">
+                <span class="text-lg">Level Up!</span>
+                <span class="hidden lg:inline material-icons text-7xl">arrow_right_alt</span>
+                <span class="lg:hidden material-icons text-7xl">arrow_downward</span>
               </div>
               <.triangle_graph data={@skill_share_data} id="triangle_graph"/>
             </div>

--- a/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
+++ b/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
@@ -41,7 +41,7 @@ defmodule BrightWeb.SkillPanelLive.GrowthShareModalComponent do
                 date_from={@date_from} />
             </div>
             <div class="lg:flex lg:flex-row">
-              <.triangle_graph data={@skill_share_data_past} id="triangle_graph_past"/>
+              <.triangle_graph data={@prev_skill_share_data} id="triangle_graph_past"/>
               <div>
                 <p class="text-lg">Level Up!</p>
                 <p class="material-icons text-7xl">arrow_right_alt</p>
@@ -66,8 +66,8 @@ defmodule BrightWeb.SkillPanelLive.GrowthShareModalComponent do
       SkillScores.get_level_count_from_skill_panel_id(skill_panel.id)
       |> Map.merge(%{name: skill_panel.name, level: assigns.new_level})
 
-    skill_share_data_past =
-      Map.get(assigns, :skill_share_data_past, socket.assigns.skill_share_data_past)
+    prev_skill_share_data =
+      Map.get(assigns, :prev_skill_share_data, socket.assigns.prev_skill_share_data)
       |> Map.merge(%{level: assigns.prev_level})
 
     # スキルクラスも取る
@@ -79,7 +79,7 @@ defmodule BrightWeb.SkillPanelLive.GrowthShareModalComponent do
      |> assign(:skill_class, skill_class)
      |> assign(:skill_panel, skill_panel)
      |> assign(:skill_share_data, skill_share_data)
-     |> assign(:skill_share_data_past, skill_share_data_past)
+     |> assign(:prev_skill_share_data, prev_skill_share_data)
      |> assign_presents()
      |> assign_historicals()}
   end

--- a/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
+++ b/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
@@ -40,7 +40,14 @@ defmodule BrightWeb.SkillPanelLive.GrowthShareModalComponent do
                 historical_skill_unit_scores={@historical_skill_unit_scores}
                 date_from={@date_from} />
             </div>
-            <.triangle_graph data={@skill_share_data} id="triangle_graph"/>
+            <div class="flex flex-row">
+              <.triangle_graph data={@skill_share_data_past} id="triangle_graph_past"/>
+              <div>
+                <p class="text-lg">Level Up!</p>
+                <p class="material-icons text-7xl">arrow_right_alt</p>
+              </div>
+              <.triangle_graph data={@skill_share_data} id="triangle_graph"/>
+            </div>
           </div>
         </div>
 

--- a/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
+++ b/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
@@ -64,7 +64,7 @@ defmodule BrightWeb.SkillPanelLive.GrowthShareModalComponent do
     skill_panel = SkillPanels.get_skill_panel!(skill_class.skill_panel_id)
 
     skill_share_data =
-      SkillScores.get_level_count_from_skill_panel_id(skill_panel.id)
+      SkillScores.get_level_count_from_skill_panel_id(skill_panel.id, skill_class.class)
       |> Map.merge(%{name: skill_panel.name, level: assigns.new_level})
 
     prev_skill_share_data =

--- a/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
+++ b/lib/bright_web/live/skill_panel_live/growth_share_modal_component.ex
@@ -67,7 +67,7 @@ defmodule BrightWeb.SkillPanelLive.GrowthShareModalComponent do
       |> Map.merge(%{name: skill_panel.name, level: assigns.new_level})
 
     skill_share_data_past =
-      socket.assigns.skill_share_data_past
+      Map.get(assigns, :skill_share_data_past, socket.assigns.skill_share_data_past)
       |> Map.merge(%{level: assigns.prev_level})
 
     # スキルクラスも取る

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -130,7 +130,10 @@ defmodule BrightWeb.SkillPanelLive.Skills do
     prev_skill_class_score = SkillScores.get_skill_class_score!(skill_class_score.id)
 
     prev_skill_share_data =
-      SkillScores.get_level_count_from_skill_panel_id(socket.assigns.skill_panel.id)
+      SkillScores.get_level_count_from_skill_panel_id(
+        socket.assigns.skill_panel.id,
+        socket.assigns.skill_class.class
+      )
 
     SkillScores.get_skill_score!(id)
     |> Map.put(:score, String.to_atom(score))

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -129,6 +129,9 @@ defmodule BrightWeb.SkillPanelLive.Skills do
     skill_class_score = socket.assigns.skill_class_score
     prev_skill_class_score = SkillScores.get_skill_class_score!(skill_class_score.id)
 
+    prev_skill_share_data =
+      SkillScores.get_level_count_from_skill_panel_id(socket.assigns.skill_panel.id)
+
     SkillScores.get_skill_score!(id)
     |> Map.put(:score, String.to_atom(score))
     |> then(&[&1])
@@ -136,7 +139,7 @@ defmodule BrightWeb.SkillPanelLive.Skills do
 
     send_update(BrightWeb.OgpComponent, id: "ogp")
 
-    open_growth_share(prev_skill_class_score)
+    open_growth_share(prev_skill_class_score, prev_skill_share_data)
     assign_renew(socket, params["class"])
   end
 
@@ -274,7 +277,7 @@ defmodule BrightWeb.SkillPanelLive.Skills do
 
   defp put_flash_first_skills_edit(socket), do: socket
 
-  defp open_growth_share(skill_class_score) do
+  defp open_growth_share(skill_class_score, prev_skill_share_data) do
     prev_level = skill_class_score.level
     prev_percentage = skill_class_score.percentage
 
@@ -289,7 +292,8 @@ defmodule BrightWeb.SkillPanelLive.Skills do
         user_id: skill_class_score.user_id,
         skill_class_id: skill_class_score.skill_class_id,
         new_level: new_level,
-        prev_level: prev_level
+        prev_level: prev_level,
+        prev_skill_share_data: prev_skill_share_data
       )
     end
   end

--- a/lib/bright_web/live/skill_panel_live/skills.ex
+++ b/lib/bright_web/live/skill_panel_live/skills.ex
@@ -287,7 +287,9 @@ defmodule BrightWeb.SkillPanelLive.Skills do
         id: "growth_share",
         open: true,
         user_id: skill_class_score.user_id,
-        skill_class_id: skill_class_score.skill_class_id
+        skill_class_id: skill_class_score.skill_class_id,
+        new_level: new_level,
+        prev_level: prev_level
       )
     end
   end

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -318,7 +318,7 @@
    module={GrowthShareModalComponent}
    id="growth_share"
    share_graph_url={@share_graph_url}
-   skill_share_data_past={@skill_share_data}
+   prev_skill_share_data={@skill_share_data}
    >
 </.live_component>
 

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -318,7 +318,6 @@
    module={GrowthShareModalComponent}
    id="growth_share"
    share_graph_url={@share_graph_url}
-   prev_skill_share_data={@skill_share_data}
    >
 </.live_component>
 

--- a/lib/bright_web/live/skill_panel_live/skills.html.heex
+++ b/lib/bright_web/live/skill_panel_live/skills.html.heex
@@ -318,6 +318,7 @@
    module={GrowthShareModalComponent}
    id="growth_share"
    share_graph_url={@share_graph_url}
+   skill_share_data_past={@skill_share_data}
    >
 </.live_component>
 

--- a/lib/bright_web/live/skill_panel_live/skills_form_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_form_component.ex
@@ -238,14 +238,18 @@ defmodule BrightWeb.SkillPanelLive.SkillsFormComponent do
     %{
       user: user,
       skill_class_score: skill_class_score,
-      skill_score_dict: skill_score_dict
+      skill_score_dict: skill_score_dict,
+      skill_panel: skill_panel
     } = socket.assigns
+
+    skill_share_data =
+      SkillScores.get_level_count_from_skill_panel_id(skill_panel.id)
 
     target_skill_scores = skill_score_dict |> Map.values() |> Enum.filter(& &1.changed)
     {:ok, _updated_result} = SkillScores.insert_or_update_skill_scores(target_skill_scores, user)
 
     # スキルクラスのレベル変更時に保有スキルカードの表示変更を通知
-    maybe_update_skill_card_component(skill_class_score)
+    maybe_update_skill_card_component(skill_class_score, skill_share_data)
 
     {:noreply,
      socket
@@ -384,7 +388,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsFormComponent do
     |> assign(:first_time_in_skill_panel, first_time_in_skill_panel)
   end
 
-  defp maybe_update_skill_card_component(skill_class_score) do
+  defp maybe_update_skill_card_component(skill_class_score, skill_share_data) do
     prev_level = skill_class_score.level
     prev_percentage = skill_class_score.percentage
 
@@ -404,7 +408,8 @@ defmodule BrightWeb.SkillPanelLive.SkillsFormComponent do
         user_id: skill_class_score.user_id,
         skill_class_id: skill_class_score.skill_class_id,
         new_level: new_level,
-        prev_level: prev_level
+        prev_level: prev_level,
+        skill_share_data_past: skill_share_data
       )
     end
   end

--- a/lib/bright_web/live/skill_panel_live/skills_form_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_form_component.ex
@@ -250,7 +250,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsFormComponent do
     {:ok, _updated_result} = SkillScores.insert_or_update_skill_scores(target_skill_scores, user)
 
     # スキルクラスのレベル変更時に保有スキルカードの表示変更を通知
-    maybe_update_skill_card_component(skill_class_score, prev_skill_share_data)
+    maybe_update_related_component(skill_class_score, prev_skill_share_data)
 
     {:noreply,
      socket
@@ -389,7 +389,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsFormComponent do
     |> assign(:first_time_in_skill_panel, first_time_in_skill_panel)
   end
 
-  defp maybe_update_skill_card_component(skill_class_score, prev_skill_share_data) do
+  defp maybe_update_related_component(skill_class_score, prev_skill_share_data) do
     prev_level = skill_class_score.level
     prev_percentage = skill_class_score.percentage
 

--- a/lib/bright_web/live/skill_panel_live/skills_form_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_form_component.ex
@@ -242,14 +242,14 @@ defmodule BrightWeb.SkillPanelLive.SkillsFormComponent do
       skill_panel: skill_panel
     } = socket.assigns
 
-    skill_share_data =
+    prev_skill_share_data =
       SkillScores.get_level_count_from_skill_panel_id(skill_panel.id)
 
     target_skill_scores = skill_score_dict |> Map.values() |> Enum.filter(& &1.changed)
     {:ok, _updated_result} = SkillScores.insert_or_update_skill_scores(target_skill_scores, user)
 
     # スキルクラスのレベル変更時に保有スキルカードの表示変更を通知
-    maybe_update_skill_card_component(skill_class_score, skill_share_data)
+    maybe_update_skill_card_component(skill_class_score, prev_skill_share_data)
 
     {:noreply,
      socket
@@ -388,7 +388,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsFormComponent do
     |> assign(:first_time_in_skill_panel, first_time_in_skill_panel)
   end
 
-  defp maybe_update_skill_card_component(skill_class_score, skill_share_data) do
+  defp maybe_update_skill_card_component(skill_class_score, prev_skill_share_data) do
     prev_level = skill_class_score.level
     prev_percentage = skill_class_score.percentage
 
@@ -409,7 +409,7 @@ defmodule BrightWeb.SkillPanelLive.SkillsFormComponent do
         skill_class_id: skill_class_score.skill_class_id,
         new_level: new_level,
         prev_level: prev_level,
-        skill_share_data_past: skill_share_data
+        prev_skill_share_data: prev_skill_share_data
       )
     end
   end

--- a/lib/bright_web/live/skill_panel_live/skills_form_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_form_component.ex
@@ -239,11 +239,12 @@ defmodule BrightWeb.SkillPanelLive.SkillsFormComponent do
       user: user,
       skill_class_score: skill_class_score,
       skill_score_dict: skill_score_dict,
-      skill_panel: skill_panel
+      skill_panel: skill_panel,
+      skill_class: skill_class
     } = socket.assigns
 
     prev_skill_share_data =
-      SkillScores.get_level_count_from_skill_panel_id(skill_panel.id)
+      SkillScores.get_level_count_from_skill_panel_id(skill_panel.id, skill_class.class)
 
     target_skill_scores = skill_score_dict |> Map.values() |> Enum.filter(& &1.changed)
     {:ok, _updated_result} = SkillScores.insert_or_update_skill_scores(target_skill_scores, user)

--- a/lib/bright_web/live/skill_panel_live/skills_form_component.ex
+++ b/lib/bright_web/live/skill_panel_live/skills_form_component.ex
@@ -398,12 +398,13 @@ defmodule BrightWeb.SkillPanelLive.SkillsFormComponent do
 
     if prev_level != new_level && prev_percentage < new_percentage do
       # レベルアップ時の表示モーダル
-      # TODO: 現在はガワだけ実装のためコメントアウトしている。シェアするURLやOGPに対応したら有効化する
       send_update(GrowthShareModalComponent,
         id: "growth_share",
         open: true,
         user_id: skill_class_score.user_id,
-        skill_class_id: skill_class_score.skill_class_id
+        skill_class_id: skill_class_score.skill_class_id,
+        new_level: new_level,
+        prev_level: prev_level
       )
     end
   end


### PR DESCRIPTION
対応内容
・三角グラフ（山）を表示
・レベルアップ前後でどのレベルかアイコンで表示

あらかじめ、PCの画面はhaigoさんにOKもらってます

PC
![image](https://github.com/user-attachments/assets/0b967c61-17f2-42ca-91e2-d1b81fd731c4)

SP
![image](https://github.com/user-attachments/assets/a1495a9a-92fb-45b9-8680-826100b17af9)

今回も修正しないこと
各パーセンテージについて
beginnerはmaxPercent - skilledPercent - normalPercent
の為割り切れないと、LevelUPの前後の各パーセンテージと誤差は発生します
beginner + normal + skilled　= 100%になることを重視しました
