### PR TITLE
メニューのスキル比較の位置を変更

### DIFF
--- a/lib/bright_web/components/layout_components.ex
+++ b/lib/bright_web/components/layout_components.ex
@@ -224,9 +224,9 @@ defmodule BrightWeb.LayoutComponents do
       {"マイページ", "/mypage", nil, "/images/common/icons/mypage.svg"},
       {"スキルを選ぶ", "/skill_select", nil, "/images/common/icons/skillSelect.svg"},
       {"スキル入力", "/skills", nil, "/images/common/icons/mySkill.svg"},
-      {"スキル比較", "/panels", nil, "/images/common/icons/skillPanel.svg"},
       {"成長履歴", "/graphs", nil, "/images/common/icons/growthPanel.svg"},
       {"チームスキル分析", "/teams", ~r/\/teams(?!\/new)/, "/images/common/icons/skillAnalyze.svg"},
+      {"スキル比較", "/panels", nil, "/images/common/icons/skillPanel.svg"},
       {"面談チャット", "/recruits/chats", nil, "/images/common/icons/oneOnOneChat.svg"}
       # TODO α版はskill_upを表示しない
       # {"スキルアップする", "/skill_up"},


### PR DESCRIPTION
チームスキル分析の下に移動
<img width="95" height="774" alt="スクリーンショット 2025-10-06 14 45 11" src="https://github.com/user-attachments/assets/7157970c-3c95-481f-9bb0-e5e121067694" />
