### PR TITLE
ドラフト反映処理 本番スキル構造の位置(position)のユニーク制約を除去

### DIFF
--- a/priv/repo/migrations/20240904052148_remove_position_unique_index_on_skill_structures.exs
+++ b/priv/repo/migrations/20240904052148_remove_position_unique_index_on_skill_structures.exs
@@ -1,0 +1,41 @@
+defmodule Bright.Repo.Migrations.RemovePositionUniqueIndexOnSkillStructures do
+  @moduledoc """
+  ドラフトツール側でpositionをユニークにしているため、
+  そのデータをコピーするだけの本番スキルテーブル側からユニーク制約を外しています。
+  （ドラフトから本番への即時反映の処理の複雑さが増すため）
+  """
+
+  use Ecto.Migration
+
+  def up do
+    # スキルカテゴリ
+    drop unique_index(:skill_categories, [:skill_unit_id, :position])
+    create index(:skill_categories, [:skill_unit_id, :position])
+
+    # スキル
+    drop unique_index(:skills, [:skill_category_id, :position])
+    create index(:skills, [:skill_category_id, :position])
+
+    # スキルクラスユニット
+    # そもそも元インデックスが不適当だったので合わせて修正
+    drop unique_index(:skill_class_units, [:skill_class_id, :skill_unit_id, :position])
+    create index(:skill_class_units, [:skill_class_id, :position])
+    create index(:skill_class_units, [:skill_unit_id])
+  end
+
+  def down do
+    # スキルカテゴリ
+    drop index(:skill_categories, [:skill_unit_id, :position])
+    create unique_index(:skill_categories, [:skill_unit_id, :position])
+
+    # スキル
+    drop index(:skills, [:skill_category_id, :position])
+    create unique_index(:skills, [:skill_category_id, :position])
+
+    # スキルクラスユニット
+    # そもそも元インデックスが不適当だったので合わせて修正
+    drop index(:skill_class_units, [:skill_class_id, :position])
+    drop index(:skill_class_units, [:skill_unit_id])
+    create unique_index(:skill_class_units, [:skill_class_id, :skill_unit_id, :position])
+  end
+end


### PR DESCRIPTION
## 対応内容

close #1632 
#1657 の留意事項にあげた、並び替えでエラーになる現象が残っていた件の対応です。

ドラフトでユニーク制約しているので、そのコピーである本番系からは不要とみなしてユニーク制約を消しました。
