### PR TITLE
ドラフトツール 本番への反映処理を追加

### DIFF
--- a/lib/bright/draft_skill_panels.ex
+++ b/lib/bright/draft_skill_panels.ex
@@ -9,6 +9,9 @@ defmodule Bright.DraftSkillPanels do
 
   alias Bright.DraftSkillPanels.SkillPanel
   alias Bright.DraftSkillPanels.DraftSkillClass
+  alias Bright.DraftSkillPanels.Release
+
+  defdelegate commit_to_release(skill_panel), to: Release, as: :commit
 
   @doc """
   Returns the list of skill_panels.

--- a/lib/bright/draft_skill_panels/release.ex
+++ b/lib/bright/draft_skill_panels/release.ex
@@ -1,0 +1,461 @@
+defmodule Bright.DraftSkillPanels.Release do
+  @moduledoc """
+  スキルパネル単位でドラフトを本番系に反映させる処理
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Bright.SkillScores
+  alias Bright.Repo
+
+  alias Bright.SkillPanels.SkillClass
+  alias Bright.SkillUnits
+  alias Bright.SkillUnits.SkillClassUnit
+  alias Bright.SkillUnits.SkillUnit
+  alias Bright.SkillUnits.SkillCategory
+  alias Bright.SkillUnits.Skill
+
+  alias Bright.DraftSkillPanels.SkillPanel, as: DraftSkillPanel
+  alias Bright.DraftSkillPanels.DraftSkillClass
+  alias Bright.DraftSkillUnits.DraftSkillClassUnit
+  alias Bright.DraftSkillUnits.DraftSkill
+
+  alias BrightWeb.TimelineHelper
+
+  @doc """
+  反映処理
+
+  - 指定スキルパネルに属するスキルクラス以下のデータが対象になる
+    - スキルユニットを共有しているケースでは、指定スキルパネルを越えて影響する
+  - 更新処理は大きく2つに分かれる
+    - スキル構造反映
+    - 影響対象のユーザースコア再計算（スキルクラス、スキルユニット）
+      - キャリアフィールドスコアは日一回のバッチ処理に任せる
+      - NOTE: 再計算に係る時間はユーザー数に依存するため、増えた場合には何かしらバッチ処理に落とす必要がある
+  """
+  def commit(skill_panel) do
+    {:ok, focused_skill_classes} = commit_structures(skill_panel)
+    SkillScores.re_aggregate_scores(focused_skill_classes)
+  end
+
+  defp commit_structures(skill_panel) do
+    # 指定スキルパネルのスキルクラス以下のデータを生成、更新、削除している
+    # - スキルクラスに関しては削除はない（スキルパネルごと削除がそれにあたる）
+    # - 返値は、後続処理の便宜上、スコア変動が発生する可能性があるスキルユニット一覧としている
+
+    # 移動前後を含めて考慮するため、最小単位のスキルから、ドラフトと本番の指定スキルパネルの全対象データを得ている
+    all_target_skill_trace_ids = list_target_skill_trace_ids(skill_panel)
+
+    # 対象データの、ドラフトと本番のそれぞれのデータを取得している（移動前後があるため指定スキルパネル以外に属するものも含む）
+    d_skill_classes = list_draft_skill_classes(skill_panel)
+    c_skill_classes = list_skill_classes(skill_panel)
+
+    {d_skills, d_skill_categories, d_skill_units} =
+      list_draft_skill_structures(all_target_skill_trace_ids)
+
+    {c_skills, c_skill_categories, c_skill_units} =
+      list_skill_structures(all_target_skill_trace_ids)
+
+    d_skill_class_units = list_draft_skill_class_units(d_skill_units)
+    c_skill_class_units = list_skill_class_units(c_skill_units)
+
+    Repo.transaction(fn ->
+      # スキルクラス
+      {_count, skill_classes} = commit_skill_classes(d_skill_classes, c_skill_classes)
+
+      # スキルユニット
+      {_count, skill_units} = commit_skill_units(d_skill_units, c_skill_units)
+
+      # スキルカテゴリ
+      {_count, skill_categories} =
+        commit_skill_categories(
+          d_skill_categories,
+          c_skill_categories,
+          skill_units,
+          d_skill_units
+        )
+
+      # スキル
+      {_count, _skills} = commit_skills(d_skills, c_skills, skill_categories, d_skill_categories)
+
+      # スキルクラス-スキルユニット関連
+      # 移動を考慮すると指定スキルパネル以外に紐づくスキルクラスも必要のため再取得
+      d_skill_classes = list_draft_skill_classes(d_skill_units)
+      skill_classes = Enum.uniq(list_skill_classes(d_skill_classes) ++ skill_classes)
+
+      {_count, _skill_class_unit} =
+        commit_skill_class_units(
+          d_skill_class_units,
+          c_skill_class_units,
+          skill_classes,
+          d_skill_classes,
+          skill_units,
+          d_skill_units
+        )
+
+      # 使われていないデータを削除する
+      # 外部制約があるので作成とは逆順に行う
+      delete_skill_class_units(d_skill_class_units, c_skill_class_units)
+      delete_skills(d_skills, c_skills)
+      delete_skill_categories(d_skill_categories, c_skill_categories)
+      delete_skill_units(d_skill_units, c_skill_units)
+
+      # スキルスコア更新が必要な可能性のあるスキルクラスを一式返す
+      Enum.uniq(skill_classes ++ c_skill_classes)
+    end)
+  end
+
+  defp commit_skill_classes(d_skill_classes, c_skill_classes) do
+    # 作成と更新をupsertで対応する
+    id_by_trace_id = Map.new(c_skill_classes, &{&1.trace_id, &1.id})
+    placeholders = gen_upsert_placeholders([:timestamp, :locked_date])
+
+    attrs_list =
+      Enum.map(d_skill_classes, fn d_skill_class ->
+        id = Map.get(id_by_trace_id, d_skill_class.trace_id, Ecto.ULID.generate())
+
+        %{
+          id: id,
+          trace_id: d_skill_class.trace_id,
+          name: d_skill_class.name,
+          class: d_skill_class.class,
+          skill_panel_id: d_skill_class.skill_panel_id,
+          locked_date: {:placeholder, :locked_date},
+          inserted_at: {:placeholder, :timestamp},
+          updated_at: {:placeholder, :timestamp}
+        }
+      end)
+
+    # idが同じものは更新、その他は新規作成
+    Repo.insert_all(
+      SkillClass,
+      attrs_list,
+      placeholders: placeholders,
+      on_conflict: {:replace, [:name, :updated_at]},
+      conflict_target: [:id],
+      returning: true
+    )
+  end
+
+  defp commit_skill_units(d_skill_units, c_skill_units) do
+    # 作成と更新をupsertで対応する
+    id_by_trace_id = Map.new(c_skill_units, &{&1.trace_id, &1.id})
+    placeholders = gen_upsert_placeholders([:timestamp, :locked_date])
+
+    attrs_list =
+      Enum.map(d_skill_units, fn d_skill_unit ->
+        id = Map.get(id_by_trace_id, d_skill_unit.trace_id, Ecto.ULID.generate())
+
+        %{
+          id: id,
+          trace_id: d_skill_unit.trace_id,
+          name: d_skill_unit.name,
+          locked_date: {:placeholder, :locked_date},
+          inserted_at: {:placeholder, :timestamp},
+          updated_at: {:placeholder, :timestamp}
+        }
+      end)
+
+    # idが同じものは更新、その他は新規作成
+    Repo.insert_all(
+      SkillUnit,
+      attrs_list,
+      placeholders: placeholders,
+      on_conflict: {:replace, [:name, :updated_at]},
+      conflict_target: [:id],
+      returning: true
+    )
+  end
+
+  defp commit_skill_categories(d_skill_categories, c_skill_categories, skill_units, d_skill_units) do
+    # 作成と更新をupsertで対応する
+    id_by_trace_id = Map.new(c_skill_categories, &{&1.trace_id, &1.id})
+    placeholders = gen_upsert_placeholders([:timestamp])
+
+    # 親スキルユニットをtrace_id経由で特定できるように辞書を生成
+    parent_trace_id_by_draft_parent_id = Map.new(d_skill_units, &{&1.id, &1.trace_id})
+    skill_unit_id_by_trace_id = Map.new(skill_units, &{&1.trace_id, &1.id})
+
+    attrs_list =
+      Enum.map(d_skill_categories, fn d_skill_category ->
+        id = Map.get(id_by_trace_id, d_skill_category.trace_id, Ecto.ULID.generate())
+
+        parent_trace_id =
+          Map.get(parent_trace_id_by_draft_parent_id, d_skill_category.draft_skill_unit_id)
+
+        skill_unit_id = Map.get(skill_unit_id_by_trace_id, parent_trace_id)
+
+        %{
+          id: id,
+          trace_id: d_skill_category.trace_id,
+          name: d_skill_category.name,
+          position: d_skill_category.position,
+          skill_unit_id: skill_unit_id,
+          inserted_at: {:placeholder, :timestamp},
+          updated_at: {:placeholder, :timestamp}
+        }
+      end)
+
+    # idが同じものは更新、その他は新規作成
+    Repo.insert_all(
+      SkillCategory,
+      attrs_list,
+      placeholders: placeholders,
+      on_conflict: {:replace, [:name, :position, :skill_unit_id, :updated_at]},
+      conflict_target: [:id],
+      returning: true
+    )
+  end
+
+  defp commit_skills(d_skills, c_skills, skill_categories, d_skill_categories) do
+    # 作成と更新をupsertで対応する
+    id_by_trace_id = Map.new(c_skills, &{&1.trace_id, &1.id})
+    placeholders = gen_upsert_placeholders([:timestamp])
+
+    # 親スキルカテゴリをtrace_id経由で特定できるように辞書を生成
+    parent_trace_id_by_draft_parent_id = Map.new(d_skill_categories, &{&1.id, &1.trace_id})
+    skill_category_id_by_trace_id = Map.new(skill_categories, &{&1.trace_id, &1.id})
+
+    attrs_list =
+      Enum.map(d_skills, fn d_skill ->
+        id = Map.get(id_by_trace_id, d_skill.trace_id, Ecto.ULID.generate())
+
+        parent_trace_id =
+          Map.get(parent_trace_id_by_draft_parent_id, d_skill.draft_skill_category_id)
+
+        skill_category_id = Map.get(skill_category_id_by_trace_id, parent_trace_id)
+
+        %{
+          id: id,
+          trace_id: d_skill.trace_id,
+          name: d_skill.name,
+          position: d_skill.position,
+          skill_category_id: skill_category_id,
+          inserted_at: {:placeholder, :timestamp},
+          updated_at: {:placeholder, :timestamp}
+        }
+      end)
+
+    # idが同じものは更新、その他は新規作成
+    Repo.insert_all(
+      Skill,
+      attrs_list,
+      placeholders: placeholders,
+      on_conflict: {:replace, [:name, :position, :skill_category_id, :updated_at]},
+      conflict_target: [:id],
+      returning: true
+    )
+  end
+
+  defp commit_skill_class_units(
+         d_skill_class_units,
+         c_skill_class_units,
+         skill_classes,
+         d_skill_classes,
+         skill_units,
+         d_skill_units
+       ) do
+    # 作成と更新をupsertで対応する
+    id_by_trace_id = Map.new(c_skill_class_units, &{&1.trace_id, &1.id})
+    placeholders = gen_upsert_placeholders([:timestamp])
+
+    # 関連をtrace_id経由で特定できるように辞書を生成
+    skill_class_trace_id_by_draft_id = Map.new(d_skill_classes, &{&1.id, &1.trace_id})
+    skill_class_id_by_trace_id = Map.new(skill_classes, &{&1.trace_id, &1.id})
+    skill_unit_trace_id_by_draft_id = Map.new(d_skill_units, &{&1.id, &1.trace_id})
+    skill_unit_id_by_trace_id = Map.new(skill_units, &{&1.trace_id, &1.id})
+
+    attrs_list =
+      Enum.map(d_skill_class_units, fn d_skill_class_unit ->
+        id = Map.get(id_by_trace_id, d_skill_class_unit.trace_id, Ecto.ULID.generate())
+
+        skill_class_trace_id =
+          Map.get(skill_class_trace_id_by_draft_id, d_skill_class_unit.draft_skill_class_id)
+
+        skill_class_id = Map.get(skill_class_id_by_trace_id, skill_class_trace_id)
+
+        skill_unit_trace_id =
+          Map.get(skill_unit_trace_id_by_draft_id, d_skill_class_unit.draft_skill_unit_id)
+
+        skill_unit_id = Map.get(skill_unit_id_by_trace_id, skill_unit_trace_id)
+
+        %{
+          id: id,
+          trace_id: d_skill_class_unit.trace_id,
+          position: d_skill_class_unit.position,
+          skill_class_id: skill_class_id,
+          skill_unit_id: skill_unit_id,
+          inserted_at: {:placeholder, :timestamp},
+          updated_at: {:placeholder, :timestamp}
+        }
+      end)
+
+    # idが同じものは更新、その他は新規作成
+    Repo.insert_all(
+      SkillClassUnit,
+      attrs_list,
+      placeholders: placeholders,
+      on_conflict: {:replace, [:position, :skill_class_id, :skill_unit_id, :updated_at]},
+      conflict_target: [:id],
+      returning: true
+    )
+  end
+
+  defp delete_skills(d_skills, c_skills) do
+    list_deleted_items(d_skills, c_skills)
+    |> Enum.each(&SkillUnits.delete_skill/1)
+  end
+
+  def delete_skill_categories(d_skill_categories, c_skill_categories) do
+    list_deleted_items(d_skill_categories, c_skill_categories)
+    |> Enum.each(&SkillUnits.delete_skill_category/1)
+  end
+
+  def delete_skill_units(d_skill_units, c_skill_units) do
+    list_deleted_items(d_skill_units, c_skill_units)
+    |> Enum.each(&SkillUnits.delete_skill_unit/1)
+  end
+
+  def delete_skill_class_units(d_skill_class_units, c_skill_class_units) do
+    list_deleted_items(d_skill_class_units, c_skill_class_units)
+    |> Enum.each(&SkillUnits.delete_skill_class_unit/1)
+  end
+
+  defp list_target_skill_trace_ids(skill_panel) do
+    # 考慮すべき全データの洗い出し
+    d_trace_ids = list_draft_skill_trace_ids_on_skill_panel(skill_panel)
+    trace_ids = list_skill_trace_ids_on_skill_panel(skill_panel)
+
+    Enum.uniq(d_trace_ids ++ trace_ids)
+  end
+
+  defp list_draft_skill_trace_ids_on_skill_panel(skill_panel) do
+    from(
+      q in DraftSkillClass,
+      where: q.skill_panel_id == ^skill_panel.id,
+      join: dsu in assoc(q, :draft_skill_units),
+      join: dsc in assoc(dsu, :draft_skill_categories),
+      join: dss in assoc(dsc, :draft_skills),
+      select: dss.trace_id
+    )
+    |> Repo.all()
+  end
+
+  defp list_skill_trace_ids_on_skill_panel(skill_panel) do
+    from(
+      q in SkillClass,
+      where: q.skill_panel_id == ^skill_panel.id,
+      join: su in assoc(q, :skill_units),
+      join: sc in assoc(su, :skill_categories),
+      join: ss in assoc(sc, :skills),
+      select: ss.trace_id
+    )
+    |> Repo.all()
+  end
+
+  defp list_draft_skill_structures(trace_ids) do
+    from(
+      q in DraftSkill,
+      where: q.trace_id in ^trace_ids,
+      join: dsc in assoc(q, :draft_skill_category),
+      join: dsu in assoc(dsc, :draft_skill_unit),
+      select: {q, dsc, dsu}
+    )
+    |> Repo.all()
+    |> reduce_skill_structures()
+  end
+
+  defp list_skill_structures(trace_ids) do
+    from(
+      q in Skill,
+      where: q.trace_id in ^trace_ids,
+      join: sc in assoc(q, :skill_category),
+      join: su in assoc(sc, :skill_unit),
+      select: {q, sc, su}
+    )
+    |> Repo.all()
+    |> reduce_skill_structures()
+  end
+
+  defp list_draft_skill_classes(%DraftSkillPanel{} = skill_panel) do
+    from(q in DraftSkillClass, where: q.skill_panel_id == ^skill_panel.id)
+    |> Repo.all()
+  end
+
+  defp list_draft_skill_classes(d_skill_units) do
+    d_skill_unit_ids = Enum.map(d_skill_units, & &1.id)
+
+    from(
+      q in DraftSkillClass,
+      join: dscu in assoc(q, :draft_skill_class_units),
+      where: dscu.draft_skill_unit_id in ^d_skill_unit_ids,
+      distinct: true
+    )
+    |> Repo.all()
+  end
+
+  defp list_skill_classes(%DraftSkillPanel{} = skill_panel) do
+    from(q in SkillClass, where: q.skill_panel_id == ^skill_panel.id)
+    |> Repo.all()
+  end
+
+  defp list_skill_classes(d_skill_classes) do
+    trace_ids = Enum.map(d_skill_classes, & &1.trace_id)
+
+    from(q in SkillClass, where: q.trace_id in ^trace_ids)
+    |> Repo.all()
+  end
+
+  defp list_draft_skill_class_units(d_skill_units) do
+    d_skill_unit_ids = Enum.map(d_skill_units, & &1.id)
+
+    from(q in DraftSkillClassUnit, where: q.draft_skill_unit_id in ^d_skill_unit_ids)
+    |> Repo.all()
+  end
+
+  defp list_skill_class_units(c_skill_units) do
+    c_skill_unit_ids = Enum.map(c_skill_units, & &1.id)
+
+    from(q in SkillClassUnit, where: q.skill_unit_id in ^c_skill_unit_ids)
+    |> Repo.all()
+  end
+
+  defp gen_upsert_placeholders(list) do
+    Enum.reduce(list, %{}, fn key, acc ->
+      Map.put(acc, key, gen_upsert_value(key))
+    end)
+  end
+
+  defp gen_upsert_value(:timestamp) do
+    NaiveDateTime.utc_now()
+    |> NaiveDateTime.truncate(:second)
+  end
+
+  defp gen_upsert_value(:locked_date) do
+    # 1つ前のスキルパネル更新日相当日付としている
+    # - 例外的な手動更新のため、あくまで前回更新日にあった体にしないとその他機能での参照に不具合が起きる
+    timeline = TimelineHelper.get_current()
+    TimelineHelper.get_shift_date_from_date(timeline.future_date, -1)
+  end
+
+  defp reduce_skill_structures(list) do
+    # {skill, category, unit}のlistを{skills, categories, units}の形に変換
+    list
+    |> Enum.reduce({[], [], []}, fn
+      {}, acc ->
+        acc
+
+      {skill, category, unit}, {skills, categories, units} ->
+        {[skill] ++ skills, [category] ++ categories, [unit] ++ units}
+    end)
+    |> then(fn {skills, categories, units} ->
+      {skills, Enum.uniq(categories), Enum.uniq(units)}
+    end)
+  end
+
+  defp list_deleted_items(d_items, c_items) do
+    # currentにありdraftにない(=ドラフトで消えている)ものが消す対象
+    d_trace_ids = Enum.map(d_items, & &1.trace_id)
+    Enum.filter(c_items, &(&1.trace_id not in d_trace_ids))
+  end
+end

