### PR TITLE
学習メモ 許可していない記法使用時のパースエラー対応

### DIFF
--- a/lib/bright/skill_evidences/markdown.ex
+++ b/lib/bright/skill_evidences/markdown.ex
@@ -41,8 +41,8 @@ defmodule Bright.SkillEvidences.Markdown do
 
   defp _permit(content) when is_bitstring(content), do: content
 
-  defp _permit({tag, _attrs, [content], _meta}) when tag not in @tags do
-    make_safe_string(content)
+  defp _permit({tag, _attrs, inner_ast, _meta}) when tag not in @tags do
+    permit(inner_ast)
   end
 
   defp _permit({"a", attrs, [content], _meta}) when is_bitstring(content) do

--- a/test/bright/skill_evidences/markdown_test.exs
+++ b/test/bright/skill_evidences/markdown_test.exs
@@ -182,6 +182,20 @@ defmodule Bright.SkillEvidences.MarkdownTest do
       assert html == "<p>リストです</p><ul><li>リストアイテム1</li><li>リストアイテム2</li></ul>"
     end
 
+    test "inner tag cases" do
+      text =
+        String.trim("""
+        1. first
+          - inner1
+          - inner2
+        2. second
+        """)
+
+      html = SkillEvidences.make_content_as_html(text)
+
+      assert html == "<li>first</li><ul><li>inner1</li><li>inner2</li></ul><li>second</li>"
+    end
+
     test "html_escape cases" do
       text =
         String.trim("""
@@ -273,7 +287,7 @@ defmodule Bright.SkillEvidences.MarkdownTest do
 
       html = SkillEvidences.make_content_as_html(text)
 
-      assert html == "<script></script>"
+      assert html == ""
 
       # in attrs
       text =
@@ -306,7 +320,7 @@ defmodule Bright.SkillEvidences.MarkdownTest do
 
       html = SkillEvidences.make_content_as_html(text)
 
-      assert html == "<img>"
+      assert html == ""
 
       # img書式
       text =
@@ -316,7 +330,7 @@ defmodule Bright.SkillEvidences.MarkdownTest do
 
       html = SkillEvidences.make_content_as_html(text)
 
-      assert html == "<p><img></p>"
+      assert html == "<p></p>"
     end
   end
 end


### PR DESCRIPTION
## 対応内容

issue #1672

関数に不備があって、許可していないタグで入れ子になっているケースがエラーになる現象がありました。
#1672 が解決するかどうかは実データがないのでわかりませんが、自動テストに記述したようなケースでエラーになります。

