### PR TITLE
スキル選択：医療版スキル群枠追加 #1678

### DIFF
--- a/assets/js/hooks/ScrollPos.js
+++ b/assets/js/hooks/ScrollPos.js
@@ -1,28 +1,23 @@
 const ScrollPos = {
   mounted() {
-    const cf = document.getElementById("wants_job_panel").children;
+    const cf = document.getElementsByClassName("career_field");
+    const pos = [...cf].map((c) => c.clientHeight);
 
-    const pos = [
-      cf[0].clientHeight,
-      cf[1].clientHeight,
-      cf[2].clientHeight,
-      cf[3].clientHeight,
-      cf[4].clientHeight,
-    ];
+    this.pushEvent("position", { pos: cf[0].id });
 
     document.addEventListener("scroll", () => {
       const y = window.scrollY;
-      if (y < pos[0]) {
-        this.pushEvent("position", { pos: cf[0].id });
-      } else if (y < pos[0] + pos[1]) {
-        this.pushEvent("position", { pos: cf[1].id });
-      } else if (y < pos[0] + pos[1] + pos[2]) {
-        this.pushEvent("position", { pos: cf[2].id });
-      } else if (y < pos[0] + pos[1] + pos[2] + pos[3]) {
-        this.pushEvent("position", { pos: cf[3].id });
-      } else {
-        this.pushEvent("position", { pos: cf[4].id });
+
+      let cumulativePosition = 0;
+      for (let i = 0; i < pos.length - 1; i++) {
+        cumulativePosition += pos[i];
+        if (y < cumulativePosition + 120) {
+          this.pushEvent("position", { pos: cf[i].id });
+          return;
+        }
       }
+
+      this.pushEvent("position", { pos: cf[cf.length - 1].id });
     });
   },
 };

--- a/lib/bright/accounts.ex
+++ b/lib/bright/accounts.ex
@@ -250,6 +250,15 @@ defmodule Bright.Accounts do
     |> Ecto.Multi.delete_all(:tokens, UserToken.user_and_contexts_query(user, [context]))
   end
 
+  @doc """
+  update user type
+  """
+  def update_user_type(%User{} = user, attrs) do
+    user
+    |> User.user_type_changeset(attrs)
+    |> Repo.update()
+  end
+
   @doc ~S"""
   Delivers the update email instructions to the given user.
 

--- a/lib/bright/accounts/user.ex
+++ b/lib/bright/accounts/user.ex
@@ -313,6 +313,13 @@ defmodule Bright.Accounts.User do
   end
 
   @doc """
+  A user changeset for changing user type.
+  """
+  def user_type_changeset(user, attrs) do
+    cast(user, attrs, [:type])
+  end
+
+  @doc """
   Verifies the password.
 
   If there is no user or the user doesn't have a password, we call

--- a/lib/bright/career_groups.ex
+++ b/lib/bright/career_groups.ex
@@ -1,0 +1,104 @@
+defmodule Bright.CareerGroups do
+  @moduledoc """
+  The CareerGroups context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Bright.Repo
+
+  alias Bright.CareerGroups.CareerGroup
+
+  @doc """
+  Returns the list of career_groups.
+
+  ## Examples
+
+      iex> list_career_groups()
+      [%CareerGroup{}, ...]
+
+  """
+  def list_career_groups do
+    Repo.all(CareerGroup)
+  end
+
+  @doc """
+  Gets a single career_group.
+
+  Raises `Ecto.NoResultsError` if the Career group does not exist.
+
+  ## Examples
+
+      iex> get_career_group!(123)
+      %CareerGroup{}
+
+      iex> get_career_group!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_career_group!(id), do: Repo.get!(CareerGroup, id)
+
+  @doc """
+  Creates a career_group.
+
+  ## Examples
+
+      iex> create_career_group(%{field: value})
+      {:ok, %CareerGroup{}}
+
+      iex> create_career_group(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_career_group(attrs \\ %{}) do
+    %CareerGroup{}
+    |> CareerGroup.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a career_group.
+
+  ## Examples
+
+      iex> update_career_group(career_group, %{field: new_value})
+      {:ok, %CareerGroup{}}
+
+      iex> update_career_group(career_group, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_career_group(%CareerGroup{} = career_group, attrs) do
+    career_group
+    |> CareerGroup.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a career_group.
+
+  ## Examples
+
+      iex> delete_career_group(career_group)
+      {:ok, %CareerGroup{}}
+
+      iex> delete_career_group(career_group)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_career_group(%CareerGroup{} = career_group) do
+    Repo.delete(career_group)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking career_group changes.
+
+  ## Examples
+
+      iex> change_career_group(career_group)
+      %Ecto.Changeset{data: %CareerGroup{}}
+
+  """
+  def change_career_group(%CareerGroup{} = career_group, attrs \\ %{}) do
+    CareerGroup.changeset(career_group, attrs)
+  end
+end

--- a/lib/bright/career_groups.ex
+++ b/lib/bright/career_groups.ex
@@ -21,6 +21,12 @@ defmodule Bright.CareerGroups do
     Repo.all(CareerGroup)
   end
 
+  def list_career_groups_with_career_field() do
+    CareerGroup
+    |> preload(:career_fields)
+    |> Repo.all()
+  end
+
   @doc """
   Gets a single career_group.
 

--- a/lib/bright/career_groups/career_group.ex
+++ b/lib/bright/career_groups/career_group.ex
@@ -1,0 +1,35 @@
+defmodule Bright.CareerGroups.CareerGroup do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias Bright.CareerGroups.CareerGroupCareerField
+  alias Bright.Accounts.User
+
+  @primary_key {:id, Ecto.ULID, autogenerate: true}
+  @foreign_key_type Ecto.ULID
+
+  schema "career_groups" do
+    field :name, :string
+    field :position, :integer
+    field :type, Ecto.Enum, values: Ecto.Enum.values(User, :type)
+
+    has_many :career_group_career_fields, CareerGroupCareerField,
+      on_replace: :delete,
+      on_delete: :delete_all
+
+    has_many :career_fields, through: [:career_group_career_fields, :career_field]
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(career_group, attrs) do
+    career_group
+    |> cast(attrs, [:name, :type, :position])
+    |> cast_assoc(:career_group_career_fields,
+      with: &CareerGroupCareerField.changeset/2,
+      sort_param: :career_group_career_fields_sort,
+      drop_param: :career_group_career_fields_drop
+    )
+    |> validate_required([:name, :type, :position])
+  end
+end

--- a/lib/bright/career_groups/career_group.ex
+++ b/lib/bright/career_groups/career_group.ex
@@ -1,4 +1,9 @@
 defmodule Bright.CareerGroups.CareerGroup do
+  @moduledoc """
+  キャリアフィールドの上位のグループ
+  ITや医療など業種自体が違うグルーピングを行う
+  """
+
   use Ecto.Schema
   import Ecto.Changeset
   alias Bright.CareerGroups.CareerGroupCareerField

--- a/lib/bright/career_groups/career_group_career_field.ex
+++ b/lib/bright/career_groups/career_group_career_field.ex
@@ -1,4 +1,8 @@
 defmodule Bright.CareerGroups.CareerGroupCareerField do
+  @moduledoc """
+  キャリアグループとキャリアフィールドを関連づけるスキーマ。
+  """
+
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/bright/career_groups/career_group_career_field.ex
+++ b/lib/bright/career_groups/career_group_career_field.ex
@@ -1,0 +1,20 @@
+defmodule Bright.CareerGroups.CareerGroupCareerField do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, Ecto.ULID, autogenerate: true}
+  @foreign_key_type Ecto.ULID
+
+  schema "career_group_career_fields" do
+    belongs_to :career_group, Bright.CareerGroups.CareerGroup
+    belongs_to :career_field, Bright.CareerFields.CareerField
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(career_group_career_field, attrs) do
+    career_group_career_field
+    |> cast(attrs, [:career_group_id, :career_field_id])
+  end
+end

--- a/lib/bright_web/components/layout_components.ex
+++ b/lib/bright_web/components/layout_components.ex
@@ -101,7 +101,7 @@ defmodule BrightWeb.LayoutComponents do
             page_sub_title={@page_sub_title}
           />
           <.plan_upgrade_button :if={Layouts.get_user_type(assigns) == :engineer} />
-          <.contact_customer_success_button />
+          <.contact_customer_success_button :if={Layouts.get_user_type(assigns) == :engineer} />
         </div>
       </div>
       <div class="flex gap-2 items-center lg:w-fit h-10">

--- a/lib/bright_web/live/admin/career_group_live/form_component.ex
+++ b/lib/bright_web/live/admin/career_group_live/form_component.ex
@@ -1,0 +1,134 @@
+defmodule BrightWeb.Admin.CareerGroupLive.FormComponent do
+  use BrightWeb, :live_component
+
+  alias Bright.CareerGroups
+  alias Bright.CareerFields
+  alias Bright.Accounts.User
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.header>
+        <%= @title %>
+        <:subtitle>Use this form to manage career_group records in your database.</:subtitle>
+      </.header>
+
+      <.simple_form
+        for={@form}
+        id="career_group-form"
+        phx-target={@myself}
+        phx-change="validate"
+        phx-submit="save"
+      >
+        <.input field={@form[:name]} type="text" label="Name" />
+        <.input field={@form[:type]} type="select" label="Type" options={Ecto.Enum.values(User, :type)} />
+        <.input field={@form[:position]} type="number" label="Position" />
+        <.label>CareerFields</.label>
+        <.inputs_for :let={c} field={@form[:career_group_career_fields]}>
+          <input type="hidden" name="career_group[career_group_career_fields_sort][]" value={c.index} />
+          <.input
+            field={c[:career_field_id]}
+            type="select"
+            label="CareerField"
+            prompt="CareerFieldを選択してください"
+            options={@career_field_options}
+          />
+          <label class="cursor-pointer">
+            <input
+              type="checkbox"
+              name="career_group[career_group_career_fields_drop][]"
+              value={c.index}
+              class="hidden"
+            /> delete
+          </label>
+        </.inputs_for>
+        <label class="block cursor-pointer">
+          <input type="checkbox" name="career_group[career_group_career_fields_sort][]" class="hidden" />
+          add career_field
+        </label>
+
+        <:actions>
+          <.button phx-disable-with="Saving...">Save Career group</.button>
+        </:actions>
+      </.simple_form>
+    </div>
+    """
+  end
+
+  @impl true
+  def update(%{career_group: career_group} = assigns, socket) do
+    changeset =
+      career_group
+      |> preload_assoc()
+      |> CareerGroups.change_career_group()
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(:career_field_options, career_field_options())
+     |> assign_form(changeset)}
+  end
+
+  @impl true
+  def handle_event("validate", %{"career_group" => career_group_params}, socket) do
+    changeset =
+      socket.assigns.career_group
+      |> preload_assoc()
+      |> CareerGroups.change_career_group(career_group_params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign_form(socket, changeset)}
+  end
+
+  def handle_event("save", %{"career_group" => career_group_params}, socket) do
+    save_career_group(socket, socket.assigns.action, career_group_params)
+  end
+
+  defp save_career_group(socket, :edit, career_group_params) do
+    career_group = preload_assoc(socket.assigns.career_group)
+
+    case CareerGroups.update_career_group(career_group, career_group_params) do
+      {:ok, career_group} ->
+        notify_parent({:saved, career_group})
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Career group updated successfully")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign_form(socket, changeset)}
+    end
+  end
+
+  defp save_career_group(socket, :new, career_group_params) do
+    case CareerGroups.create_career_group(career_group_params) do
+      {:ok, career_group} ->
+        notify_parent({:saved, preload_assoc(career_group)})
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Career group created successfully")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign_form(socket, changeset)}
+    end
+  end
+
+  defp assign_form(socket, %Ecto.Changeset{} = changeset) do
+    assign(socket, :form, to_form(changeset))
+  end
+
+  defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
+
+  defp career_field_options() do
+    CareerFields.list_career_fields()
+    |> Enum.map(&{&1.name_en, &1.id})
+  end
+
+  defp preload_assoc(career_group) do
+    Bright.Repo.preload(career_group, [:career_fields, :career_group_career_fields])
+  end
+end

