### PR TITLE
リンク周りを修正

### DIFF
--- a/lib/bright_web/controllers/skill_panel_controller.ex
+++ b/lib/bright_web/controllers/skill_panel_controller.ex
@@ -17,7 +17,7 @@ defmodule BrightWeb.SkillPanelController do
            panel.id
          ) do
       true ->
-        redirect(conn, to: ~p"/panels/#{panel.id}")
+        redirect(conn, to: ~p"/skills/#{panel.id}")
 
       false ->
         UserSkillPanels.create_user_skill_panel(%{
@@ -27,7 +27,7 @@ defmodule BrightWeb.SkillPanelController do
 
         conn
         |> put_flash(:info, "スキルパネル:#{panel.name}を取得しました")
-        |> redirect(to: ~p"/panels/#{panel.id}")
+        |> redirect(to: ~p"/skills/#{panel.id}")
     end
   end
 end

--- a/lib/bright_web/live/mypage_live/index.html.heex
+++ b/lib/bright_web/live/mypage_live/index.html.heex
@@ -35,7 +35,7 @@
         module={BrightWeb.SkillListComponent}
         display_user={@display_user}
         me={@me}
-        root="panels"
+        root="skills"
         anonymous={@anonymous}
         career_field={@career_field}
       />

--- a/lib/bright_web/live/onboarding_live/job_panel_components.ex
+++ b/lib/bright_web/live/onboarding_live/job_panel_components.ex
@@ -125,7 +125,7 @@ defmodule BrightWeb.OnboardingLive.JobPanelComponents do
   def unlocked_job(%{current_path: "skill_select"} = assigns) do
     ~H"""
     <div class="cursor-pointer">
-      <.link navigate={"/#{@current_path}/#{@panel_id}?career_field=#{@career_field.name_en}"} >
+      <.link navigate={"/#{@current_path}/#{@panel_id}?career_field=#{@career_field.name_en}&class=1"} >
       <div
         id={"#{@career_field.name_en}-#{@panel_id}"}
         class={"px-2 lg:px-4 m-2 rounded w-[150px] lg:w-[340px] min-h-[140px] lg:min-h-[74px] flex flex-col hover:bg-[#F5FBFB] #{if is_nil(@score), do: "border-[2px]", else: "border border-brightGreen-300"}"}

--- a/lib/bright_web/live/onboarding_live/skill_inputs.ex
+++ b/lib/bright_web/live/onboarding_live/skill_inputs.ex
@@ -401,7 +401,7 @@ defmodule BrightWeb.OnboardingLive.SkillInputs do
 
   defp put_flash_first_skills_edit(socket), do: socket
 
-  defp open_growth_share(skill_class_score, prev_skill_share_data) do
+  def open_growth_share(skill_class_score, prev_skill_share_data) do
     prev_level = skill_class_score.level
     prev_percentage = skill_class_score.percentage
 

--- a/lib/bright_web/live/onboarding_live/skill_inputs.ex
+++ b/lib/bright_web/live/onboarding_live/skill_inputs.ex
@@ -142,13 +142,13 @@ defmodule BrightWeb.OnboardingLive.SkillInputs do
   end
 
   def handle_event("update_score", %{"score_id" => id, "score" => score} = params, socket) do
-    prev_skill_class_score = socket.assigns.skill_class_score
+    # prev_skill_class_score = socket.assigns.skill_class_score
 
-    prev_skill_share_data =
-      SkillScores.get_level_count_from_skill_panel_id(
-        socket.assigns.skill_panel.id,
-        socket.assigns.skill_class.class
-      )
+    # prev_skill_share_data =
+    #  SkillScores.get_level_count_from_skill_panel_id(
+    #    socket.assigns.skill_panel.id,
+    #    socket.assigns.skill_class.class
+    #  )
 
     SkillScores.get_skill_score!(id)
     |> Map.put(:score, String.to_atom(score))
@@ -157,7 +157,8 @@ defmodule BrightWeb.OnboardingLive.SkillInputs do
 
     send_update(BrightWeb.OgpComponent, id: "ogp")
 
-    open_growth_share(prev_skill_class_score, prev_skill_share_data)
+    # バグがあったので一旦落とす
+    # open_growth_share(prev_skill_class_score, prev_skill_share_data)
 
     socket
     |> assign_renew(params["class"])

--- a/lib/bright_web/live/onboarding_live/skill_inputs.ex
+++ b/lib/bright_web/live/onboarding_live/skill_inputs.ex
@@ -44,7 +44,7 @@ defmodule BrightWeb.OnboardingLive.SkillInputs do
     socket
     |> assign_display_user(params)
     |> assign_skill_panel(skill_panel_params)
-    |> assign(:page_title, "スキルパネル")
+    |> assign(:page_title, "スキル入力")
     |> assign(:class_color, @class_color)
     |> assign(:label_color, @label_color)
     |> assign(:skill_share_open, false)

--- a/test/bright_web/controllers/skill_panel_controller_test.exs
+++ b/test/bright_web/controllers/skill_panel_controller_test.exs
@@ -14,13 +14,13 @@ defmodule BrightWeb.SkillPanelControllerTest do
     test "exists skill_panel", %{conn: conn, skill_panel: skill_panel} do
       conn = get(conn, "/get_skill_panel/#{skill_panel.id}")
       assert Phoenix.Flash.get(conn.assigns.flash, :info) == "スキルパネル:#{skill_panel.name}を取得しました"
-      assert redirected_to(conn) == ~p"/panels/#{skill_panel.id}"
+      assert redirected_to(conn) == ~p"/skills/#{skill_panel.id}"
     end
 
     test "exists skill_panel and already get", %{conn: conn, skill_panel: skill_panel, user: user} do
       insert(:user_skill_panel, user: user, skill_panel: skill_panel)
       conn = get(conn, "/get_skill_panel/#{skill_panel.id}")
-      assert redirected_to(conn) == ~p"/panels/#{skill_panel.id}"
+      assert redirected_to(conn) == ~p"/skills/#{skill_panel.id}"
     end
 
     test "not exists skill panels", %{conn: conn} do


### PR DESCRIPTION
ブログからの流入時のリダイレクト先を修正
スキルクラスからの移動先をクラス１で固定
マイページのスキルリストのリンクをスキル入力に変更
スキル入力のタイトル修正
ナイスブライトを一旦下げる