### PR TITLE
マイページ 学習メモが表示領域を越えて表示されている現象対応

### DIFF
--- a/lib/bright_web/components/skill_evidence_components.ex
+++ b/lib/bright_web/components/skill_evidence_components.ex
@@ -41,7 +41,7 @@ defmodule BrightWeb.SkillEvidenceComponents do
 
     <%# 投稿表示 %>
     <div
-      class="grow flex flex-col gap-y-2 mx-2 cursor-pointer link-evidence"
+      class="grow flex flex-col gap-y-2 mx-2 cursor-pointer link-evidence w-full overflow-x-auto"
       phx-click="edit_skill_evidence"
       phx-target={@myself}
       phx-value-id={@skill_evidence.id}


### PR DESCRIPTION
## 対応内容

close: #1662 

## 参考画像

**修正前**

![スクリーンショット 2024-12-17 102557](https://github.com/user-attachments/assets/5c16da65-6699-4b17-a0e8-7fcc642b7bd1)

**修正後**

![スクリーンショット 2024-12-17 102608](https://github.com/user-attachments/assets/773c200b-5dee-4819-a65d-6f512555637d)