--- a/lib/bright_web/live/admin/career_group_live/index.ex
+++ b/lib/bright_web/live/admin/career_group_live/index.ex
@@ -1,0 +1,53 @@
+defmodule BrightWeb.Admin.CareerGroupLive.Index do
+  use BrightWeb, :live_view
+
+  alias Bright.Repo
+  alias Bright.CareerGroups
+  alias Bright.CareerGroups.CareerGroup
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     stream(
+       socket,
+       :career_groups,
+       Repo.preload(CareerGroups.list_career_groups(), :career_fields)
+     )}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}) do
+    socket
+    |> assign(:page_title, "Edit Career group")
+    |> assign(:career_group, CareerGroups.get_career_group!(id))
+  end
+
+  defp apply_action(socket, :new, _params) do
+    socket
+    |> assign(:page_title, "New Career group")
+    |> assign(:career_group, %CareerGroup{})
+  end
+
+  defp apply_action(socket, :index, _params) do
+    socket
+    |> assign(:page_title, "Listing Career groups")
+    |> assign(:career_group, nil)
+  end
+
+  @impl true
+  def handle_info({BrightWeb.Admin.CareerGroupLive.FormComponent, {:saved, career_group}}, socket) do
+    {:noreply, stream_insert(socket, :career_groups, career_group)}
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    career_group = CareerGroups.get_career_group!(id)
+    {:ok, _} = CareerGroups.delete_career_group(career_group)
+
+    {:noreply, stream_delete(socket, :career_groups, career_group)}
+  end
+end

