### PR TITLE
スキル検索：医療版タブ追加／デフォルト指定

### DIFF
--- a/lib/bright/career_groups.ex
+++ b/lib/bright/career_groups.ex
@@ -51,6 +51,29 @@ defmodule Bright.CareerGroups do
   def get_career_group!(id), do: Repo.get!(CareerGroup, id)
 
   @doc """
+  Gets a single career_group's related career_fields.
+
+  Raises `Ecto.Query.CastError` if type not a member in User.type Enum's
+
+  ## Examples
+
+      iex> get_career_group_related_career_field(:engineer)
+      [%CareerField{}]
+
+      iex> get_career_group_related_career_field(:none)
+      ** (Ecto.Query.CastError)
+
+  """
+
+  def get_career_group_related_career_field(type) do
+    CareerGroup
+    |> where(type: ^type)
+    |> preload(:career_fields)
+    |> Repo.one()
+    |> then(& &1.career_fields)
+  end
+
+  @doc """
   Creates a career_group.
 
   ## Examples

--- a/lib/bright/career_groups.ex
+++ b/lib/bright/career_groups.ex
@@ -66,11 +66,13 @@ defmodule Bright.CareerGroups do
   """
 
   def get_career_group_related_career_field(type) do
-    CareerGroup
-    |> where(type: ^type)
-    |> preload(:career_fields)
-    |> Repo.one()
-    |> then(& &1.career_fields)
+    group =
+      CareerGroup
+      |> where(type: ^type)
+      |> preload(:career_fields)
+      |> Repo.one()
+
+    if is_nil(group), do: [], else: group.career_fields
   end
 
   @doc """

--- a/lib/bright/user_searches.ex
+++ b/lib/bright/user_searches.ex
@@ -51,9 +51,9 @@ defmodule Bright.UserSearches do
         {job_params, job_range_params, skill_params},
         options \\ []
       ) do
-    default = [exclude_user_ids: [], page: 1, sort: :last_updated_desc]
+    default = [exclude_user_ids: [], page: 1, sort: :last_updated_desc, user_type: :engineer]
 
-    %{exclude_user_ids: exclude_user_ids, page: page, sort: sort} =
+    %{exclude_user_ids: exclude_user_ids, page: page, sort: sort, user_type: user_type} =
       Keyword.merge(default, options)
       |> Enum.into(%{})
 
@@ -73,7 +73,7 @@ defmodule Bright.UserSearches do
 
     from(
       u in User,
-      where: u.id in ^user_ids,
+      where: u.id in ^user_ids and u.type == ^user_type,
       left_join: s_score in assoc(u, :skill_scores),
       join: job in assoc(u, :user_job_profile),
       left_join: sc_score in assoc(u, :skill_class_scores),

--- a/lib/bright_web/live/search_live/doctor_search_component.ex
+++ b/lib/bright_web/live/search_live/doctor_search_component.ex
@@ -1,0 +1,293 @@
+defmodule BrightWeb.SearchLive.DoctorSearchComponent do
+  use BrightWeb, :live_component
+
+  alias Bright.{CareerGroups, SkillPanels, UserSearches}
+  alias Bright.SearchForm.{UserSearch, SkillSearch}
+  alias Bright.UserJobProfiles.UserJobProfile
+  alias BrightWeb.SearchLive.SearchResultsComponent
+  alias BrightWeb.BrightCoreComponents, as: BrightCore
+
+  import BrightWeb.TabComponents, only: [tab_footer: 1]
+
+  @class [クラス1: 1, クラス2: 2, クラス3: 3]
+  @level [見習い: "beginner", 平均: "normal", ベテラン: "skilled"]
+  @sort_options [
+    スキルパネルの最終更新日降順: :last_updated_desc,
+    スキルパネルの最終更新日昇順: :last_updated_asc,
+    希望年収降順: :income_desc,
+    希望年収昇順: :income_asc,
+    スキルスコア降順: :score_desc,
+    スキルスコア昇順: :score_asc
+  ]
+
+  @impl true
+  def mount(socket) do
+    search = %UserSearch{skills: [%SkillSearch{}]}
+    changeset = UserSearch.changeset(search, %{})
+
+    skill_panels =
+      SkillPanels.list_skill_panel_with_career_field()
+      |> Enum.group_by(& &1.career_field, &{&1.name, &1.id})
+      |> Map.put(nil, [])
+
+    socket
+    |> assign(:user_search, search)
+    |> assign(:career_fields, [])
+    |> assign(:skill_panels, skill_panels)
+    |> assign(:class, @class)
+    |> assign(:level, @level)
+    |> assign(:sort_options, @sort_options)
+    |> assign(:search_results, [])
+    |> assign(:skill_params, [])
+    |> assign(:stock_user_ids, [])
+    |> assign(:no_result, false)
+    |> assign(:total_pages, 0)
+    |> assign(:page, 1)
+    |> assign(:sort, :score_desc)
+    |> assign(:changeset, changeset)
+    |> assign_form(changeset)
+    |> then(&{:ok, &1})
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    career_fields =
+      CareerGroups.get_career_group_related_career_field(:medical)
+      |> Enum.map(&{&1.name_ja, &1.name_en})
+
+    socket
+    |> assign(assigns)
+    |> assign(:career_fields, career_fields)
+    |> then(&{:ok, &1})
+  end
+
+  @impl true
+  def handle_event(
+        "validate",
+        %{"user_search" => user_search_params, "_target" => target},
+        socket
+      ) do
+    params =
+      user_search_params
+      |> reset_pj_end(target)
+      |> reset_work_style(target)
+      |> reset_skill_form_when_career_field_change(target)
+
+    changeset =
+      socket.assigns.user_search
+      |> UserSearch.changeset(params)
+      |> Map.put(:action, :validte)
+
+    socket
+    |> assign(:changeset, changeset)
+    |> assign_form(changeset)
+    |> then(&{:noreply, &1})
+  end
+
+  # 空post
+  def handle_event(
+        "search",
+        %{"user_search" => params},
+        %{assigns: %{changeset: %{changes: changes}}} = socket
+      )
+      when map_size(changes) == 0 do
+    changeset =
+      socket.assigns.user_search
+      |> UserSearch.changeset(params)
+      |> Map.put(:action, :validte)
+
+    socket
+    |> assign_form(changeset)
+    |> then(&{:noreply, &1})
+  end
+
+  # スキルの検索項目でスキルパネルまで入力していないものがある
+  def handle_event(
+        "search",
+        _params,
+        %{assigns: %{changeset: %{valid?: false}}} = socket
+      ) do
+    {:noreply, socket}
+  end
+
+  def handle_event(
+        "search",
+        _params,
+        %{assigns: %{changeset: %{changes: changes}, current_user: user, sort: sort}} = socket
+      ) do
+    {skills, search_params} = convert_changes_to_search_params(changes)
+
+    result =
+      UserSearches.search_users_by_job_profile_and_skill_score(
+        search_params,
+        exclude_user_ids: [user.id],
+        sort: sort,
+        user_type: user.type
+      )
+
+    socket
+    |> assign_result(result)
+    |> assign(:skill_params, skills)
+    |> then(&{:noreply, &1})
+  end
+
+  def handle_event(
+        "previous_button_click",
+        _params,
+        %{assigns: %{page: page, sort: sort, changeset: changeset, current_user: user}} = socket
+      ) do
+    page = page - 1
+    page = if page < 1, do: 1, else: page
+    {_, search_params} = convert_changes_to_search_params(changeset.changes)
+
+    result =
+      UserSearches.search_users_by_job_profile_and_skill_score(
+        search_params,
+        exclude_user_ids: [user.id],
+        page: page,
+        sort: sort,
+        user_type: user.type
+      )
+
+    socket
+    |> assign_result(result)
+    |> then(&{:noreply, &1})
+  end
+
+  def handle_event(
+        "next_button_click",
+        _params,
+        %{
+          assigns: %{
+            page: page,
+            sort: sort,
+            total_pages: total_pages,
+            changeset: changeset,
+            current_user: user
+          }
+        } = socket
+      ) do
+    page = page + 1
+    page = if page > total_pages, do: total_pages, else: page
+
+    {_, search_params} = convert_changes_to_search_params(changeset.changes)
+
+    result =
+      UserSearches.search_users_by_job_profile_and_skill_score(
+        search_params,
+        exclude_user_ids: [user.id],
+        page: page,
+        sort: sort,
+        user_type: user.type
+      )
+
+    socket
+    |> assign_result(result)
+    |> then(&{:noreply, &1})
+  end
+
+  def handle_event(
+        "change_sort",
+        %{"sort" => sort},
+        %{assigns: %{changeset: changeset, current_user: user}} = socket
+      ) do
+    {_, search_params} = convert_changes_to_search_params(changeset.changes)
+
+    %{entries: users} =
+      UserSearches.search_users_by_job_profile_and_skill_score(
+        search_params,
+        exclude_user_ids: [user.id],
+        sort: String.to_atom(sort),
+        user_type: user.type
+      )
+
+    socket
+    |> assign(:search_results, users)
+    |> assign(:page, 1)
+    |> assign(:sort, String.to_atom(sort))
+    |> then(&{:noreply, &1})
+  end
+
+  defp assign_form(socket, %Ecto.Changeset{} = changeset) do
+    assign(socket, :form, to_form(changeset))
+  end
+
+  defp assign_result(socket, %{entries: []}) do
+    socket
+    |> assign(:search_results, [])
+    |> assign(:skill_params, [])
+    |> assign(:no_result, true)
+  end
+
+  defp assign_result(socket, result) do
+    socket
+    |> assign(:search_results, result.entries)
+    |> assign(:total_entries, result.total_entries)
+    |> assign(:total_pages, result.total_pages)
+    |> assign(:page, result.page_number)
+    |> assign(:no_result, false)
+  end
+
+  defp disabled?(bool_or_string), do: to_string(bool_or_string) == "false"
+
+  defp convert_changes_to_search_params(changes) do
+    skills =
+      Map.get(changes, :skills, [])
+      |> Enum.map(& &1.changes)
+      |> Enum.reject(&(Map.get(&1, :skill_panel) == nil))
+
+    search_params = {
+      Map.put(changes, :job_searching, true)
+      |> Map.drop([:skills, :desired_income])
+      |> Map.to_list(),
+      Map.take(changes, [:desired_income]),
+      skills
+    }
+
+    {skills, search_params}
+  end
+
+  # キャリアフィールドが変更されたら、それ以降の値はリセットされる
+  defp reset_skill_form_when_career_field_change(params, [_, "skills", index, "career_field"]) do
+    merge_skill_params(params, index, %{"class" => "", "level" => "", "skill_panel" => ""})
+  end
+
+  defp reset_skill_form_when_career_field_change(params, [_, "skills", index, "skill_panel"]) do
+    merge_skill_params(params, index, %{"class" => "", "level" => ""})
+  end
+
+  defp reset_skill_form_when_career_field_change(params, [_, "skills", index, "class"]) do
+    merge_skill_params(params, index, %{"level" => ""})
+  end
+
+  defp reset_skill_form_when_career_field_change(params, _target), do: params
+
+  defp merge_skill_params(params, index, clear_params) do
+    skills = Map.get(params, "skills")
+
+    skill =
+      Map.get(skills, index)
+      |> Map.merge(clear_params)
+
+    Map.put(params, "skills", Map.put(skills, index, skill))
+  end
+
+  # 勤務体系のチェックが外れるとそれ以降の入力がクリアされる
+  defp reset_work_style(params, [_, "office_work"]),
+    do:
+      Map.merge(params, %{
+        "office_pref" => "",
+        "office_working_hours" => "",
+        "office_work_holidays" => "false"
+      })
+
+  defp reset_work_style(params, [_, "remote_work"]),
+    do: Map.merge(params, %{"remote_working_hours" => "", "remote_work_holidays" => "false"})
+
+  defp reset_work_style(params, _target), do: params
+
+  # undecidedがクリックされたら pj_endがクリアされ、pj_endを入力するとundecidedがクリアされる
+  defp reset_pj_end(params, [_, "pj_end_undecided"]), do: Map.put(params, "pj_end", "")
+  defp reset_pj_end(params, [_, "pj_end"]), do: Map.put(params, "pj_end_undecided", "false")
+  defp reset_pj_end(params, _target), do: params
+end

--- a/lib/bright_web/live/search_live/doctor_search_component.html.heex
+++ b/lib/bright_web/live/search_live/doctor_search_component.html.heex
@@ -1,0 +1,228 @@
+<li class="block">
+  <.form
+    for={@form}
+    id="user_search_form"
+    phx-target={@myself}
+    phx-change="validate"
+    phx-submit="search"
+  >
+    <div :if={false} class="border-b border-brightGray-200 flex flex-wrap items-center">
+      <div class="w-fit">
+        <label class="flex items-center py-4">
+          <span class="w-36 text-start">希望年収で絞り込む</span>
+          <BrightCore.input
+            field={@form[:desired_income]}
+            input_class="border border-brightGray-200 px-2 py-1 mr-2 rounded w-40"
+            size="20"
+            type="number"
+            step="0.01"
+            after_label="万円以下"
+          />
+        </label>
+      </div>
+    </div>
+
+    <div :if={false} class="border-b border-brightGray-200 flex flex-wrap py-4 w-full">
+      <span class="w-36 text-start">業務可否で絞り込む</span>
+      <div class="flex items-center">
+        <BrightCore.input
+          field={@form[:wish_employed]}
+          label_class="w-12 text-left"
+          type="checkbox"
+          label="要OJT"
+        />
+        <BrightCore.input
+          field={@form[:wish_change_job]}
+          label_class="w-24 text-left"
+          type="checkbox"
+          label="現業以外も可"
+        />
+        <BrightCore.input
+          field={@form[:wish_side_job]}
+          label_class="w-16 text-left"
+          type="checkbox"
+          label="副業も可"
+        />
+        <BrightCore.input
+          field={@form[:wish_freelance]}
+          label_class="w-24 text-left"
+          type="checkbox"
+          label="業務委託も可"
+        />
+      </div>
+    </div>
+
+    <div :if={false} class="border-b border-brightGray-200 flex flex-wrap py-4 w-full">
+      <span class="py-1 w-36 text-start">勤務可否で絞り込む</span>
+      <div>
+        <div class="flex items-center">
+          <BrightCore.input
+            field={@form[:office_work]}
+            label_class="w-16 text-left"
+            type="checkbox"
+            label="出勤"
+          />
+          <BrightCore.input
+            field={@form[:office_pref]}
+            input_class="w-36"
+            disabled={disabled?(@form[:office_work].value)}
+            type="select"
+            options={Ecto.Enum.mappings(UserJobProfile, :office_pref)}
+            prompt="希望勤務地"
+          />
+          <BrightCore.input
+            field={@form[:office_working_hours]}
+            input_class="w-36"
+            disabled={disabled?(@form[:office_work].value)}
+            type="select"
+            options={Ecto.Enum.mappings(UserJobProfile, :office_working_hours)}
+            prompt="希望勤務時間"
+          />
+          <BrightCore.input
+            field={@form[:office_work_holidays]}
+            container_class="ml-4"
+            disabled={disabled?(@form[:office_work].value)}
+            type="checkbox"
+            label_class={if disabled?(@form[:office_work].value), do: "opacity-50"}
+            label="土日祝の稼働も含む"
+          />
+        </div>
+
+        <div class="flex items-center mt-2">
+          <BrightCore.input
+            field={@form[:remote_work]}
+            label_class="w-16 text-left"
+            type="checkbox"
+            label="リモート"
+          />
+          <BrightCore.input
+            field={@form[:remote_working_hours]}
+            input_class="w-36"
+            disabled={disabled?(@form[:remote_work].value)}
+            type="select"
+            options={Ecto.Enum.mappings(UserJobProfile, :remote_working_hours)}
+            prompt="希望勤務時間"
+          />
+          <BrightCore.input
+            field={@form[:remote_work_holidays]}
+            container_class="ml-4"
+            disabled={disabled?(@form[:remote_work].value)}
+            type="checkbox"
+            label_class={if disabled?(@form[:remote_work].value), do: "opacity-50"}
+            label="土日祝の稼働も含む"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div class="flex mt-4" id="skill_section">
+      <span class="mt-2 w-32 text-start">スキルで絞り込む</span>
+      <div>
+        <.inputs_for :let={sk} field={@form[:skills]}>
+          <input type="hidden" name="user_search[skills_sort][]" value={sk.index} />
+          <div class="flex items-center mb-4">
+            <label :if={sk.index > 0} class="cursor-pointer">
+              <input
+                type="checkbox"
+                name="user_search[skills_drop][]"
+                value={sk.index}
+                class="hidden"
+              />
+              <i class="delete_skill_conditions bg-base block border border-base cursor-pointer h-4 indent-40 -ml-5 mr-1 overflow-hidden relative rounded-full w-4 before:top-1/2 before:left-1/2 before:-ml-1 before:-mt-px before:content-[''] before:block before:absolute before:w-2 before:h-0.5 before:bg-white hover:filter hover:brightness-[80%]">
+                スキル削除
+              </i>
+            </label>
+
+            <BrightCore.input
+              field={sk[:career_field]}
+              input_class="border border-brightGray-200 mr-2 px-2 py-1 rounded w-46 text-md"
+              error_class="absolute ml-4"
+              type="select"
+              options={@career_fields}
+              prompt="キャリアフィールド"
+            />
+            <BrightCore.input
+              field={sk[:skill_panel]}
+              input_class="border border-brightGray-200 mr-2 px-2 py-1 rounded w-44"
+              error_class="absolute ml-4"
+              type="select"
+              options={Map.get(@skill_panels, sk[:career_field].value, [])}
+              disabled={is_nil(sk[:career_field].value) || sk[:career_field].value == ""}
+              prompt="スキル"
+            />
+            <BrightCore.input
+              field={sk[:class]}
+              input_class="border border-brightGray-200 mr-2 px-2 py-1 rounded w-26"
+              type="select"
+              options={@class}
+              disabled={sk[:skill_panel].value in ["", nil]}
+              prompt="クラス"
+            />
+            <BrightCore.input
+              field={sk[:level]}
+              input_class="border border-brightGray-200 mr-2 px-2 py-1 rounded w-26"
+              type="select"
+              options={@level}
+              disabled={sk[:class].value in ["", nil]}
+              prompt="レベル"
+            />
+          </div>
+        </.inputs_for>
+      </div>
+    </div>
+    <label :if={Enum.count(@form[:skills].value) < 3} class="block cursor-pointer">
+      <input type="checkbox" name="user_search[skills_sort][]" class="hidden" />
+      <i
+        id="set_skill_conditions"
+        class="bg-base block border border-base cursor-pointer h-4 indent-40 mx-auto overflow-hidden relative rounded-full w-4 before:top-1/2 before:left-1/2 before:-ml-1 before:-mt-px before:content-[''] before:block before:absolute before:w-2 before:h-0.5 before:bg-white after:top-1/2 after:left-1/2 after:-ml-1 after:-mt-px after:content-[''] after:block after:absolute after:w-2 after:h-0.5 after:bg-white after:rotate-90 hover:filter hover:brightness-[80%]"
+      >
+        追加
+      </i>
+    </label>
+
+    <div class="flex mt-16 mx-auto w-fit">
+      <BrightCore.button class="bg-base" phx-disable-with="Searching...">検索する</BrightCore.button>
+    </div>
+  </.form>
+
+  <div :if={@no_result} class="mt-5 text-xl text-center">
+    該当するユーザーは見つかりませんでした
+  </div>
+  <div :if={length(@search_results) > 0}>
+    <div class="flex items-center mt-8">
+      <span>
+        <%= if @total_entries > 5 && @page != @total_pages, do: 5 * @page, else: @total_entries %>
+      </span><span class="text-xs">件／</span>
+      <span><%= @total_entries %></span><span class="text-xs">件中</span>
+
+      <form phx-change="change_sort" phx-target={@myself}>
+        <BrightCore.input
+          name="sort"
+          value={@sort}
+          input_class="border border-brightGray-200 ml-4 px-2 py-1 rounded"
+          type="select"
+          options={@sort_options}
+        />
+      </form>
+
+      <p :if={false} class="ml-2">※採用面談が決まるまで匿名で表示されます</p>
+    </div>
+    <.tab_footer
+      id="user_search_result_footer"
+      page={@page}
+      total_pages={@total_pages}
+      target={@myself}
+    />
+    <.live_component
+      id="user_search_result"
+      prefix="user"
+      search={true}
+      anon={true}
+      module={SearchResultsComponent}
+      current_user={@current_user}
+      result={@search_results}
+      skill_params={@skill_params}
+      stock_user_ids={@stock_user_ids}
+    />
+  </div>
+</li>

--- a/lib/bright_web/live/search_live/result_components.ex
+++ b/lib/bright_web/live/search_live/result_components.ex
@@ -115,7 +115,7 @@ defmodule BrightWeb.SearchLive.ResultComponents do
 
   def action_area(assigns) do
     ~H"""