--- a/lib/bright/draft_skill_panels/release.ex
+++ b/lib/bright/draft_skill_panels/release.ex
@@ -39,8 +39,10 @@ defmodule Bright.DraftSkillPanels.Release do
 
   defp commit_structures(skill_panel) do
     # 指定スキルパネルのスキルクラス以下のデータを生成、更新、削除している
-    # - スキルクラスに関しては削除はない（スキルパネルごと削除がそれにあたる）
     # - 返値は、後続処理の便宜上、スコア変動が発生する可能性があるスキルユニット一覧としている
+    # - スキルクラスに関しては削除はない（スキルパネルごと削除がそれにあたる）
+
+    # NOTE 以下、大まかな流れは、対象データを収集、スキルクラスからドラフトを本番に反映、不要分を削除になります。
 
     # 移動前後を含めて考慮するため、最小単位のスキルから、ドラフトと本番の指定スキルパネルの全対象データを得ている
     all_target_skill_trace_ids = list_target_skill_trace_ids(skill_panel)
@@ -87,7 +89,7 @@ defmodule Bright.DraftSkillPanels.Release do
       {_count, _skills} = commit_skills(d_skills, c_skills, skill_categories, d_skill_categories)
 
       # スキルクラス-スキルユニット関連
-      # 移動を考慮すると指定スキルパネル以外に紐づくスキルクラスも必要のため再取得
+      # 移動を考慮すると指定スキルパネル以外に紐づくデータも必要のためスキルクラスを再取得
       d_skill_classes = list_draft_skill_classes(d_skill_units)
       skill_classes = Enum.uniq(list_skill_classes(d_skill_classes) ++ skill_classes)
 