--- a/lib/bright_web/live/admin/career_group_live/index.html.heex
+++ b/lib/bright_web/live/admin/career_group_live/index.html.heex
@@ -1,0 +1,47 @@
+<.header>
+  Listing Career groups
+  <:actions>
+    <.link patch={~p"/admin/career_groups/new"}>
+      <.button>New Career group</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.table
+  id="career_groups"
+  rows={@streams.career_groups}
+  row_click={fn {_id, career_group} -> JS.navigate(~p"/admin/career_groups/#{career_group}") end}
+>
+  <:col :let={{_id, career_group}} label="Name"><%= career_group.name %></:col>
+  <:col :let={{_id, career_group}} label="type"><%= career_group.type %></:col>
+  <:col :let={{_id, career_group}} label="position"><%= career_group.position %></:col>
+  <:col :let={{_id, career_group}} label="Career Fields">
+      <%= Enum.map(career_group.career_fields, & &1.name_en) |> Enum.join(",") %>
+  </:col>
+
+  <:action :let={{_id, career_group}}>
+    <div class="sr-only">
+      <.link navigate={~p"/admin/career_groups/#{career_group}"}>Show</.link>
+    </div>
+    <.link patch={~p"/admin/career_groups/#{career_group}/edit"}>Edit</.link>
+  </:action>
+  <:action :let={{id, career_group}}>
+    <.link
+      phx-click={JS.push("delete", value: %{id: career_group.id}) |> hide("##{id}")}
+      data-confirm="Are you sure?"
+    >
+      Delete
+    </.link>
+  </:action>
+</.table>
+
+<.modal :if={@live_action in [:new, :edit]} id="career_group-modal" show on_cancel={JS.patch(~p"/admin/career_groups")}>
+  <.live_component
+    module={BrightWeb.Admin.CareerGroupLive.FormComponent}
+    id={@career_group.id || :new}
+    title={@page_title}
+    action={@live_action}
+    career_group={@career_group}
+    patch={~p"/admin/career_groups"}
+  />
+</.modal>