-    <div class="border-l border-brightGray-200 border-dashed ml-2 pl-2 w-28">
+    <div class={"ml-2 pl-2 w-28 #{if @user.type == :engineer, do: "border-l border-brightGray-200 border-dashed" }"}>
       <%= if @user.id in @stock_user_ids do %>
         <p class="mb-2 justify-center text-gray-300 bg-white px-2 py-1 inline-flex font-medium rounded-md text-sm items-center border border-gray-300 w-28 cursor-default">
           <span

--- a/lib/bright_web/live/search_live/search_result_component.ex
+++ b/lib/bright_web/live/search_live/search_result_component.ex
@@ -84,7 +84,7 @@ defmodule BrightWeb.SearchLive.SearchResultComponent do
               />
             </div>
           </div>
-          <div :if={@search} class="flex justify-end mt-8">
+          <div :if={@search && @current_user_type == :engineer} class="flex justify-end mt-8">
             <a
               phx-click={
                 if @hr_enabled,

--- a/lib/bright_web/live/search_live/search_result_component.ex
+++ b/lib/bright_web/live/search_live/search_result_component.ex
@@ -74,7 +74,7 @@ defmodule BrightWeb.SearchLive.SearchResultComponent do
         <% end %>
         <div class="border-l border-brightGray-200 border-dashed w-[512px] ml-2 px-2">
           <div class="flex">
-            <.job_area job={@user.user_job_profile} last_updated={@user.last_updated} />
+            <.job_area :if={@user.type == :engineer} job={@user.user_job_profile} last_updated={@user.last_updated} />
             <div :if={@search}>
               <.action_area
                 user={@user}

--- a/lib/bright_web/live/search_live/search_results_component.ex
+++ b/lib/bright_web/live/search_live/search_results_component.ex
@@ -18,6 +18,7 @@ defmodule BrightWeb.SearchLive.SearchResultsComponent do
             module={BrightWeb.SearchLive.SearchResultComponent}
             anon={!Enum.member?(@team_members, user.id) and @anon}
             user={user}
+            current_user_type={@current_user.type}
             index={index}
             skill_params={@skill_params}
             stock_user_ids={@stock_user_ids}

--- a/lib/bright_web/live/search_live/skill_saerch_component.ex
+++ b/lib/bright_web/live/search_live/skill_saerch_component.ex
@@ -3,14 +3,22 @@ defmodule BrightWeb.SearchLive.SkillSearchComponent do
 
   alias Bright.RecruitmentStockUsers
   alias BrightWeb.SearchLive.UserSearchComponent
+  alias BrightWeb.SearchLive.DoctorSearchComponent
   import BrightWeb.TabComponents
 
   @tabs [
     {"user", "スキル検索"}
+  ]
+
+  @medical_tabs [
+    {"medical", "専門医検索"},
+    {"user", "エンジニア検索"}
     # αでは落とす
     # {"team", "チーム検索"}
   ]
+
   @default_tab "user"
+  @default_medical_tab "medical"
 
   @impl true
   def render(assigns) do
@@ -37,12 +45,21 @@ defmodule BrightWeb.SearchLive.SkillSearchComponent do
             selected_tab={@selected_tab}
             target={@myself}
           >
+            <%= if @selected_tab == "user" do %>
             <.live_component
               id="user_search_tab"
               module={UserSearchComponent}
               current_user={@current_user}
               stock_user_ids={@stock_user_ids}
             />
+            <% else %>
+            <.live_component
+              id="doctor_search_tab"
+              module={DoctorSearchComponent}
+              current_user={@current_user}
+              stock_user_ids={@stock_user_ids}
+            />
+            <% end %>
           </.tab>
         </section>
       </div>
@@ -52,10 +69,16 @@ defmodule BrightWeb.SearchLive.SkillSearchComponent do
 
   @impl true
   def update(%{current_user: user} = assigns, socket) do
+    {tabs, tab} =
+      case user.type do
+        :engineer -> {@tabs, @default_tab}
+        :medical -> {@medical_tabs, @default_medical_tab}
+      end
+
     socket
     |> assign(assigns)
-    |> assign(:tabs, @tabs)
-    |> assign(:selected_tab, @default_tab)
+    |> assign(:tabs, tabs)
+    |> assign(:selected_tab, tab)
     |> assign(:click_away_disable, false)
     |> assign(:stock_user_ids, RecruitmentStockUsers.list_stock_user_ids(user.id))
     |> then(&{:ok, &1})

--- a/lib/bright_web/live/search_live/user_search_component.ex
+++ b/lib/bright_web/live/search_live/user_search_component.ex
@@ -30,9 +30,13 @@ defmodule BrightWeb.SearchLive.UserSearchComponent do
       |> Enum.group_by(& &1.career_field, &{&1.name, &1.id})
       |> Map.put(nil, [])
 
+    career_fields =
+      CareerGroups.get_career_group_related_career_field(:engineer)
+      |> Enum.map(&{&1.name_ja, &1.name_en})
+
     socket
     |> assign(:user_search, search)
-    |> assign(:career_fields, [])
+    |> assign(:career_fields, career_fields)
     |> assign(:skill_panels, skill_panels)
     |> assign(:class, @class)
     |> assign(:level, @level)
@@ -51,13 +55,8 @@ defmodule BrightWeb.SearchLive.UserSearchComponent do
 
   @impl true
   def update(assigns, socket) do
-    career_fields =
-      CareerGroups.get_career_group_related_career_field(:engineer)
-      |> Enum.map(&{&1.name_ja, &1.name_en})
-
     socket
     |> assign(assigns)
-    |> assign(:career_fields, career_fields)
     |> then(&{:ok, &1})
   end
 

--- a/lib/bright_web/live/search_live/user_search_component.ex
+++ b/lib/bright_web/live/search_live/user_search_component.ex
@@ -1,7 +1,7 @@
 defmodule BrightWeb.SearchLive.UserSearchComponent do
   use BrightWeb, :live_component
 
-  alias Bright.{CareerFields, SkillPanels, UserSearches}
+  alias Bright.{CareerGroups, SkillPanels, UserSearches}
   alias Bright.SearchForm.{UserSearch, SkillSearch}
   alias Bright.UserJobProfiles.UserJobProfile
   alias BrightWeb.SearchLive.SearchResultsComponent
@@ -25,10 +25,6 @@ defmodule BrightWeb.SearchLive.UserSearchComponent do
     search = %UserSearch{skills: [%SkillSearch{}]}
     changeset = UserSearch.changeset(search, %{})
 
-    career_fields =
-      CareerFields.list_career_fields()
-      |> Enum.map(&{&1.name_ja, &1.name_en})
-
     skill_panels =
       SkillPanels.list_skill_panel_with_career_field()
       |> Enum.group_by(& &1.career_field, &{&1.name, &1.id})
@@ -36,7 +32,7 @@ defmodule BrightWeb.SearchLive.UserSearchComponent do
 
     socket
     |> assign(:user_search, search)
-    |> assign(:career_fields, career_fields)
+    |> assign(:career_fields, [])
     |> assign(:skill_panels, skill_panels)
     |> assign(:class, @class)
     |> assign(:level, @level)
@@ -54,7 +50,16 @@ defmodule BrightWeb.SearchLive.UserSearchComponent do
   end
 
   @impl true
-  def update(assigns, socket), do: {:ok, assign(socket, assigns)}
+  def update(assigns, socket) do
+    career_fields =
+      CareerGroups.get_career_group_related_career_field(:engineer)
+      |> Enum.map(&{&1.name_ja, &1.name_en})
+
+    socket
+    |> assign(assigns)
+    |> assign(:career_fields, career_fields)
+    |> then(&{:ok, &1})
+  end
 
   @impl true
   def handle_event(

--- a/lib/bright_web/live/search_live/user_search_component.html.heex
+++ b/lib/bright_web/live/search_live/user_search_component.html.heex
@@ -205,7 +205,7 @@
         />
       </form>
 
-      <p class="ml-2">※採用面談が決まるまで匿名で表示されます</p>
+      <p :if={@current_user.type == :engineer} class="ml-2">※採用面談が決まるまで匿名で表示されます</p>
     </div>
     <.tab_footer
       id="user_search_result_footer"

--- a/lib/bright_web/live/team_live/my_team_live.html.heex
+++ b/lib/bright_web/live/team_live/my_team_live.html.heex
@@ -24,7 +24,7 @@
           </button>
         </.link>
         <button
-          :if={!is_nil(@display_team) && Teams.is_admin?(@display_team, @current_user)}
+          :if={!is_nil(@display_team) && Teams.is_admin?(@display_team, @current_user) && @current_user.type == :engineer}
           class="inline-flex gap-x-2 justify-center text-sm text-center font-bold px-4 py-1.5 rounded-md text-white bg-base w-full lg:w-64 hover:filter hover:brightness-[80%]"
           phx-click="toggle_show_hr_support_modal"
           phx-value-team_id={@display_team.id}

--- a/lib/bright_web/live/team_live/team_create_live_component.ex
+++ b/lib/bright_web/live/team_live/team_create_live_component.ex
@@ -165,8 +165,15 @@ defmodule BrightWeb.TeamCreateLiveComponent do
 
     if team_count >= limit do
       # 上限になっており追加できないケース
-      changeset = changeset_with_teams_limit_msg(team, team_params, limit)
-      open_free_trial_modal(team_count + 1, team, team_params, team_type, id)
+      changeset =
+        case user.type do
+          :engineer ->
+            open_free_trial_modal(team_count + 1, team, team_params, team_type, id)
+            changeset_with_teams_limit_msg(team, team_params, limit)
+
+          :medical ->
+            changeset_without_teams_limit_msg(team, team_params, limit)
+        end
 
       {:ng, assign_team_form(socket, changeset)}
     else
@@ -284,6 +291,16 @@ defmodule BrightWeb.TeamCreateLiveComponent do
   defp changeset_with_teams_limit_msg(team, params, limit) do
     msg =
       "現在のプランでは、チーム数の上限は#{limit}です<br /><br />「アップグレード」ボタンから上位プランをご購入いただくと<br />作成できるチーム数を増やせます"
+
+    team
+    |> Team.registration_changeset(params)
+    |> Ecto.Changeset.add_error(:name, msg)
+    |> Map.put(:action, :validate)
+  end
+
+  defp changeset_without_teams_limit_msg(team, params, limit) do
+    msg =
+      "現在のプランでは、チーム数の上限は#{limit}です"
 
     team
     |> Team.registration_changeset(params)

--- a/lib/bright_web/live/user_settings_live/user_setting_component.ex
+++ b/lib/bright_web/live/user_settings_live/user_setting_component.ex
@@ -76,9 +76,15 @@ defmodule BrightWeb.UserSettingsLive.UserSettingComponent do
   @impl true
   def update(%{action: action} = assigns, socket) do
     tabs =
-      case assigns.current_user.type do
-        :engineer -> @tabs
-        :medical -> @medical_tabs
+      case Map.get(assigns, :current_user, nil) do
+        nil ->
+          @tabs
+
+        user ->
+          case user.type do
+            :engineer -> @tabs
+            :medical -> @medical_tabs
+          end
       end
 
     socket

--- a/lib/bright_web/live/user_settings_live/user_setting_component.ex
+++ b/lib/bright_web/live/user_settings_live/user_setting_component.ex
@@ -13,6 +13,7 @@ defmodule BrightWeb.UserSettingsLive.UserSettingComponent do
     # NOTE: α版では通知機能はなし
     # "notification" => UserSettingsLive.NotificationSettingComponent　
   }
+
   @tabs [
     {"general", "一般"},
     {"auth", "メール・パスワード"},
@@ -21,6 +22,13 @@ defmodule BrightWeb.UserSettingsLive.UserSettingComponent do
     {"plan", "利用プラン"}
     # NOTE: α版では通知機能はなし
     # {"notification", "通知"}
+  ]
+
+  @medical_tabs [
+    {"general", "一般"},
+    {"auth", "メール・パスワード"},
+    {"sns", "SNS連携"},
+    {"plan", "利用プラン"}
   ]
 
   @impl true
@@ -67,9 +75,15 @@ defmodule BrightWeb.UserSettingsLive.UserSettingComponent do
 
   @impl true
   def update(%{action: action} = assigns, socket) do
+    tabs =
+      case assigns.current_user.type do
+        :engineer -> @tabs
+        :medical -> @medical_tabs
+      end
+
     socket
     |> assign(assigns)
-    |> assign(:tabs, @tabs)
+    |> assign(:tabs, tabs)
     |> assign(:selected_tab, action)
     |> assign(:module, Map.get(@tab_module, action))
     |> assign(:modal_flash, Map.get(assigns, :modal_flash, %{}))

--- a/test/bright/user_searches_test.exs
+++ b/test/bright/user_searches_test.exs
@@ -434,5 +434,35 @@ defmodule Bright.UserSearchesTest do
       assert %{entries: [%{id: ^id}]} =
                UserSearches.search_users_by_job_profile_and_skill_score(query)
     end
+
+    test "only engineer user", %{
+      user_1: %{id: id} = user_1,
+      user_2: user_2
+    } do
+      Bright.Accounts.update_user_type(user_2, %{type: :medical})
+      insert(:user_job_profile, user: user_1)
+      insert(:user_job_profile, user: user_2)
+
+      query = {[], %{}, []}
+
+      assert %{entries: [%{id: ^id}]} =
+               UserSearches.search_users_by_job_profile_and_skill_score(query)
+    end
+
+    test "only medical user", %{
+      user_1: %{id: id} = user_1,
+      user_2: user_2
+    } do
+      Bright.Accounts.update_user_type(user_1, %{type: :medical})
+      insert(:user_job_profile, user: user_1)
+      insert(:user_job_profile, user: user_2)
+
+      query = {[], %{}, []}
+
+      assert %{entries: [%{id: ^id}]} =
+               UserSearches.search_users_by_job_profile_and_skill_score(query,
+                 user_type: :medical
+               )
+    end
   end
 end

--- a/test/bright_web/live/subscription_live/free_trial_recommendation_component_test.exs
+++ b/test/bright_web/live/subscription_live/free_trial_recommendation_component_test.exs
@@ -75,6 +75,7 @@ defmodule BrightWeb.SubscriptionLive.FreeTrialRecommendationComponentTest do
       job = insert(:job)
       insert(:career_field_job, career_field: career_field, job: job)
       insert(:job_skill_panel, job: job, skill_panel: skill_panel)
+      insert(:career_group, career_fields: [career_field])
 
       %{
         skill_panel: skill_panel,
@@ -130,6 +131,7 @@ defmodule BrightWeb.SubscriptionLive.FreeTrialRecommendationComponentTest do
       skill_panel: skill_panel,
       subscription_plan: subscription_plan
     } do
+      IO.inspect(career_field)
       {:ok, live, _html} = live(conn, ~p"/mypage")
       submit_search_form(live, career_field, skill_panel)
 

--- a/test/bright_web/live/subscription_live/free_trial_recommendation_component_test.exs
+++ b/test/bright_web/live/subscription_live/free_trial_recommendation_component_test.exs
@@ -72,10 +72,15 @@ defmodule BrightWeb.SubscriptionLive.FreeTrialRecommendationComponentTest do
       [%{skills: [skill]}] = insert_skill_categories_and_skills(skill_unit, [1])
 
       career_field = insert(:career_field)
+      career_group = insert(:career_group)
       job = insert(:job)
       insert(:career_field_job, career_field: career_field, job: job)
       insert(:job_skill_panel, job: job, skill_panel: skill_panel)
-      insert(:career_group, career_fields: [career_field])
+
+      insert(:career_group_career_field,
+        career_group_id: career_group.id,
+        career_field_id: career_field.id
+      )
 
       %{
         skill_panel: skill_panel,
@@ -131,7 +136,6 @@ defmodule BrightWeb.SubscriptionLive.FreeTrialRecommendationComponentTest do
       skill_panel: skill_panel,
       subscription_plan: subscription_plan
     } do
-      IO.inspect(career_field)
       {:ok, live, _html} = live(conn, ~p"/mypage")
       submit_search_form(live, career_field, skill_panel)
 


### PR DESCRIPTION
## エンジニア版
そのまま

![スクリーンショット 2025-01-24 19 48 07](https://github.com/user-attachments/assets/c4051a4f-b364-42dd-9e79-eef21f5232f4)

## 医療版
専門医検索がデフォルトで表示される

勤務地等の絞り込みはなく、スキルパネルのみ
検索結果も面談の打診等は非表示にしてある

![スクリーンショット 2025-01-24 16 23 50](https://github.com/user-attachments/assets/9d61c4ca-c056-46c9-8051-569d8fb4406e)

２つ目のタブはエンジニア検索で
検索結果に面談の打診のボタンは無い