--- a/lib/bright/skill_units.ex
+++ b/lib/bright/skill_units.ex
@@ -150,6 +150,22 @@ defmodule Bright.SkillUnits do
   end
 
   @doc """
+  Deletes a skill_category.
+
+  ## Examples
+
+      iex> delete_skill_category(skill_category)
+      {:ok, %SkillCategory{}}
+
+      iex> delete_skill_category(skill_category)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_skill_category(%SkillCategory{} = skill_category) do
+    Repo.delete(skill_category)
+  end
+
+  @doc """
   Returns an `%Ecto.Changeset{}` for tracking skill_category changes.
 
   ## Examples
@@ -200,6 +216,16 @@ defmodule Bright.SkillUnits do
     |> Repo.update()
   end
 
+  def delete_skill(%Skill{} = skill) do
+    Repo.transaction(fn ->
+      Ecto.assoc(skill, :skill_evidences)
+      |> Repo.all()
+      |> Enum.each(&Repo.delete/1)
+
+      Repo.delete!(skill)
+    end)
+  end
+
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking skill changes.
 
@@ -211,5 +237,9 @@ defmodule Bright.SkillUnits do
   """
   def change_skill(%Skill{} = skill, attrs \\ %{}) do
     Skill.changeset(skill, attrs)
+  end
+
+  def delete_skill_class_unit(%SkillClassUnit{} = skill_class_unit) do
+    Repo.delete(skill_class_unit)
   end
 end

--- a/lib/bright/skill_units/skill.ex
+++ b/lib/bright/skill_units/skill.ex
@@ -21,10 +21,10 @@ defmodule Bright.SkillUnits.Skill do
 
     belongs_to :skill_category, SkillCategory
 
-    has_many :skill_scores, Bright.SkillScores.SkillScore
+    has_many :skill_scores, Bright.SkillScores.SkillScore, on_delete: :delete_all
     has_many :skill_evidences, Bright.SkillEvidences.SkillEvidence
-    has_one :skill_exam, Bright.SkillExams.SkillExam
-    has_one :skill_reference, Bright.SkillReferences.SkillReference
+    has_one :skill_exam, Bright.SkillExams.SkillExam, on_delete: :delete_all
+    has_one :skill_reference, Bright.SkillReferences.SkillReference, on_delete: :delete_all
 
     timestamps()
   end

--- a/lib/bright/skill_units/skill_unit.ex
+++ b/lib/bright/skill_units/skill_unit.ex
@@ -28,7 +28,7 @@ defmodule Bright.SkillUnits.SkillUnit do
 
     has_many :skill_classes, through: [:skill_class_units, :skill_class]
 
-    has_many(:skill_unit_scores, Bright.SkillScores.SkillUnitScore)
+    has_many :skill_unit_scores, Bright.SkillScores.SkillUnitScore, on_delete: :delete_all
 
     timestamps()
   end

--- a/lib/bright_web/live/admin/skill_panel_live/show.ex
+++ b/lib/bright_web/live/admin/skill_panel_live/show.ex
@@ -29,9 +29,13 @@ defmodule BrightWeb.Admin.SkillPanelLive.Show do
 
   @impl true
   def handle_event("commit", _params, socket) do
+    %{skill_panel: skill_panel} = socket.assigns
     DraftSkillPanels.commit_to_release(socket.assigns.skill_panel)
 
-    {:noreply, put_flash(socket, :info, "反映を行いました")}
+    {:noreply,
+     socket
+     |> put_flash(:info, "反映を行いました")
+     |> push_navigate(to: ~p"/admin/skill_panels/#{skill_panel}")}
   end
 
   defp page_title(:show), do: "Show Skill panel"

--- a/lib/bright_web/live/admin/skill_panel_live/show.ex
+++ b/lib/bright_web/live/admin/skill_panel_live/show.ex
@@ -27,6 +27,13 @@ defmodule BrightWeb.Admin.SkillPanelLive.Show do
      |> assign(:draft_skill_classes, draft_skill_classes)}
   end
 
+  @impl true
+  def handle_event("commit", _params, socket) do
+    DraftSkillPanels.commit_to_release(socket.assigns.skill_panel)
+
+    {:noreply, put_flash(socket, :info, "反映を行いました")}
+  end
+
   defp page_title(:show), do: "Show Skill panel"
   defp page_title(:edit), do: "Edit Skill panel"
 end

--- a/lib/bright_web/live/admin/skill_panel_live/show.html.heex
+++ b/lib/bright_web/live/admin/skill_panel_live/show.html.heex
@@ -41,6 +41,17 @@
         </li>
       <% end %>
     </ul>
+
+    <button
+      class={[
+        "rounded-lg bg-red-700 hover:bg-red-900 py-2 px-3",
+        "text-sm font-semibold leading-6 text-white active:text-white/80 mt-4"
+      ]}
+      data-confirm={"「#{@skill_panel.name}」を本番系に反映しますか？"}
+      phx-click="commit"
+    >
+      本番系へ反映
+    </button>
   </:item>
 </.list>
 

--- a/test/bright/draft_skill_panels/release_test.exs
+++ b/test/bright/draft_skill_panels/release_test.exs
@@ -1,0 +1,770 @@
+defmodule Bright.DraftSkillPanels.ReleaseTest do
+  use Bright.DataCase, async: true
+
+  alias Bright.DraftSkillPanels.Release
+
+  alias Bright.Repo
+  alias Bright.SkillPanels.SkillClass
+  alias Bright.SkillPanels.SkillPanel
+  alias Bright.SkillUnits.SkillUnit
+  alias Bright.SkillUnits.SkillCategory
+  alias Bright.SkillUnits.Skill
+  alias Bright.SkillUnits.SkillClassUnit
+
+  # テストデータ生成の共通処理
+  defp create_draft_skill do
+    draft_skill_unit = insert(:draft_skill_unit, name: "draft")
+
+    draft_skill_category =
+      insert(:draft_skill_category, draft_skill_unit: draft_skill_unit, name: "draft")
+
+    draft_skill = insert(:draft_skill, draft_skill_category: draft_skill_category, name: "draft")
+
+    {draft_skill_unit, draft_skill_category, draft_skill}
+  end
+
+  defp create_skill_with_draft do
+    {draft_skill_unit, draft_skill_category, draft_skill} = drafts = create_draft_skill()
+    skill_unit = insert(:skill_unit, trace_id: draft_skill_unit.trace_id, name: "current")
+
+    skill_category =
+      insert(:skill_category,
+        skill_unit: skill_unit,
+        trace_id: draft_skill_category.trace_id,
+        name: "current"
+      )
+
+    skill =
+      insert(:skill,
+        skill_category: skill_category,
+        trace_id: draft_skill.trace_id,
+        name: "current"
+      )
+
+    {drafts, {skill_unit, skill_category, skill}}
+  end
+
+  defp create_skill do
+    skill_unit = insert(:skill_unit)
+    skill_category = insert(:skill_category, skill_unit: skill_unit)
+    skill = insert(:skill, skill_category: skill_category)
+
+    {skill_unit, skill_category, skill}
+  end
+
+  setup do
+    %{skill_panel: insert(:draft_skill_panel)}
+  end
+
+  test "just runs", ctx do
+    assert {:ok, _} = Release.commit(ctx.skill_panel)
+  end
+
+  describe "commit structures" do
+    test "inserts skill_class", ctx do
+      # スキルクラスの新規作成確認
+      draft_skill_class = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      Release.commit(ctx.skill_panel)
+
+      new_one = Repo.get_by!(SkillClass, trace_id: draft_skill_class.trace_id)
+      assert new_one.name == draft_skill_class.name
+      assert new_one.class == draft_skill_class.class
+      assert new_one.skill_panel_id == draft_skill_class.skill_panel_id
+    end
+
+    test "updates skill_classes", ctx do
+      # スキルクラスの更新確認
+      draft_skill_class = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class.trace_id
+        )
+
+      Release.commit(ctx.skill_panel)
+
+      updated_one = Repo.get_by!(SkillClass, id: skill_class.id)
+      assert updated_one.name == draft_skill_class.name
+    end
+
+    test "inserts skill_unit / skill_category / skill", ctx do
+      # ベーシックなスキルユニット以下の新規作成確認
+      draft_skill_class = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+      {draft_skill_unit, draft_skill_category, draft_skill} = create_draft_skill()
+
+      draft_skill_class_unit =
+        insert(:draft_skill_class_unit,
+          draft_skill_class: draft_skill_class,
+          draft_skill_unit: draft_skill_unit
+        )
+
+      Release.commit(ctx.skill_panel)
+
+      # 作成されていることを確認
+      new_skill_unit = Repo.get_by!(SkillUnit, trace_id: draft_skill_unit.trace_id)
+      new_skill_category = Repo.get_by!(SkillCategory, trace_id: draft_skill_category.trace_id)
+      new_skill = Repo.get_by!(Skill, trace_id: draft_skill.trace_id)
+      new_skill_class = Repo.get_by!(SkillClass, trace_id: draft_skill_class.trace_id)
+
+      new_skill_class_unit =
+        Repo.get_by!(SkillClassUnit, trace_id: draft_skill_class_unit.trace_id)
+
+      assert new_skill_unit.name == draft_skill_unit.name
+
+      assert new_skill_category.name == draft_skill_category.name
+      assert new_skill_category.position == draft_skill_category.position
+      assert new_skill_category.skill_unit_id == new_skill_unit.id
+
+      assert new_skill.name == draft_skill.name
+      assert new_skill.position == draft_skill.position
+      assert new_skill.skill_category_id == new_skill_category.id
+
+      assert new_skill_class_unit.skill_class_id == new_skill_class.id
+      assert new_skill_class_unit.skill_unit_id == new_skill_unit.id
+    end
+
+    test "updates skill_unit / skill_category / skill", ctx do
+      # ベーシックなスキルユニット以下の更新確認
+      draft_skill_class = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class.trace_id,
+          name: "before"
+        )
+
+      {
+        {draft_skill_unit, draft_skill_category, draft_skill},
+        {skill_unit, skill_category, skill}
+      } = create_skill_with_draft()
+
+      insert(:draft_skill_class_unit,
+        draft_skill_class: draft_skill_class,
+        draft_skill_unit: draft_skill_unit
+      )
+
+      insert(:skill_class_unit, skill_class: skill_class, skill_unit: skill_unit)
+
+      Release.commit(ctx.skill_panel)
+
+      # ドラフト内容に更新されていることを確認
+      updated_skill_unit = Repo.get_by!(SkillUnit, trace_id: draft_skill_unit.trace_id)
+
+      updated_skill_category =
+        Repo.get_by!(SkillCategory, trace_id: draft_skill_category.trace_id)
+
+      updated_skill = Repo.get_by!(Skill, trace_id: draft_skill.trace_id)
+
+      assert updated_skill_unit.id == skill_unit.id
+      assert updated_skill_unit.name == draft_skill_unit.name
+
+      assert updated_skill_category.id == skill_category.id
+      assert updated_skill_category.name == draft_skill_category.name
+      assert updated_skill_category.position == draft_skill_category.position
+      assert updated_skill_category.skill_unit_id == skill_unit.id
+
+      assert updated_skill.id == skill.id
+      assert updated_skill.name == draft_skill.name
+      assert updated_skill.position == draft_skill.position
+      assert updated_skill.skill_category_id == skill_category.id
+    end
+
+    test "deletes skill_unit / skill_category / skill", ctx do
+      skill_class = insert(:skill_class, skill_panel_id: ctx.skill_panel.id)
+      {skill_unit, skill_category, skill} = create_skill()
+      insert(:skill_class_unit, skill_class: skill_class, skill_unit: skill_unit)
+
+      Release.commit(ctx.skill_panel)
+
+      # ドラフトには何も残っていないので全て削除されていること
+      refute Repo.get_by(SkillUnit, id: skill_unit.id)
+      refute Repo.get_by(SkillCategory, id: skill_category.id)
+      refute Repo.get_by(Skill, id: skill.id)
+    end
+
+    test "adds skill_unit by move", ctx do
+      draft_skill_class = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class.trace_id
+        )
+
+      {
+        {draft_skill_unit, _draft_skill_category, _draft_skill},
+        {skill_unit, _skill_category, _skill}
+      } = create_skill_with_draft()
+
+      skill_panel_from = insert(:skill_panel)
+      draft_skill_class_from = insert(:draft_skill_class, skill_panel_id: skill_panel_from.id)
+
+      skill_class_from =
+        insert(:skill_class,
+          skill_panel: skill_panel_from,
+          trace_id: draft_skill_class_from.trace_id
+        )
+
+      #   本番上はスキルユニットを別スキルパネルに存在させ、ドラフト上は移動済みとする
+      draft_skill_class_unit =
+        insert(:draft_skill_class_unit,
+          draft_skill_class: draft_skill_class,
+          draft_skill_unit: draft_skill_unit
+        )
+
+      insert(:skill_class_unit,
+        skill_class: skill_class_from,
+        skill_unit: skill_unit,
+        trace_id: draft_skill_class_unit.trace_id
+      )
+
+      Release.commit(ctx.skill_panel)
+
+      # 処理後データ状況（スキルユニット移動）の確認
+      skill_class_unit = Repo.get_by(SkillClassUnit, skill_unit_id: skill_unit.id)
+      assert skill_class_unit.skill_class_id == skill_class.id
+    end
+
+    test "removes skill_unit by move", ctx do
+      draft_skill_class = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class.trace_id
+        )
+
+      {
+        {draft_skill_unit, _draft_skill_category, _draft_skill},
+        {skill_unit, _skill_category, _skill}
+      } = create_skill_with_draft()
+
+      skill_panel_to = insert(:skill_panel)
+      draft_skill_class_to = insert(:draft_skill_class, skill_panel_id: skill_panel_to.id)
+
+      skill_class_to =
+        insert(:skill_class, skill_panel: skill_panel_to, trace_id: draft_skill_class_to.trace_id)
+
+      #   本番上はスキルユニットを本スキルパネルに存在させ、ドラフト上は移動済みとする
+      draft_skill_class_unit =
+        insert(:draft_skill_class_unit,
+          draft_skill_class: draft_skill_class_to,
+          draft_skill_unit: draft_skill_unit
+        )
+
+      insert(:skill_class_unit,
+        skill_class: skill_class,
+        skill_unit: skill_unit,
+        trace_id: draft_skill_class_unit.trace_id
+      )
+
+      Release.commit(ctx.skill_panel)
+
+      # 処理後データ状況（スキルユニット移動）の反映確認
+      skill_class_unit = Repo.get_by(SkillClassUnit, skill_unit_id: skill_unit.id)
+      assert skill_class_unit.skill_class_id == skill_class_to.id
+    end
+
+    test "adds skill_category by move", ctx do
+      draft_skill_class = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class.trace_id
+        )
+
+      {
+        {draft_skill_unit, _draft_skill_category, _draft_skill},
+        {skill_unit, _skill_category, _skill}
+      } = create_skill_with_draft()
+
+      draft_skill_class_unit =
+        insert(:draft_skill_class_unit,
+          draft_skill_class: draft_skill_class,
+          draft_skill_unit: draft_skill_unit
+        )
+
+      insert(:skill_class_unit,
+        skill_class: skill_class,
+        skill_unit: skill_unit,
+        trace_id: draft_skill_class_unit.trace_id
+      )
+
+      # 移動元とドラフトデータ上での移動の準備
+      draft_skill_class_2 = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class_2 =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class_2.trace_id
+        )
+
+      {
+        {draft_skill_unit_2, draft_skill_category_2, _draft_skill_2},
+        {skill_unit_2, skill_category_2, _skill_2}
+      } = create_skill_with_draft()
+
+      draft_skill_class_unit_2 =
+        insert(:draft_skill_class_unit,
+          draft_skill_class: draft_skill_class_2,
+          draft_skill_unit: draft_skill_unit_2
+        )
+
+      insert(:skill_class_unit,
+        skill_class: skill_class_2,
+        skill_unit: skill_unit_2,
+        trace_id: draft_skill_class_unit_2.trace_id
+      )
+
+      #   ドラフト上での移動処理相当のupdate
+      Repo.update(
+        Ecto.Changeset.change(draft_skill_category_2, draft_skill_unit_id: draft_skill_unit.id)
+      )
+
+      Release.commit(ctx.skill_panel)
+
+      # 処理後データ状況（スキルカテゴリ移動）の反映確認
+      skill_category_2 = Repo.get_by(SkillCategory, id: skill_category_2.id)
+      assert skill_category_2.skill_unit_id == skill_unit.id
+    end
+
+    test "removes skill_category by move", ctx do
+      draft_skill_class = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class.trace_id
+        )
+
+      {
+        {draft_skill_unit, draft_skill_category, _draft_skill},
+        {skill_unit, skill_category, _skill}
+      } = create_skill_with_draft()
+
+      draft_skill_class_unit =
+        insert(:draft_skill_class_unit,
+          draft_skill_class: draft_skill_class,
+          draft_skill_unit: draft_skill_unit
+        )
+
+      insert(:skill_class_unit,
+        skill_class: skill_class,
+        skill_unit: skill_unit,
+        trace_id: draft_skill_class_unit.trace_id
+      )
+
+      # 移動先とドラフトデータ上での移動の準備
+      draft_skill_class_2 = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class_2 =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class_2.trace_id
+        )
+
+      {
+        {draft_skill_unit_2, _draft_skill_category_2, _draft_skill_2},
+        {skill_unit_2, _skill_category_2, _skill_2}
+      } = create_skill_with_draft()
+
+      draft_skill_class_unit_2 =
+        insert(:draft_skill_class_unit,
+          draft_skill_class: draft_skill_class_2,
+          draft_skill_unit: draft_skill_unit_2
+        )
+
+      insert(:skill_class_unit,
+        skill_class: skill_class_2,
+        skill_unit: skill_unit_2,
+        trace_id: draft_skill_class_unit_2.trace_id
+      )
+
+      #   ドラフト上での移動処理相当のupdate
+      Repo.update(
+        Ecto.Changeset.change(draft_skill_category, draft_skill_unit_id: draft_skill_unit_2.id)
+      )
+
+      Release.commit(ctx.skill_panel)
+
+      # 処理後データ状況（スキルカテゴリ移動）の反映確認
+      skill_category = Repo.get_by(SkillCategory, id: skill_category.id)
+      assert skill_category.skill_unit_id == skill_unit_2.id
+    end
+
+    test "adds skill by move", ctx do
+      draft_skill_class = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class.trace_id
+        )
+
+      {
+        {draft_skill_unit, draft_skill_category, _draft_skill},
+        {skill_unit, skill_category, _skill}
+      } = create_skill_with_draft()
+
+      draft_skill_class_unit =
+        insert(:draft_skill_class_unit,
+          draft_skill_class: draft_skill_class,
+          draft_skill_unit: draft_skill_unit
+        )
+
+      insert(:skill_class_unit,
+        skill_class: skill_class,
+        skill_unit: skill_unit,
+        trace_id: draft_skill_class_unit.trace_id
+      )
+
+      # 移動元とドラフトデータ上での移動の準備
+      draft_skill_class_2 = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class_2 =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class_2.trace_id
+        )
+
+      {
+        {draft_skill_unit_2, _draft_skill_category_2, draft_skill_2},
+        {skill_unit_2, _skill_category_2, skill_2}
+      } = create_skill_with_draft()
+
+      draft_skill_class_unit_2 =
+        insert(:draft_skill_class_unit,
+          draft_skill_class: draft_skill_class_2,
+          draft_skill_unit: draft_skill_unit_2
+        )
+
+      insert(:skill_class_unit,
+        skill_class: skill_class_2,
+        skill_unit: skill_unit_2,
+        trace_id: draft_skill_class_unit_2.trace_id
+      )
+
+      #   ドラフト上での移動処理相当のupdate
+      Repo.update(
+        Ecto.Changeset.change(draft_skill_2, draft_skill_category_id: draft_skill_category.id)
+      )
+
+      Release.commit(ctx.skill_panel)
+
+      # 処理後データ状況（スキル移動）の反映確認
+      skill_2 = Repo.get_by(Skill, id: skill_2.id)
+      assert skill_2.skill_category_id == skill_category.id
+    end
+
+    test "removes skill by move", ctx do
+      draft_skill_class = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class.trace_id
+        )
+
+      {
+        {draft_skill_unit, _draft_skill_category, draft_skill},
+        {skill_unit, _skill_category, skill}
+      } = create_skill_with_draft()
+
+      draft_skill_class_unit =
+        insert(:draft_skill_class_unit,
+          draft_skill_class: draft_skill_class,
+          draft_skill_unit: draft_skill_unit
+        )
+
+      insert(:skill_class_unit,
+        skill_class: skill_class,
+        skill_unit: skill_unit,
+        trace_id: draft_skill_class_unit.trace_id
+      )
+
+      # 移動元とドラフトデータ上での移動の準備
+      draft_skill_class_2 = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class_2 =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class_2.trace_id
+        )
+
+      {
+        {draft_skill_unit_2, draft_skill_category_2, _draft_skill_2},
+        {skill_unit_2, skill_category_2, _skill_2}
+      } = create_skill_with_draft()
+
+      draft_skill_class_unit_2 =
+        insert(:draft_skill_class_unit,
+          draft_skill_class: draft_skill_class_2,
+          draft_skill_unit: draft_skill_unit_2
+        )
+
+      insert(:skill_class_unit,
+        skill_class: skill_class_2,
+        skill_unit: skill_unit_2,
+        trace_id: draft_skill_class_unit_2.trace_id
+      )
+
+      #   ドラフト上での移動処理相当のupdate
+      Repo.update(
+        Ecto.Changeset.change(draft_skill, draft_skill_category_id: draft_skill_category_2.id)
+      )
+
+      Release.commit(ctx.skill_panel)
+
+      # 処理後データ状況（スキル移動）の反映確認
+      skill = Repo.get_by(Skill, id: skill.id)
+      assert skill.skill_category_id == skill_category_2.id
+    end
+  end
+
+  describe "relations" do
+    alias Bright.SkillReferences.SkillReference
+    alias Bright.SkillExams.SkillExam
+    alias Bright.SkillScores.SkillScore
+    alias Bright.SkillEvidences.SkillEvidence
+    alias Bright.SkillEvidences.SkillEvidencePost
+
+    test "removes skill with relations such as score", ctx do
+      skill_class = insert(:skill_class, skill_panel_id: ctx.skill_panel.id)
+      {skill_unit, _skill_category, skill} = create_skill()
+      insert(:skill_class_unit, skill_class: skill_class, skill_unit: skill_unit)
+
+      # スキルまわりの関連生成
+      skill_reference = insert(:skill_reference, skill: skill)
+      skill_exam = insert(:skill_exam, skill: skill)
+      user = insert(:user)
+      skill_score = insert(:skill_score, skill: skill, user: user, score: :high)
+      skill_evidence = insert(:skill_evidence, skill: skill, user: user)
+
+      skill_evidence_post =
+        insert(:skill_evidence_post, skill_evidence: skill_evidence, user: user)
+
+      Release.commit(ctx.skill_panel)
+
+      # スキルと合わせて削除されること
+      refute Repo.get_by(Skill, id: skill.id)
+      refute Repo.get_by(SkillReference, id: skill_reference.id)
+      refute Repo.get_by(SkillExam, id: skill_exam.id)
+      refute Repo.get_by(SkillScore, id: skill_score.id)
+      refute Repo.get_by(SkillEvidence, id: skill_evidence.id)
+      refute Repo.get_by(SkillEvidencePost, id: skill_evidence_post.id)
+    end
+
+    test "does not affects skill relations by move", ctx do
+      draft_skill_class = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class.trace_id
+        )
+
+      {
+        {draft_skill_unit, draft_skill_category, _draft_skill},
+        {skill_unit, skill_category, _skill}
+      } = create_skill_with_draft()
+
+      draft_skill_class_unit =
+        insert(:draft_skill_class_unit,
+          draft_skill_class: draft_skill_class,
+          draft_skill_unit: draft_skill_unit
+        )
+
+      insert(:skill_class_unit,
+        skill_class: skill_class,
+        skill_unit: skill_unit,
+        trace_id: draft_skill_class_unit.trace_id
+      )
+
+      # 移動元とドラフトデータ上での移動の準備
+      draft_skill_class_2 = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class_2 =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class_2.trace_id
+        )
+
+      {
+        {draft_skill_unit_2, _draft_skill_category_2, draft_skill_2},
+        {skill_unit_2, _skill_category_2, skill_2}
+      } = create_skill_with_draft()
+
+      draft_skill_class_unit_2 =
+        insert(:draft_skill_class_unit,
+          draft_skill_class: draft_skill_class_2,
+          draft_skill_unit: draft_skill_unit_2
+        )
+
+      insert(:skill_class_unit,
+        skill_class: skill_class_2,
+        skill_unit: skill_unit_2,
+        trace_id: draft_skill_class_unit_2.trace_id
+      )
+
+      #   移動元スキルに関連設定
+      skill_reference = insert(:skill_reference, skill: skill_2)
+      skill_exam = insert(:skill_exam, skill: skill_2)
+      user = insert(:user)
+      skill_score = insert(:skill_score, skill: skill_2, user: user, score: :high)
+      skill_evidence = insert(:skill_evidence, skill: skill_2, user: user)
+
+      #   ドラフト上での移動処理相当のupdate
+      Repo.update(
+        Ecto.Changeset.change(draft_skill_2, draft_skill_category_id: draft_skill_category.id)
+      )
+
+      Release.commit(ctx.skill_panel)
+
+      # 移動後も特に関連が影響を受けていないこと
+      assert Repo.get_by(Skill, id: skill_2.id, skill_category_id: skill_category.id)
+      assert Repo.get_by(SkillReference, id: skill_reference.id, skill_id: skill_2.id)
+      assert Repo.get_by(SkillExam, id: skill_exam.id, skill_id: skill_2.id)
+      assert Repo.get_by(SkillScore, id: skill_score.id, skill_id: skill_2.id)
+      assert Repo.get_by(SkillEvidence, id: skill_evidence.id, skill_id: skill_2.id)
+    end
+  end
+
+  describe "scores update" do
+    alias Bright.SkillScores.SkillClassScore
+    alias Bright.SkillScores.SkillUnitScore
+
+    test "updates skill_classes.score", ctx do
+      # 100%のスキルユニットを空のスキルクラスに移動して確認している
+      draft_skill_class = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class.trace_id
+        )
+
+      {
+        {draft_skill_unit, _draft_skill_category, _draft_skill},
+        {skill_unit, _skill_category, skill}
+      } = create_skill_with_draft()
+
+      skill_panel_from = insert(:skill_panel)
+      draft_skill_class_from = insert(:draft_skill_class, skill_panel_id: skill_panel_from.id)
+
+      skill_class_from =
+        insert(:skill_class,
+          skill_panel: skill_panel_from,
+          trace_id: draft_skill_class_from.trace_id
+        )
+
+      #   本番上はスキルユニットを別スキルパネルに存在させ、ドラフト上は移動済みとする
+      draft_skill_class_unit =
+        insert(:draft_skill_class_unit,
+          draft_skill_class: draft_skill_class,
+          draft_skill_unit: draft_skill_unit
+        )
+
+      insert(:skill_class_unit,
+        skill_class: skill_class_from,
+        skill_unit: skill_unit,
+        trace_id: draft_skill_class_unit.trace_id
+      )
+
+      # 処理前のスコア準備
+      user = insert(:user)
+      skill_panel = Repo.get(SkillPanel, ctx.skill_panel.id)
+      insert(:user_skill_panel, skill_panel: skill_panel, user: user)
+      insert(:user_skill_panel, skill_panel: skill_panel_from, user: user)
+      insert(:skill_score, skill: skill, user: user, score: :high)
+
+      skill_class_score =
+        insert(:skill_class_score, skill_class: skill_class, user: user, percentage: 0)
+
+      Release.commit(ctx.skill_panel)
+
+      # 処理後データ状況（スキルユニットスコア）の確認
+      skill_class_score = Repo.get_by(SkillClassScore, id: skill_class_score.id)
+      assert skill_class_score.percentage == 100
+    end
+
+    test "updates skill_units.score", ctx do
+      # 0/1で0%のスキルユニットにhighスキルを1つ移動して50%になることを確認している
+      draft_skill_class = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class.trace_id
+        )
+
+      {
+        {draft_skill_unit, draft_skill_category, _draft_skill},
+        {skill_unit, _skill_category, skill}
+      } = create_skill_with_draft()
+
+      draft_skill_class_unit =
+        insert(:draft_skill_class_unit,
+          draft_skill_class: draft_skill_class,
+          draft_skill_unit: draft_skill_unit
+        )
+
+      insert(:skill_class_unit,
+        skill_class: skill_class,
+        skill_unit: skill_unit,
+        trace_id: draft_skill_class_unit.trace_id
+      )
+
+      # 移動元とドラフトデータ上での移動の準備
+      draft_skill_class_2 = insert(:draft_skill_class, skill_panel_id: ctx.skill_panel.id)
+
+      skill_class_2 =
+        insert(:skill_class,
+          skill_panel_id: ctx.skill_panel.id,
+          trace_id: draft_skill_class_2.trace_id
+        )
+
+      {
+        {draft_skill_unit_2, _draft_skill_category_2, draft_skill_2},
+        {skill_unit_2, _skill_category_2, skill_2}
+      } = create_skill_with_draft()
+
+      draft_skill_class_unit_2 =
+        insert(:draft_skill_class_unit,
+          draft_skill_class: draft_skill_class_2,
+          draft_skill_unit: draft_skill_unit_2
+        )
+
+      insert(:skill_class_unit,
+        skill_class: skill_class_2,
+        skill_unit: skill_unit_2,
+        trace_id: draft_skill_class_unit_2.trace_id
+      )
+
+      #   ドラフト上での移動処理相当のupdate
+      Repo.update(
+        Ecto.Changeset.change(draft_skill_2, draft_skill_category_id: draft_skill_category.id)
+      )
+
+      # 処理前のスコア準備
+      user = insert(:user)
+      skill_panel = Repo.get(SkillPanel, ctx.skill_panel.id)
+      insert(:user_skill_panel, skill_panel: skill_panel, user: user)
+      insert(:skill_score, skill: skill, user: user, score: :low)
+      insert(:skill_score, skill: skill_2, user: user, score: :high)
+      insert(:skill_class_score, skill_class: skill_class, user: user)
+
+      skill_unit_score =
+        insert(:skill_unit_score, skill_unit: skill_unit, user: user, percentage: 0)
+
+      Release.commit(ctx.skill_panel)
+
+      # 処理後データ状況（スキルユニットスコア）の確認
+      skill_unit_score = Repo.get_by(SkillUnitScore, id: skill_unit_score.id)
+      assert skill_unit_score.percentage == 50
+    end
+  end
+end


### PR DESCRIPTION
## 対応内容

#1632 

ドラフトツールに、ドラフトから本番にスキルパネル単位で即時反映するボタンを設置しました。

厳密にはスキルパネルに含まれるスキルクラス と スキルユニットは1:1対応ではなく、スキルユニット共有があるため、「スキルパネルに関連するデータ」を対象として処理を行い、本番へ反映します。

そのため、異なるスキルパネル（スキルクラス）の構造やスコアも本番へ反映されるケース（前述の共有していたり、スキル移動操作時など）があります。

## 留意事項

既に本番にデータがある場合にドラフトでスキルなどの位置を上下して変更すると、反映処理が失敗する事象がありました。これは本番系への反映の処理途中で（一時的に）positionの一意制約にひっかかることが原因のようです。

解消には、まとめて変更するようなロジックをやめて一つ一つ制約にかからないようにするか、（本PRを含めてドラフトでの変更が前提になるため）本番系でのposition一意制約は消すか、になると思います。とりあえず大きな問題ではないと思うので、また別件として対応します。

（※この失敗は３か月更新のバッチでは発生しません）


## 参考画像

下図のように「本番系へ反映」ボタンを追加しています。

![image](https://github.com/user-attachments/assets/0ec61d5a-6b96-4a1a-b906-6ac871a6d1bc)