--- a/lib/bright_web/live/admin/career_group_live/show.ex
+++ b/lib/bright_web/live/admin/career_group_live/show.ex
@@ -1,0 +1,22 @@
+defmodule BrightWeb.Admin.CareerGroupLive.Show do
+  use BrightWeb, :live_view
+
+  alias Bright.CareerGroups
+  alias Bright.Repo
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(%{"id" => id}, _, socket) do
+    {:noreply,
+     socket
+     |> assign(:page_title, page_title(socket.assigns.live_action))
+     |> assign(:career_group, CareerGroups.get_career_group!(id) |> Repo.preload(:career_fields))}
+  end
+
+  defp page_title(:show), do: "Show Career group"
+  defp page_title(:edit), do: "Edit Career group"
+end

--- a/lib/bright_web/live/admin/career_group_live/show.html.heex
+++ b/lib/bright_web/live/admin/career_group_live/show.html.heex
@@ -1,0 +1,32 @@
+<.header>
+  Career group <%= @career_group.id %>
+  <:subtitle>This is a career_group record from your database.</:subtitle>
+  <:actions>
+    <.link patch={~p"/admin/career_groups/#{@career_group}/show/edit"} phx-click={JS.push_focus()}>
+      <.button>Edit Career group</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.list>
+  <:item title="Name"><%= @career_group.name %></:item>
+  <:item title="Type"><%= @career_group.type %></:item>
+  <:item title="position"><%= @career_group.position %></:item>
+</.list>
+
+<.list :for={career <- @career_group.career_fields}>
+  <:item title="career_field"><%= career.name %></:item>
+</.list>
+
+<.back navigate={~p"/admin/career_groups"}>Back to career_groups</.back>
+
+<.modal :if={@live_action == :edit} id="career_group-modal" show on_cancel={JS.patch(~p"/admin/career_groups/#{@career_group}")}>
+  <.live_component
+    module={BrightWeb.Admin.CareerGroupLive.FormComponent}
+    id={@career_group.id}
+    title={@page_title}
+    action={@live_action}
+    career_group={@career_group}
+    patch={~p"/admin/career_groups/#{@career_group}"}
+  />
+</.modal>

--- a/lib/bright_web/live/onboarding_live/index.html.heex
+++ b/lib/bright_web/live/onboarding_live/index.html.heex
@@ -17,6 +17,7 @@
   <.live_component
     id="wants_job"
     current_path={@current_path}
+    user_type={@current_user.type}
     pos={@pos}
     scores={@scores}
     module={BrightWeb.OnboardingLive.JobPanelComponents}

--- a/lib/bright_web/live/onboarding_live/job_panel_components.ex
+++ b/lib/bright_web/live/onboarding_live/job_panel_components.ex
@@ -1,7 +1,7 @@
 defmodule BrightWeb.OnboardingLive.JobPanelComponents do
   use BrightWeb, :live_component
 
-  alias Bright.{Jobs, CareerFields}
+  alias Bright.{Jobs, CareerFields, CareerGroups}
   alias Bright.Jobs.Job
 
   @rank %{entry: "入門", basic: "基本", advanced: "応用", expert: "高度"}
@@ -10,49 +10,59 @@ defmodule BrightWeb.OnboardingLive.JobPanelComponents do
   def render(assigns) do
     ~H"""
     <div class="flex flex-col lg:flex-row">
-      <div class="bg-white rounded w-full order-2 mt-4 lg:mt-0 lg:order-1">
-        <div id="wants_job_panel" class="p-2 lg:p-4" phx-hook="ScrollPos">
-          <%= for career_field <- @career_fields do %>
-            <div id={career_field.name_en}>
-              <h3 class={"border-l-4 px-2 border-#{career_field.name_en}-dark"}><%= career_field.name_ja %></h3>
-              <%= for rank <- Ecto.Enum.values(Job, :rank) do %>
-                <div class="my-8">
-                  <p class="text-left text-brightGray-400 text-xl"><%= @rank[rank] %></p>
-                  <hr class="h-[2px] bg-brightGray-50 mb-4" />
-                  <div class="flex flex-wrap justify-center mt-2 lg:justify-start">
-                    <% jobs = Map.get(@jobs, career_field.name_en, %{}) %>
-                    <%= for job <- Map.get(jobs, rank, []) do %>
-                      <%= if Enum.count(job.skill_panels) == 0 do %>
-                        <.locked_job job={job} />
-                      <% else %>
-                        <% panel_id = List.first(job.skill_panels) |> Map.get(:id, nil) %>
-                        <.unlocked_job
-                          panel_id={panel_id}
-                          score={Enum.find(@scores, & &1.id == panel_id)}
-                          current_path={@current_path}
-                          job={job}
-                          career_field={career_field}
-                        />
+      <div class="w-full order-2 mt-4 lg:mt-0 lg:order-1">
+        <div id="wants_job_panel" class="" phx-hook="ScrollPos">
+          <%= for career_group <- @career_groups do %>
+          <p class="text-2xl"><%= career_group.name %></p>
+          <div class="bg-white rounded mb-4 p-2 lg:p-4">
+            <%= for career_field <- career_group.career_fields do %>
+              <div id={career_field.name_en} class="career_field">
+                <h3 class={"border-l-4 px-2 border-#{career_field.name_en}-dark"}><%= career_field.name_ja %></h3>
+                <%= for rank <- Ecto.Enum.values(Job, :rank) do %>
+                  <div class="my-8">
+                    <p class="text-left text-brightGray-400 text-xl"><%= @rank[rank] %></p>
+                    <hr class="h-[2px] bg-brightGray-50 mb-4" />
+                    <div class="flex flex-wrap justify-center mt-2 lg:justify-start">
+                      <% jobs = Map.get(@jobs, career_field.name_en, %{}) %>
+                      <%= for job <- Map.get(jobs, rank, []) do %>
+                        <%= if Enum.count(job.skill_panels) == 0 do %>
+                          <.locked_job job={job} />
+                        <% else %>
+                          <% panel_id = List.first(job.skill_panels) |> Map.get(:id, nil) %>
+                          <.unlocked_job
+                            panel_id={panel_id}
+                            score={Enum.find(@scores, & &1.id == panel_id)}
+                            current_path={@current_path}
+                            job={job}
+                            career_field={career_field}
+                          />
+                        <% end %>
                       <% end %>
-                    <% end %>
+                    </div>
                   </div>
-                </div>
-              <% end %>
+                <% end %>
+              </div>
+            <% end %>
             </div>
           <% end %>
         </div>
       </div>
-      <div class="lg:ml-12 bg-white h-full p-2 sticky top-16 lg:top-2 order-1 lg:order-2">
-        <div class="flex flex-row lg:flex-col w-full lg:w-[240px] ">
-        <%= for career_field <- @career_fields do %>
-          <p
-            class={"cursor-pointer px-1 lg:px-4 py-2 lg:mb-2 text-xs lg:text-lg text-[#004D36] #{if @pos == career_field.name_en, do: "border-l-4 border-#{career_field.name_en}-dark bg-#{career_field.name_en}-light", else: "ml-1"}"}
-            phx-click="scroll_to"
-            phx-value-pos={career_field.name_en}
-          >
-            <%= career_field.name_ja %>
-          </p>
-        <% end %>
+      <div class="lg:ml-12 h-full p-2 sticky top-16 lg:top-2 order-1 lg:order-2">
+        <div class="flex flex-col">
+          <%= for career_group <- @career_groups do %>
+          <p class="p-2 lg:w-[240px] bg-white underline"><%= career_group.name %></p>
+            <div class="flex flex-row lg:flex-col w-full lg:w-[240px] bg-white mb-4">
+              <%= for career_field <- career_group.career_fields do %>
+                <p
+                  class={"cursor-pointer px-1 lg:px-4 py-2 lg:mb-2 text-xs lg:text-lg text-[#004D36] #{if @pos == career_field.name_en, do: "border-l-4 border-#{career_field.name_en}-dark bg-#{career_field.name_en}-light", else: "ml-1"}"}
+                  phx-click="scroll_to"
+                  phx-value-pos={career_field.name_en}
+                >
+                  <%= career_field.name_ja %>
+                </p>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       </div>
     </div>
@@ -182,11 +192,13 @@ defmodule BrightWeb.OnboardingLive.JobPanelComponents do
 
   @impl true
   def update(assigns, socket) do
-    career_fields = CareerFields.list_career_fields()
+    career_groups =
+      CareerGroups.list_career_groups_with_career_field()
+      |> Enum.sort_by(&(&1.type != assigns.user_type))
 
     socket
     |> assign(assigns)
-    |> assign(:career_fields, career_fields)
+    |> assign(:career_groups, career_groups)
     |> then(&{:ok, &1})
   end
 

--- a/lib/bright_web/live/onboarding_live/job_panel_components.ex
+++ b/lib/bright_web/live/onboarding_live/job_panel_components.ex
@@ -1,7 +1,7 @@
 defmodule BrightWeb.OnboardingLive.JobPanelComponents do
   use BrightWeb, :live_component
 
-  alias Bright.{Jobs, CareerFields, CareerGroups}
+  alias Bright.{Jobs, CareerGroups}
   alias Bright.Jobs.Job
 
   @rank %{entry: "入門", basic: "基本", advanced: "応用", expert: "高度"}

--- a/lib/bright_web/live/user_settings_live/current_subscription_plan_component.ex
+++ b/lib/bright_web/live/user_settings_live/current_subscription_plan_component.ex
@@ -2,6 +2,7 @@ defmodule BrightWeb.UserSettingsLive.CurrentSubscriptionPlanComponent do
   use BrightWeb, :live_component
 
   alias Bright.Subscriptions
+  alias Bright.CareerGroups
   alias Bright.Subscriptions.SubscriptionUserPlan
 
   @impl true
@@ -10,12 +11,32 @@ defmodule BrightWeb.UserSettingsLive.CurrentSubscriptionPlanComponent do
     <li class="block">
       <div class="flex flex-col mt-8">
         <div id="current_subscription_plan" class="flex flex-col lg:flex-row lg:flex-wrap text-left">
+        <%= for career_group <- @career_groups do %>
           <div class="w-full">
+            <%= career_group.name %>
             <label class="flex items-center py-4">
               <span class="w-32">利用プラン</span>
-              <span class="w-full"><%= @plan %></span>
+              <span class="w-full"><%= Map.get(@plan, career_group.type) %></span>
+              <div class="lg:ml-4 mt-1 py-4 w-full lg:w-fit">
+                <%= if @user.type == career_group.type do %>
+                <p class="bg-white block border-2 border-solid border-brightGray-600 font-bold px-2 py-1 rounded select-none text-center text-black w-full lg:w-28">
+                  利用中
+                </p>
+                <% else %>
+                <button
+                  type="button"
+                  phx-click="toggle"
+                  phx-target={@myself}
+                  phx-value-type={career_group.type}
+                  class="bg-brightGray-900 block border border-solid border-brightGray-900 cursor-pointer font-bold px-2 py-1 rounded select-none text-center text-white w-full lg:w-28 hover:filter hover:brightness-[80%]"
+                >
+                  切り替える
+                </button>
+                <% end %>
+              </div>
             </label>
           </div>
+          <% end %>
         </div>
       </div>
     </li>
@@ -25,8 +46,11 @@ defmodule BrightWeb.UserSettingsLive.CurrentSubscriptionPlanComponent do
   @impl true
   def update(assigns, socket) do
     subscription_user_plan = Subscriptions.get_user_subscription_user_plan(assigns.user.id)
-
     current_datetime = NaiveDateTime.utc_now()
+
+    career_groups =
+      CareerGroups.list_career_groups()
+      |> Enum.sort_by(&(&1.type != assigns.user.type))
 
     plan =
       case subscription_user_plan do
@@ -51,8 +75,20 @@ defmodule BrightWeb.UserSettingsLive.CurrentSubscriptionPlanComponent do
 
     socket =
       socket
-      |> assign(:plan, plan)
+      |> assign(assigns)
+      |> assign(:plan, %{engineer: plan, medical: "なし"})
+      |> assign(:career_groups, career_groups)
 
     {:ok, socket}
+  end
+
+  @impl true
+  def handle_event("toggle", %{"type" => type}, socket) do
+    {:ok, user} = Bright.Accounts.update_user_type(socket.assigns.user, %{type: type})
+
+    socket
+    |> assign(:user, user)
+    |> redirect(to: ~p"/mypage")
+    |> then(&{:noreply, &1})
   end
 end

--- a/lib/bright_web/router.ex
+++ b/lib/bright_web/router.ex
@@ -90,6 +90,12 @@ defmodule BrightWeb.Router do
       live "/jobs/:id", JobLive.Show, :show
       live "/jobs/:id/show/edit", JobLive.Show, :edit
 
+      live "/career_groups", CareerGroupLive.Index, :index
+      live "/career_groups/new", CareerGroupLive.Index, :new
+      live "/career_groups/:id/edit", CareerGroupLive.Index, :edit
+      live "/career_groups/:id", CareerGroupLive.Show, :show
+      live "/career_groups/:id/show/edit", CareerGroupLive.Show, :edit
+
       live "/career_want_jobs", CareerWantJobLive.Index, :index
       live "/career_want_jobs/new", CareerWantJobLive.Index, :new
       live "/career_want_jobs/:id/edit", CareerWantJobLive.Index, :edit

--- a/priv/repo/migrations/20241227050614_create_career_groups.exs
+++ b/priv/repo/migrations/20241227050614_create_career_groups.exs
@@ -1,0 +1,13 @@
+defmodule Bright.Repo.Migrations.CreateCareerGroups do
+  use Ecto.Migration
+
+  def change do
+    create table(:career_groups) do
+      add :name, :string
+      add :type, :string
+      add :position, :integer
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20241227054755_create_career_group_career_fields.exs
+++ b/priv/repo/migrations/20241227054755_create_career_group_career_fields.exs
@@ -1,0 +1,15 @@
+defmodule Bright.Repo.Migrations.CreateCareerGroupCareerFields do
+  use Ecto.Migration
+
+  def change do
+    create table(:career_group_career_fields) do
+      add :career_group_id, references(:career_groups, on_delete: :nothing)
+      add :career_field_id, references(:career_fields, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:career_group_career_fields, [:career_group_id])
+    create index(:career_group_career_fields, [:career_field_id])
+  end
+end

--- a/test/bright/accounts_test.exs
+++ b/test/bright/accounts_test.exs
@@ -870,6 +870,18 @@ defmodule Bright.AccountsTest do
     end
   end
 
+  describe "update_user_type/2" do
+    setup do
+      %{user: insert(:user)}
+    end
+
+    test "update user type", %{user: user} do
+      {:ok, user} = Accounts.update_user_type(user, %{type: :medical})
+
+      assert user.type == :medical
+    end
+  end
+
   describe "change_new_user_sub_email/2" do
     setup do
       %{user: insert(:user)}

--- a/test/bright/career_groups_test.exs
+++ b/test/bright/career_groups_test.exs
@@ -1,0 +1,75 @@
+defmodule Bright.CareerGroupsTest do
+  use Bright.DataCase
+
+  alias Bright.CareerGroups
+
+  describe "career_groups" do
+    alias Bright.CareerGroups.CareerGroup
+
+    @invalid_attrs %{name: nil, type: :engineer, position: nil}
+
+    test "list_career_groups/0 returns all career_groups" do
+      career_group = insert(:career_group)
+      assert CareerGroups.list_career_groups() == [career_group]
+    end
+
+    test "get_career_group!/1 returns the career_group with given id" do
+      career_group = insert(:career_group)
+      assert CareerGroups.get_career_group!(career_group.id) == career_group
+    end
+
+    test "create_career_group/1 with valid data creates a career_group" do
+      valid_attrs = %{
+        name: "some name",
+        type: :engineer,
+        position: 1
+      }
+
+      assert {:ok, %CareerGroup{} = career_group} = CareerGroups.create_career_group(valid_attrs)
+      assert career_group.name == "some name"
+      assert career_group.type == :engineer
+      assert career_group.position == 1
+    end
+
+    test "create_career_group/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = CareerGroups.create_career_group(@invalid_attrs)
+    end
+
+    test "update_career_group/2 with valid data updates the career_group" do
+      career_group = insert(:career_group)
+
+      update_attrs = %{
+        name: "some updated name",
+        type: :medical,
+        position: 2
+      }
+
+      assert {:ok, %CareerGroup{} = career_group} =
+               CareerGroups.update_career_group(career_group, update_attrs)
+
+      assert career_group.name == "some updated name"
+      assert career_group.type == :medical
+      assert career_group.position == 2
+    end
+
+    test "update_career_group/2 with invalid data returns error changeset" do
+      career_group = insert(:career_group)
+
+      assert {:error, %Ecto.Changeset{}} =
+               CareerGroups.update_career_group(career_group, @invalid_attrs)
+
+      assert career_group == CareerGroups.get_career_group!(career_group.id)
+    end
+
+    test "delete_career_group/1 deletes the career_group" do
+      career_group = insert(:career_group)
+      assert {:ok, %CareerGroup{}} = CareerGroups.delete_career_group(career_group)
+      assert_raise Ecto.NoResultsError, fn -> CareerGroups.get_career_group!(career_group.id) end
+    end
+
+    test "change_career_group/1 returns a career_group changeset" do
+      career_group = insert(:career_group)
+      assert %Ecto.Changeset{} = CareerGroups.change_career_group(career_group)
+    end
+  end
+end

--- a/test/bright_web/live/admin/career_group_live_test.exs
+++ b/test/bright_web/live/admin/career_group_live_test.exs
@@ -1,0 +1,125 @@
+defmodule BrightWeb.CareerGroupLiveTest do
+  use BrightWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  @create_attrs %{
+    name: "some name",
+    type: "engineer",
+    position: 1
+  }
+  @update_attrs %{
+    name: "some updated name",
+    type: "medical",
+    position: 2
+  }
+  @invalid_attrs %{name: nil, type: "engineer", position: nil}
+
+  defp create_career_group(_) do
+    career_group = insert(:career_group)
+    %{career_group: career_group}
+  end
+
+  describe "Index" do
+    setup [:create_career_group]
+
+    test "lists all career_groups", %{conn: conn, career_group: career_group} do
+      {:ok, _index_live, html} = live(conn, ~p"/admin/career_groups")
+
+      assert html =~ "Listing Career groups"
+      assert html =~ career_group.name
+    end
+
+    test "saves new career_group", %{conn: conn} do
+      {:ok, index_live, _html} = live(conn, ~p"/admin/career_groups")
+
+      assert index_live |> element("a", "New Career group") |> render_click() =~
+               "New Career group"
+
+      assert_patch(index_live, ~p"/admin/career_groups/new")
+
+      assert index_live
+             |> form("#career_group-form", career_group: @invalid_attrs)
+             |> render_change() =~ "入力してください"
+
+      assert index_live
+             |> form("#career_group-form", career_group: @create_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"/admin/career_groups")
+
+      html = render(index_live)
+      assert html =~ "Career group created successfully"
+      assert html =~ "some name"
+    end
+
+    test "updates career_group in listing", %{conn: conn, career_group: career_group} do
+      {:ok, index_live, _html} = live(conn, ~p"/admin/career_groups")
+
+      assert index_live
+             |> element("#career_groups-#{career_group.id} a", "Edit")
+             |> render_click() =~
+               "Edit Career group"
+
+      assert_patch(index_live, ~p"/admin/career_groups/#{career_group}/edit")
+
+      assert index_live
+             |> form("#career_group-form", career_group: @invalid_attrs)
+             |> render_change() =~ "入力してください"
+
+      assert index_live
+             |> form("#career_group-form", career_group: @update_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"/admin/career_groups")
+
+      html = render(index_live)
+      assert html =~ "Career group updated successfully"
+      assert html =~ "some updated name"
+    end
+
+    test "deletes career_group in listing", %{conn: conn, career_group: career_group} do
+      {:ok, index_live, _html} = live(conn, ~p"/admin/career_groups")
+
+      assert index_live
+             |> element("#career_groups-#{career_group.id} a", "Delete")
+             |> render_click()
+
+      refute has_element?(index_live, "#career_groups-#{career_group.id}")
+    end
+  end
+
+  describe "Show" do
+    setup [:create_career_group]
+
+    test "displays career_group", %{conn: conn, career_group: career_group} do
+      {:ok, _show_live, html} = live(conn, ~p"/admin/career_groups/#{career_group}")
+
+      assert html =~ "Show Career group"
+      assert html =~ career_group.name
+    end
+
+    test "updates career_group within modal", %{conn: conn, career_group: career_group} do
+      {:ok, show_live, _html} = live(conn, ~p"/admin/career_groups/#{career_group}")
+
+      assert show_live |> element("a", "Edit") |> render_click() =~
+               "Edit Career group"
+
+      assert_patch(show_live, ~p"/admin/career_groups/#{career_group}/show/edit")
+
+      assert show_live
+             |> form("#career_group-form", career_group: @invalid_attrs)
+             |> render_change() =~ "入力してください"
+
+      assert show_live
+             |> form("#career_group-form", career_group: @update_attrs)
+             |> render_submit()
+
+      assert_patch(show_live, ~p"/admin/career_groups/#{career_group}")
+
+      html = render(show_live)
+      assert html =~ "Career group updated successfully"
+      assert html =~ "some updated name"
+    end
+  end
+end

--- a/test/bright_web/live/user_settings_live/current_subscription_plan_component_test.exs
+++ b/test/bright_web/live/user_settings_live/current_subscription_plan_component_test.exs
@@ -3,6 +3,11 @@ defmodule BrightWeb.UserSettingsLive.CurrentSubscriptionPlanComponentTest do
 
   import Phoenix.LiveViewTest
 
+  setup do
+    insert(:career_group, name: "Bright IT", type: :engineer, position: 1)
+    :ok
+  end
+
   describe "利用プラン" do
     setup [:register_and_log_in_user, :setup_subscription_plan]
 
@@ -140,6 +145,20 @@ defmodule BrightWeb.UserSettingsLive.CurrentSubscriptionPlanComponentTest do
       lv |> element("a", "利用プラン") |> render_click()
 
       assert lv |> has_element?("#current_subscription_plan", "誰でもダイレクト採用")
+    end
+
+    test "update user type and redirect mypage", %{conn: conn, user: user} do
+      insert(:career_group, name: "Bright 医療", type: :medical, position: 2)
+      {:ok, lv, _html} = live(conn, ~p"/mypage")
+      lv |> element("a", "利用プラン") |> render_click()
+
+      assert lv
+             |> element("button", "切り替える")
+             |> render_click()
+             |> follow_redirect(conn, ~p"/mypage")
+
+      user = Bright.Repo.get(Bright.Accounts.User, user.id)
+      assert user.type == :medical
     end
   end
 end

--- a/test/factories/career_group_career_field_factory.ex
+++ b/test/factories/career_group_career_field_factory.ex
@@ -1,0 +1,13 @@
+defmodule Bright.CareerGroupCareerFieldFactory do
+  @moduledoc """
+  Factory for Bright.CareerGroups.CareerGroupCareerField
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      def career_group_career_field_factory do
+        %Bright.CareerGroups.CareerGroupCareerField{}
+      end
+    end
+  end
+end

--- a/test/factories/career_group_factory.ex
+++ b/test/factories/career_group_factory.ex
@@ -1,0 +1,17 @@
+defmodule Bright.CareerGroupFactory do
+  @moduledoc """
+  Factory for Bright.CareerGroups.CareerGroup
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      def career_group_factory do
+        %Bright.CareerGroups.CareerGroup{
+          name: "Bright",
+          type: "engineer",
+          position: 1
+        }
+      end
+    end
+  end
+end

--- a/test/factories/user_factory.ex
+++ b/test/factories/user_factory.ex
@@ -10,6 +10,7 @@ defmodule Bright.UserFactory do
           name: sequence(:name, &"user_name_#{&1}"),
           email: sequence(:email, &"user#{&1}@example.com"),
           hashed_password: Bcrypt.hash_pwd_salt(valid_user_password()),
+          type: :engineer,
           password_registered: true,
           confirmed_at: NaiveDateTime.utc_now()
         }

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -32,6 +32,10 @@ defmodule Bright.Factory do
   use Bright.CareerFieldFactory
   use Bright.CareerFieldJobFactory
 
+  # CareerGroups context
+  use Bright.CareerGroupFactory
+  use Bright.CareerGroupCareerFieldFactory
+
   # UserJobProfiles context
   use Bright.UserJobProfileFactory
 


### PR DESCRIPTION
 キャリアフィールドをITや医療など業種別にグルーピングするテーブルCareerGroup作成
ユーザータイプによってスキルを選ぶで表示されるスキルパネル郡が変わるように変更
ユーザータイプを利用中のプランから変更できるように変更

### type: Engineer
![スクリーンショット 2025-01-21 13 45 25](https://github.com/user-attachments/assets/3650f20b-4f55-4d68-b1b7-cb73a4d54fc4)

![スクリーンショット 2025-01-21 13 45 31](https://github.com/user-attachments/assets/aa6d3be4-e2d6-47a8-bc28-126ebdb59c9a)


### type: medical

![スクリーンショット 2025-01-21 13 45 05](https://github.com/user-attachments/assets/2fbe3b0f-f43b-497a-9221-22981b63041e)

![スクリーンショット 2025-01-21 13 45 14](https://github.com/user-attachments/assets/2ca4e24f-918b-4462-8a6d-7c2c21fc45ac)
